### PR TITLE
Adding methods for accessing windows credential manager #70

### DIFF
--- a/example/credentials.dart
+++ b/example/credentials.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:win32/win32.dart';
+
+void write({String credentialName, String userName, String password}) {
+  print('Writing $credentialName ...');
+  final examplePassword = utf8.encode(password);
+  final blob = allocate<Uint8>(count: examplePassword.length);
+  final blobBytes = blob.asTypedList(examplePassword.length);
+  blobBytes.setAll(0, examplePassword);
+
+  final credential = CREDENTIAL.allocate()
+    ..Type = CRED_TYPE_GENERIC
+    ..TargetName = TEXT(credentialName)
+    ..Persist = CRED_PERSIST_LOCAL_MACHINE
+    ..UserName = TEXT(userName)
+    ..CredentialBlob = blob
+    ..CredentialBlobSize = examplePassword.length;
+  final result = CredWrite(credential.addressOf, 0);
+  if (result != TRUE) {
+    final errorCode = GetLastError();
+    print('Error ($result): $errorCode');
+    return;
+  }
+  print('Success. (${credential.CredentialBlobSize})');
+
+  free(blob);
+  free(credential.addressOf);
+}
+
+void read(String credentialName) {
+  print('Reading $credentialName ...');
+  final cred = CREDENTIAL.allocate();
+  final result =
+      CredRead(TEXT(credentialName), CRED_TYPE_GENERIC, 0, cred.addressOf);
+  if (result != TRUE) {
+    final errorCode = GetLastError();
+    print('Error ($result): $errorCode');
+    return;
+  }
+  print('Success. size: ${cred.CredentialBlobSize}');
+  // final blob = cred.CredentialBlob.asTypedList(cred.CredentialBlobSize);
+  // final password = utf8.decode(blob);
+  // print('read password: $password');
+  CredFree(cred.addressOf);
+  free(cred.addressOf);
+}
+
+void main() {
+  print('Accessing Credentials.');
+  write(
+    credentialName: 'exampleCredential',
+    userName: 'MyUserName',
+    password: 'MyPassword',
+  );
+  read('exampleCredential');
+}

--- a/lib/src/advapi32.dart
+++ b/lib/src/advapi32.dart
@@ -34,3 +34,7 @@ final CredRead =
 /// {@category advapi32}
 final CredFree =
     _advapi32.lookupFunction<credFreeNative, credFreeDart>('CredFree');
+
+/// {@category advapi32}
+final CredDelete =
+    _advapi32.lookupFunction<credDeleteNative, credDeleteDart>('CredDeleteW');

--- a/lib/src/advapi32.dart
+++ b/lib/src/advapi32.dart
@@ -22,3 +22,15 @@ final RegOpenKeyEx = _advapi32
 final RegQueryValueEx =
     _advapi32.lookupFunction<regQueryValueExNative, regQueryValueExDart>(
         'RegQueryValueExW');
+
+/// {@category advapi32}
+final CredWrite =
+    _advapi32.lookupFunction<credWriteNative, credWriteDart>('CredWriteW');
+
+/// {@category advapi32}
+final CredRead =
+    _advapi32.lookupFunction<credReadNative, credReadDart>('CredReadW');
+
+/// {@category advapi32}
+final CredFree =
+    _advapi32.lookupFunction<credFreeNative, credFreeDart>('CredFree');

--- a/lib/src/blob.dart
+++ b/lib/src/blob.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Extension methods to make it easier to work with Uint8List in ffi.
+
+import 'dart:ffi';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart';
+
+extension Uint8ListBlob on Uint8List {
+  /// Allocates a pointer filled with the Uint8List data.
+  Pointer<Uint8> allocatePointer() {
+    final blob = allocate<Uint8>(count: length);
+    final blobBytes = blob.asTypedList(length);
+    blobBytes.setAll(0, this);
+    return blob;
+  }
+}

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -533,6 +533,30 @@ const ERROR_MORE_DATA = 234;
 const ERROR_CANCELLED = 1223;
 
 /// @nodoc
+const ERROR_NO_SUCH_LOGON_SESSION = 1312;
+
+/// @nodoc
+const ERROR_INVALID_FLAGS = 1004;
+
+/// @nodoc
+const ERROR_BAD_USERNAME = 2202;
+
+/// @nodoc
+const ERROR_NOT_FOUND = 1168;
+
+/// @nodoc
+const SCARD_E_NO_READERS_AVAILABLE = 2148532270;
+
+/// @nodoc
+const SCARD_E_NO_SMARTCARD = 0x8010000C;
+
+/// @nodoc
+const SCARD_W_REMOVED_CARD = 0x80100069;
+
+/// @nodoc
+const SCARD_W_WRONG_CHV = 0x8010006B;
+
+/// @nodoc
 const APPMODEL_ERROR_NO_PACKAGE = 15700;
 
 /// @nodoc
