### PR TITLE
Add tool feature: hide console window at the runtime

### DIFF
--- a/tool/build.cmd
+++ b/tool/build.cmd
@@ -1,6 +1,13 @@
 @echo off
 call dart2native example\console.dart -o example\bin\console.exe
+
 call dart2native example\hello.dart -o example\bin\hello.exe
+call dart tool\hide_console\switch_subsystem.dart GUI example\bin\hello.exe
+
 call dart2native example\paint.dart -o example\bin\paint.exe
+call dart tool\hide_console\switch_subsystem.dart GUI example\bin\paint.exe
+
 call dart2native example\tetris\main.dart -o example\bin\tetris.exe
+call dart tool\hide_console\switch_subsystem.dart GUI example\bin\tetris.exe
+
 call dart2native example\msgbox.dart -o example\bin\msgbox.exe

--- a/tool/hide_console/README.md
+++ b/tool/hide_console/README.md
@@ -1,0 +1,33 @@
+# Hide console window
+When you run a GUI application written and compiled with dart, a console appears that can be hidden with this tutorial.
+## How to
+1. First build your program
+
+```cmd
+cd win32
+dart compile exe .\example\hello.dart -o .\example\bin\your_app.exe
+```
+
+2. Then run the patch
+
+```cmd
+dart .\tool\hide_console\switch_subsystem.dart GUI .\example\bin\your_app.exe
+```
+3. Run your application and enjoy
+```cmd
+call .\example\bin\your_app.exe
+```
+## Return the console back
+```cmd
+dart .\tool\hide_console\switch_subsystem.dart CONSOLE .\example\bin\your_app.exe
+```
+
+## How it works
+The dart script `switch_subsystem.dart` replaces bytes in the PE header (your_app.exe). This changes the system flag from `WINDOWS:CONSOLE` to `WINDOWS:GUI`.
+
+```dart
+final IMAGE_SUBSYSTEM_WINDOWS_GUI = [98, 52, 68, 0, 2];
+final file = File('your_app.exe').openSync(mode: FileMode.append);
+file.setPositionSync(START_PE + SUBSYSTEM_PE);
+file.writeFromSync(IMAGE_SUBSYSTEM_WINDOWS_GUI);
+```

