### PR TITLE
Replace deprecated Utf16.toUtf16 static method to string.toNativeUtf16()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.0-nullsafety.11
+ - Fixes `Method not found: 'Utf16.toUtf16'` ([#155](https://github.com/timsneath/win32/issues/155))
+
 ## 2.0.0-nullsafety.10
 
 - Make VARIANT more representative of the underlying type.

--- a/example/devices.dart
+++ b/example/devices.dart
@@ -5,6 +5,7 @@
 // Finds physical volumes on the system
 
 import 'dart:ffi';
+
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
@@ -19,7 +20,7 @@ void displayVolumePaths(String volumeName) {
   final charCount = calloc<Uint32>();
   charCount.value = MAX_PATH;
   error = GetVolumePathNamesForVolumeName(
-      Utf16.toUtf16(volumeName), pathNamePtr, charCount.value, charCount);
+      volumeName.toNativeUtf16(), pathNamePtr, charCount.value, charCount);
 
   if (error != 0) {
     if (charCount.value > 1) {

--- a/example/notepad/utf16string.dart
+++ b/example/notepad/utf16string.dart
@@ -1,4 +1,5 @@
 import 'dart:ffi';
+
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
@@ -18,7 +19,7 @@ class Utf16String {
 
   factory Utf16String.fromString(String string) {
     final value = Utf16String(string.length + 1);
-    value.pointer = Utf16.toUtf16(string);
+    value.pointer = string.toNativeUtf16();
     value.length = string.length;
 
     return value;

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -28,4 +28,5 @@ Pointer<Uint8> convertToANSIString(String str) {
   return pStr;
 }
 
-const TEXT = Utf16.toUtf16;
+Pointer<Utf16> TEXT(String s, {Allocator allocator = malloc}) =>
+    s.toNativeUtf16(allocator: allocator);

--- a/lib/src/winrt/winrt_helpers.dart
+++ b/lib/src/winrt/winrt_helpers.dart
@@ -52,7 +52,8 @@ String convertFromHString(Pointer<IntPtr> hstring) {
 Pointer<IntPtr> convertToHString(String string) {
   final hString = calloc<IntPtr>();
   // Create a HSTRING representing the object
-  final hr = WindowsCreateString(Utf16.toUtf16(string), string.length, hString);
+  final hr =
+      WindowsCreateString(string.toNativeUtf16(), string.length, hString);
   if (FAILED(hr)) {
     throw WindowsException(hr);
   } else {
@@ -78,7 +79,7 @@ Pointer<IntPtr> CreateObject(String className, String iid) {
   try {
     // Create a HSTRING representing the object
     var hr = WindowsCreateString(
-        Utf16.toUtf16(className), className.length, hstrClass);
+        className.toNativeUtf16(), className.length, hstrClass);
     if (FAILED(hr)) {
       throw WindowsException(hr);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: win32
 description: A Dart library for accessing common Win32 APIs using FFI. No C required!
-version: 2.0.0-nullsafety.10
+version: 2.0.0-nullsafety.11
 homepage: https://win32.pub
 repository: https://github.com/timsneath/win32
 issue_tracker: https://github.com/timsneath/win32/issues
 documentation: https://win32.pub
 
 environment:
-  sdk: '>=2.12.0-259.8 <3.0.0'
+  sdk: ">=2.12.0-259.8 <3.0.0"
 
 dependencies:
-  ffi: '>=0.3.0-nullsafety.1 <2.0.0'
+  ffi: ">=0.3.0-nullsafety.1 <2.0.0"
 
 dev_dependencies:
   pedantic: ^1.10.0-nullsafety.3


### PR DESCRIPTION
Fixes https://github.com/timsneath/win32/issues/155 by using the extension methods on `String.toNativeUtf16()`.