@@ -5545,3 +5569,45 @@ const PRODUCT_XBOX_SCARLETTHOSTOS = 0x000000C5;
 
 /// @nodoc
 const PRODUCT_UNLICENSED = 0xABCDABCD;
+
+/// @nodoc
+const CRED_PRESERVE_CREDENTIAL_BLOB = 0x1;
+
+/// @nodoc
+const CRED_FLAGS_PROMPT_NOW = 0x2;
+
+/// @nodoc
+const CRED_FLAGS_USERNAME_TARGET = 0x4;
+
+/// @nodoc
+const CRED_TYPE_GENERIC = 0x1;
+
+/// @nodoc
+const CRED_TYPE_DOMAIN_PASSWORD = 0x2;
+
+/// @nodoc
+const CRED_TYPE_DOMAIN_CERTIFICATE = 0x3;
+
+/// @nodoc
+const CRED_TYPE_DOMAIN_VISIBLE_PASSWORD = 0x4;
+
+/// @nodoc
+const CRED_TYPE_GENERIC_CERTIFICATE = 0x5;
+
+/// @nodoc
+const CRED_TYPE_DOMAIN_EXTENDED = 0x6;
+
+/// @nodoc
+const CRED_TYPE_MAXIMUM = 0x7;
+
+/// @nodoc
+const CRED_TYPE_MAXIMUM_EX = CRED_TYPE_MAXIMUM + 1000;
+
+/// @nodoc
+const CRED_PERSIST_SESSION = 0x1;
+
+/// @nodoc
+const CRED_PERSIST_LOCAL_MACHINE = 0x2;
+
+/// @nodoc
+const CRED_PERSIST_ENTERPRISE = 0x3;

--- a/lib/src/structs.dart
+++ b/lib/src/structs.dart
@@ -1579,6 +1579,96 @@ class GUID extends Struct {
   }
 }
 
+// typedef struct _CREDENTIAL_ATTRIBUTEW {
+// #if ...
+//   wchar_t *Keyword;
+// #else
+//   LPWSTR  Keyword;
+// #endif
+//   DWORD   Flags;
+//   DWORD   ValueSize;
+//   LPBYTE  Value;
+// } CREDENTIAL_ATTRIBUTEW, *PCREDENTIAL_ATTRIBUTEW;
+class CREDENTIAL_ATTRIBUTE extends Struct {
+  Pointer<Utf16> Keyword;
+  @Uint32()
+  int Flags;
+  @Uint32()
+  int ValueSize;
+  Pointer<Uint8> Value;
+
+  factory CREDENTIAL_ATTRIBUTE.allocate() =>
+      allocate<CREDENTIAL_ATTRIBUTE>().ref
+        ..Keyword = nullptr
+        ..Flags = 0
+        ..ValueSize = 0
+        ..Value = nullptr;
+}
+
+// typedef struct _CREDENTIALW {
+//   DWORD                  Flags;
+//   DWORD                  Type;
+// #if ...
+//   wchar_t                *TargetName;
+// #else
+//   LPWSTR                 TargetName;
+// #endif
+// #if ...
+//   wchar_t                *Comment;
+// #else
+//   LPWSTR                 Comment;
+// #endif
+//   FILETIME               LastWritten;
+//   DWORD                  CredentialBlobSize;
+//   LPBYTE                 CredentialBlob;
+//   DWORD                  Persist;
+//   DWORD                  AttributeCount;
+//   PCREDENTIAL_ATTRIBUTEW Attributes;
+// #if ...
+//   wchar_t                *TargetAlias;
+// #else
+//   LPWSTR                 TargetAlias;
+// #endif
+// #if ...
+//   wchar_t                *UserName;
+// #else
+//   LPWSTR                 UserName;
+// #endif
+// } CREDENTIALW, *PCREDENTIALW;
+class CREDENTIAL extends Struct {
+  @Uint32()
+  int Flags;
+  @Uint32()
+  int Type;
+  Pointer<Utf16> TargetName;
+  Pointer<Utf16> Comment;
+  Pointer<FILETIME> LastWritten;
+  @Uint32()
+  int CredentialBlobSize;
+  Pointer<Uint8> CredentialBlob;
+  @Uint32()
+  int Persist;
+  @Uint32()
+  int AttributeCount;
+  Pointer<CREDENTIAL_ATTRIBUTE> Attributes;
+  Pointer<Utf16> TargetAlias;
+  Pointer<Utf16> UserName;
+
+  factory CREDENTIAL.allocate() => allocate<CREDENTIAL>().ref
+    ..Flags = 0
+    ..Type = 0
+    ..TargetName = nullptr
+    ..Comment = nullptr
+    ..LastWritten = nullptr
+    ..CredentialBlobSize = 0
+    ..CredentialBlob = nullptr
+    ..Persist = 0
+    ..AttributeCount = 0
+    ..Attributes = nullptr
+    ..TargetAlias = nullptr
+    ..UserName = nullptr;
+}
+
 // *** CONSOLE STRUCTS ***
 
 // Dart FFI does not yet have support for nested structs, so there's extra

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -2024,13 +2024,13 @@ typedef credReadNative = Int32 Function(
   Pointer<Utf16> TargetName,
   Uint32 Type,
   Uint32 Flags,
-  Pointer<CREDENTIAL> Credential,
+  Pointer<Pointer<CREDENTIAL>> Credential,
 );
 typedef credReadDart = int Function(
   Pointer<Utf16> TargetName,
   int Type,
   int Flags,
-  Pointer<CREDENTIAL> Credential,
+  Pointer<Pointer<CREDENTIAL>> Credential,
 );
 
 // void CredFree(