--- a/tool/hide_console/src/args.dart
+++ b/tool/hide_console/src/args.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'errors/args_error.dart';
+import 'sub_system.dart';
+
+class Args {
+  final SubSystem subsystem;
+
+  final String fileName;
+
+  Args(List<String> args)
+      : assert(checkArgsLen(args)),
+        subsystem = getSubSystem(args[0]),
+        fileName = findExeFile(args[1]);
+
+  static bool checkArgsLen(List<String> args) {
+    if (args.length != 2) {
+      throw ArgsTwoArgumentError();
+    }
+    return true;
+  }
+
+  static SubSystem getSubSystem(String textName) {
+    final normalizeName = normalizeSubSystemName(textName);
+    switch (normalizeName) {
+      case 'GUI':
+        return SubSystem.GUI;
+
+      case 'CONSOLE':
+        return SubSystem.CONSOLE;
+    }
+
+    throw ArgsInvalidSubSystemError(textName);
+  }
+
+  static String normalizeSubSystemName(String textName) => textName
+      .trim()
+      .toUpperCase()
+      .replaceAll(RegExp(r'(^\"|\"$)'), '');
+
+  static String findExeFile(String argsFileName) {
+    if (File(argsFileName).existsSync()) {
+      return argsFileName;
+    }
+
+    final fullFilePath = getFullFilePath(argsFileName);
+
+    if (File(fullFilePath).existsSync()) {
+      return fullFilePath;
+    }
+
+    throw ArgsFileNotFoundError(argsFileName, fullFilePath);
+  }
+
+  static String getFullFilePath(String name) =>
+      Platform.script
+          .path
+          .replaceFirst(RegExp('[^//]+\$'), name)
+          .substring(1)
+          .replaceAll('/', r'\');
+}

--- a/tool/hide_console/src/errors/app_error.dart
+++ b/tool/hide_console/src/errors/app_error.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+abstract class AppError extends Error {
+  String get message;
+
+  static final isDebug = Platform.environment['dart_debug'] == 'true';
+
+  @override
+  String toString() =>
+      normalizeMessage(message) + getStackTraceIfDebug;
+
+  String get getStackTraceIfDebug => isDebug ? '\n$stackTrace' : '';
+
+  static String normalizeMessage(String msg) => msg.replaceAll('        ', '');
+}

--- a/tool/hide_console/src/errors/args_error.dart
+++ b/tool/hide_console/src/errors/args_error.dart
@@ -1,0 +1,47 @@
+import '../sub_system.dart';
+import 'app_error.dart';
+
+class ArgsInvalidSubSystemError extends AppError {
+  final String invalidArgumentName;
+
+  @override
+  String get message => '''
+        First argument "$invalidArgumentName" invalid.
+        Available options: $availableOptions
+      ''';
+
+  ArgsInvalidSubSystemError(this.invalidArgumentName);
+
+  static String get availableOptions => SubSystem.values
+      .map((name) => '"${getNameOnly(name)}"').join(', ');
+
+  static String getNameOnly(SubSystem enumName) =>
+      enumName.toString().replaceFirst(RegExp(r'^.+\.'), '');
+}
+
+class ArgsTwoArgumentError extends AppError {
+  @override
+  String get message => r'''
+        Invalid arguments. 
+        Enter two arguments. 
+        Examples:
+        switch_subsystem "GUI" ..\path\your_app.exe
+        switch_subsystem "CONSOLE" ..\path\your_app.exe
+      ''';
+
+  ArgsTwoArgumentError();
+}
+
+class ArgsFileNotFoundError extends AppError {
+  final String fileName;
+  final String fullFilePathName;
+
+  @override
+  String get message => '''
+        File not found
+          "$fileName"
+          "$fullFilePathName"
+      ''';
+
+  ArgsFileNotFoundError(this.fileName, this.fullFilePathName);
+}

--- a/tool/hide_console/src/errors/win_pe_patcher_error.dart
+++ b/tool/hide_console/src/errors/win_pe_patcher_error.dart
@@ -1,0 +1,12 @@
+import 'app_error.dart';
+
+class WinPePatcherVerifyError extends AppError {
+  final String fileName;
+
+  WinPePatcherVerifyError(this.fileName);
+  @override
+  String get message => '''
+        Verify error.
+        File "$fileName" is not executable file.
+      ''';
+}

--- a/tool/hide_console/src/sub_system.dart
+++ b/tool/hide_console/src/sub_system.dart
@@ -1,0 +1,5 @@
+
+enum SubSystem {
+  CONSOLE,
+  GUI
+}

--- a/tool/hide_console/src/win_pe_patcher.dart
+++ b/tool/hide_console/src/win_pe_patcher.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'errors/win_pe_patcher_error.dart';
+import 'sub_system.dart';
+
+class WinPePatcher {
+  static const START_PE = 256 + 16;
+  static const SUBSYSTEM_PE = 88;
+
+  static final IMAGE_SUBSYSTEM_WINDOWS_GUI = [98, 52, 68, 0, 2];
+  static final IMAGE_SUBSYSTEM_WINDOWS_CONSOLE = [0, 0, 0, 0, 3];
+
+  String fileName;
+
+  WinPePatcher(this.fileName);
+
+  void change(SubSystem subSystem) {
+    final bytesSubSystem = getBytes(subSystem);
+    final file = open(fileName);
+    file.writeFromSync(bytesSubSystem);
+    file.closeSync();
+  }
+
+  static List<int> getBytes(SubSystem subSystem) =>
+      (subSystem == SubSystem.GUI)
+        ? IMAGE_SUBSYSTEM_WINDOWS_GUI
+        : IMAGE_SUBSYSTEM_WINDOWS_CONSOLE;
+
+  static RandomAccessFile open(String fileName) {
+    final entry = File(fileName);
+    verifyPEHeader(entry);
+    final file = entry.openSync(mode: FileMode.append);
+    file.setPositionSync(START_PE + SUBSYSTEM_PE);
+    return file;
+  }
+
+  static void verifyPEHeader(File fileEntry) {
+    final file = fileEntry.openSync(mode: FileMode.read);
+    final Mark_Zbikowski =  Uint8List.fromList([0x4D, 0x5A]);
+    final magicNumbers = file.readSync(2);
+    if (magicNumbers[0] != Mark_Zbikowski[0] ||
+        magicNumbers[1] != Mark_Zbikowski[1] ) {
+      throw WinPePatcherVerifyError(fileEntry.path);
+    }
+    file.close();
+  }
+}

--- a/tool/hide_console/switch_subsystem.dart
+++ b/tool/hide_console/switch_subsystem.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'src/args.dart';
+import 'src/errors/app_error.dart';
+import 'src/win_pe_patcher.dart';
+
+void main(List<String> listArgs) {
+  try {
+    final args = Args(listArgs);
+    WinPePatcher(args.fileName)
+        .change(args.subsystem);
+    print('File patched ${args.subsystem}: ${args.fileName}');
+    // ignore: avoid_catching_errors
+  } on AppError catch (e) {
+    stderr.writeln(e);
+    return;
+  }
+}


### PR DESCRIPTION
# Hide console window
When you run a GUI application written and compiled with dart, a console appears that can be hidden with this tutorial.
## How to
1. First build your program

```cmd
cd win32
dart compile exe .\example\hello.dart -o .\example\bin\your_app.exe
```

2. Then run the patch

```cmd
dart .\tool\hide_console\switch_subsystem.dart GUI .\example\bin\your_app.exe
```
3. Run your application and enjoy
```cmd
call .\example\bin\your_app.exe
```
## Return the console back
```cmd
dart .\tool\hide_console\switch_subsystem.dart CONSOLE .\example\bin\your_app.exe
```

## How it works
The dart script `switch_subsystem.dart` replaces bytes in the PE header (your_app.exe). This changes the system flag from `WINDOWS:CONSOLE` to `WINDOWS:GUI`.

```dart
final IMAGE_SUBSYSTEM_WINDOWS_GUI = [98, 52, 68, 0, 2];
final file = File('your_app.exe').openSync(mode: FileMode.append);
file.setPositionSync(START_PE + SUBSYSTEM_PE);
file.writeFromSync(IMAGE_SUBSYSTEM_WINDOWS_GUI);
```