### PR TITLE
Implement EnumProcessModulesEx

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -5790,3 +5790,15 @@ const CRED_PERSIST_LOCAL_MACHINE = 0x2;
 
 /// @nodoc
 const CRED_PERSIST_ENTERPRISE = 0x3;
+
+/// @nodoc
+const LIST_MODULES_32BIT = 0x01;
+
+/// @nodoc
+const LIST_MODULES_64BIT = 0x02;
+
+/// @nodoc
+const LIST_MODULES_ALL = 0x03;
+
+/// @nodoc
+const LIST_MODULES_DEFAULT = 0x0;

--- a/lib/src/psapi.dart
+++ b/lib/src/psapi.dart
@@ -20,6 +20,11 @@ final EnumProcessModules =
         'EnumProcessModules');
 
 /// {@category psapi}
+final EnumProcessModulesEx =
+    _psapi.lookupFunction<enumProcessModulesExNative, enumProcessModulesExDart>(
+        'EnumProcessModulesEx');
+
+/// {@category psapi}
 final GetModuleBaseName =
     _psapi.lookupFunction<getModuleBaseNameNative, getModuleBaseNameDart>(
         'GetModuleBaseNameW');

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -696,6 +696,26 @@ typedef enumProcessModulesNative = Int32 Function(IntPtr hProcess,
 typedef enumProcessModulesDart = int Function(int hProcess,
     Pointer<IntPtr> lphModule, int cb, Pointer<Uint32> lpcbNeeded);
 
+//  BOOL EnumProcessModulesEx(
+//  HANDLE  hProcess,
+//      HMODULE *lphModule,
+//  DWORD   cb,
+//      LPDWORD lpcbNeeded,
+//  DWORD   dwFilterFlag
+//);
+typedef enumProcessModulesExNative = Int32 Function(
+    IntPtr hProcess,
+    Pointer<IntPtr> lphModule,
+    Uint32 cb,
+    Pointer<Uint32> lpcbNeeded,
+    Uint32 dwFilterFlag);
+typedef enumProcessModulesExDart = int Function(
+    int hProcess,
+    Pointer<IntPtr> lphModule,
+    int cb,
+    Pointer<Uint32> lpcbNeeded,
+    int dwFilterFlag);
+
 // BOOL EnumResourceNamesW(
 //   HMODULE          hModule,
 //   LPCWSTR          lpType,

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -696,13 +696,13 @@ typedef enumProcessModulesNative = Int32 Function(IntPtr hProcess,
 typedef enumProcessModulesDart = int Function(int hProcess,
     Pointer<IntPtr> lphModule, int cb, Pointer<Uint32> lpcbNeeded);
 
-//  BOOL EnumProcessModulesEx(
-//  HANDLE  hProcess,
-//      HMODULE *lphModule,
-//  DWORD   cb,
-//      LPDWORD lpcbNeeded,
-//  DWORD   dwFilterFlag
-//);
+// BOOL EnumProcessModulesEx(
+//   HANDLE  hProcess,
+//   HMODULE *lphModule,
+//   DWORD   cb,
+//   LPDWORD lpcbNeeded,
+//   DWORD   dwFilterFlag
+// );
 typedef enumProcessModulesExNative = Int32 Function(
     IntPtr hProcess,
     Pointer<IntPtr> lphModule,


### PR DESCRIPTION
I needed `EnumProcessModulesEx` since I was using dart 64bit to list the process modules of a 32bit process, maybe someone else would use this 