@@ -2038,3 +2038,19 @@ typedef credReadDart = int Function(
 // );
 typedef credFreeNative = Void Function(Pointer Buffer);
 typedef credFreeDart = void Function(Pointer Buffer);
+
+// BOOL CredDeleteW(
+//   LPCWSTR TargetName,
+//   DWORD   Type,
+//   DWORD   Flags
+// );
+typedef credDeleteNative = Int32 Function(
+  Pointer<Utf16> TargetName,
+  Uint32 Type,
+  Uint32 Flags,
+);
+typedef credDeleteDart = int Function(
+  Pointer<Utf16> TargetName,
+  int Type,
+  int Flags,
+);

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -2000,3 +2000,41 @@ typedef writeProcessMemoryDart = int Function(
     Pointer<Void> lpBuffer,
     int nSize,
     Pointer<IntPtr> lpNumberOfBytesWritten);
+
+// BOOL CredWriteW(
+//   PCREDENTIALW Credential,
+//   DWORD        Flags
+// );
+typedef credWriteNative = Int32 Function(
+  Pointer<CREDENTIAL> Credential,
+  Uint32 Flags,
+);
+typedef credWriteDart = int Function(
+  Pointer<CREDENTIAL> Credential,
+  int Flags,
+);
+
+// BOOL CredReadW(
+//   LPCWSTR      TargetName,
+//   DWORD        Type,
+//   DWORD        Flags,
+//   PCREDENTIALW *Credential
+// );
+typedef credReadNative = Int32 Function(
+  Pointer<Utf16> TargetName,
+  Uint32 Type,
+  Uint32 Flags,
+  Pointer<CREDENTIAL> Credential,
+);
+typedef credReadDart = int Function(
+  Pointer<Utf16> TargetName,
+  int Type,
+  int Flags,
+  Pointer<CREDENTIAL> Credential,
+);
+
+// void CredFree(
+//   PVOID Buffer
+// );
+typedef credFreeNative = Void Function(Pointer Buffer);
+typedef credFreeDart = void Function(Pointer Buffer);

--- a/lib/win32.dart
+++ b/lib/win32.dart
@@ -78,6 +78,7 @@
 library win32;
 
 // Core Win32 APIs, constants and macros
+export 'src/blob.dart';
 export 'src/callbacks.dart';
 export 'src/constants.dart';
 export 'src/exceptions.dart';


### PR DESCRIPTION
Adds
* `CredWrite`
* `CredRead`
* `CredFree` (required after CredRead)
* `CredDelete`

One weird behavior with `GetLastError`: when I first check the result code and afterwards call `GetLastError` it is always zero:

```dart
  final result =
      CredRead(TEXT('nonExistingCredential'), CRED_TYPE_GENERIC, 0, credPointer);
  if (result != TRUE) {
    final error = GetLastError();
    print('Error: $error');
  }
```

This will always print `Error: 0`, but when i move the GetLastError before the `if`:

```dart
  final result =
      CredRead(TEXT('nonExistingCredential'), CRED_TYPE_GENERIC, 0, credPointer);
  final error = GetLastError();
  if (result != TRUE) {
    print('Error: $error');
  }
```

It will print: `Error: 1168` (which is `ERROR_NOT_FOUND`) - Maybe dart invokes some system calls in the `if`? Did you stumble upon this before? The current version in this PR uses the first variant, ie. is buggy.. but I think it is kind of strange to *always* call `GetLastError()` without checking whether it was an error before?

