### PR TITLE
Calculate COM vtable starts from metadata

### DIFF
--- a/test/vtablestart_test.dart
+++ b/test/vtablestart_test.dart
@@ -1,72 +1,76 @@
+// COM interfaces have a chain of inheritance, and the function vtable depends
+// on this being calculated accurately. Test a variety of existing interfaces to
+// make sure the algorithm matches a manual count.
+
 @TestOn('windows')
 
 import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:winmd/winmd.dart';
+
 import '../tool/metadata/generate_com_apis.dart';
 
 void main() {
   test('vTableStart', () {
-    final typesList = [
-      ['Windows.Win32.Automation.IDispatch', 3],
-      ['Windows.Win32.Automation.IEnumVARIANT', 3],
-      ['Windows.Win32.Automation.IErrorInfo', 3],
-      ['Windows.Win32.Automation.ISupportErrorInfo', 3],
-      ['Windows.Win32.Com.IBindCtx', 3],
-      ['Windows.Win32.Com.IClassFactory', 3],
-      ['Windows.Win32.Com.IEnumMoniker', 3],
-      ['Windows.Win32.Com.IEnumString', 3],
-      ['Windows.Win32.Com.IMoniker', 8],
-      ['Windows.Win32.Com.IPersist', 3],
-      ['Windows.Win32.Com.IPersistStream', 4],
-      ['Windows.Win32.Com.IProvideClassInfo', 3],
-      ['Windows.Win32.Com.IRunningObjectTable', 3],
-      ['Windows.Win32.Intl.IEnumSpellingError', 3],
-      ['Windows.Win32.Intl.ISpellChecker', 3],
-      ['Windows.Win32.Intl.ISpellCheckerChangedEventHandler', 3],
-      ['Windows.Win32.Intl.ISpellCheckerFactory', 3],
-      ['Windows.Win32.Intl.ISpellingError', 3],
-      ['Windows.Win32.NetworkListManager.IEnumNetworkConnections', 7],
-      ['Windows.Win32.NetworkListManager.IEnumNetworks', 7],
-      ['Windows.Win32.NetworkListManager.INetwork', 7],
-      ['Windows.Win32.NetworkListManager.INetworkConnection', 7],
-      ['Windows.Win32.NetworkListManager.INetworkListManager', 7],
-      ['Windows.Win32.Shell.IApplicationActivationManager', 3],
-      ['Windows.Win32.Shell.IDesktopWallpaper', 3],
-      ['Windows.Win32.Shell.IEnumIDList', 3],
-      ['Windows.Win32.Shell.IFileDialog', 4],
-      ['Windows.Win32.Shell.IFileDialog2', 27],
-      ['Windows.Win32.Shell.IFileDialogCustomize', 3],
-      ['Windows.Win32.Shell.IFileIsInUse', 3],
-      ['Windows.Win32.Shell.IFileOpenDialog', 27],
-      ['Windows.Win32.Shell.IFileSaveDialog', 27],
-      ['Windows.Win32.Shell.IKnownFolder', 3],
-      ['Windows.Win32.Shell.IKnownFolderManager', 3],
-      ['Windows.Win32.Shell.IModalWindow', 3],
-      ['Windows.Win32.Shell.IShellFolder', 3],
-      ['Windows.Win32.Shell.IShellItem', 3],
-      ['Windows.Win32.Shell.IShellItem2', 8],
-      ['Windows.Win32.Shell.IShellItemArray', 3],
-      ['Windows.Win32.Shell.IShellItemFilter', 3],
-      ['Windows.Win32.StructuredStorage.ISequentialStream', 3],
-      ['Windows.Win32.StructuredStorage.IStream', 5],
-      ['Windows.Win32.WinRT.IInspectable', 3],
-      ['Windows.Win32.Wmi.IEnumWbemClassObject', 3],
-      ['Windows.Win32.Wmi.IWbemClassObject', 3],
-      ['Windows.Win32.Wmi.IWbemContext', 3],
-      ['Windows.Win32.Wmi.IWbemLocator', 3],
-      ['Windows.Win32.Wmi.IWbemServices', 3],
-    ];
+    const testedTypes = <String, int>{
+      'Windows.Win32.Automation.IDispatch': 3,
+      'Windows.Win32.Automation.IEnumVARIANT': 3,
+      'Windows.Win32.Automation.IErrorInfo': 3,
+      'Windows.Win32.Automation.ISupportErrorInfo': 3,
+      'Windows.Win32.Com.IBindCtx': 3,
+      'Windows.Win32.Com.IClassFactory': 3,
+      'Windows.Win32.Com.IEnumMoniker': 3,
+      'Windows.Win32.Com.IEnumString': 3,
+      'Windows.Win32.Com.IMoniker': 8,
+      'Windows.Win32.Com.IPersist': 3,
+      'Windows.Win32.Com.IPersistStream': 4,
+      'Windows.Win32.Com.IProvideClassInfo': 3,
+      'Windows.Win32.Com.IRunningObjectTable': 3,
+      'Windows.Win32.Intl.IEnumSpellingError': 3,
+      'Windows.Win32.Intl.ISpellChecker': 3,
+      'Windows.Win32.Intl.ISpellCheckerChangedEventHandler': 3,
+      'Windows.Win32.Intl.ISpellCheckerFactory': 3,
+      'Windows.Win32.Intl.ISpellingError': 3,
+      'Windows.Win32.NetworkListManager.IEnumNetworkConnections': 7,
+      'Windows.Win32.NetworkListManager.IEnumNetworks': 7,
+      'Windows.Win32.NetworkListManager.INetwork': 7,
+      'Windows.Win32.NetworkListManager.INetworkConnection': 7,
+      'Windows.Win32.NetworkListManager.INetworkListManager': 7,
+      'Windows.Win32.Shell.IApplicationActivationManager': 3,
+      'Windows.Win32.Shell.IDesktopWallpaper': 3,
+      'Windows.Win32.Shell.IEnumIDList': 3,
+      'Windows.Win32.Shell.IFileDialog': 4,
+      'Windows.Win32.Shell.IFileDialog2': 27,
+      'Windows.Win32.Shell.IFileDialogCustomize': 3,
+      'Windows.Win32.Shell.IFileIsInUse': 3,
+      'Windows.Win32.Shell.IFileOpenDialog': 27,
+      'Windows.Win32.Shell.IFileSaveDialog': 27,
+      'Windows.Win32.Shell.IKnownFolder': 3,
+      'Windows.Win32.Shell.IKnownFolderManager': 3,
+      'Windows.Win32.Shell.IModalWindow': 3,
+      'Windows.Win32.Shell.IShellFolder': 3,
+      'Windows.Win32.Shell.IShellItem': 3,
+      'Windows.Win32.Shell.IShellItem2': 8,
+      'Windows.Win32.Shell.IShellItemArray': 3,
+      'Windows.Win32.Shell.IShellItemFilter': 3,
+      'Windows.Win32.StructuredStorage.ISequentialStream': 3,
+      'Windows.Win32.StructuredStorage.IStream': 5,
+      'Windows.Win32.WinRT.IInspectable': 3,
+      'Windows.Win32.Wmi.IEnumWbemClassObject': 3,
+      'Windows.Win32.Wmi.IWbemClassObject': 3,
+      'Windows.Win32.Wmi.IWbemContext': 3,
+      'Windows.Win32.Wmi.IWbemLocator': 3,
+      'Windows.Win32.Wmi.IWbemServices': 3,
+    };
 
     final scope = MetadataStore.getScopeForFile(
         File('tool/metadata/Windows.Win32.winmd'));
 
-    for (final type in typesList) {
-      final calculatedVTableStart =
-          vTableStart(scope.findTypeDef(type.first as String));
+    for (final type in testedTypes.keys) {
+      final calculatedVTableStart = vTableStart(scope.findTypeDef(type));
 
-      expect(calculatedVTableStart, equals(type.last));
+      expect(calculatedVTableStart, equals(testedTypes[type]));
     }
   });
 }

--- a/test/vtablestart_test.dart
+++ b/test/vtablestart_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:winmd/winmd.dart';
+import '../tool/metadata/generate_com_apis.dart';
+
+void main() {
+  test('vTableStart', () {
+    final typesList = [
+      ['Windows.Win32.Automation.IDispatch', 3],
+      ['Windows.Win32.Automation.IEnumVARIANT', 3],
+      ['Windows.Win32.Automation.IErrorInfo', 3],
+      ['Windows.Win32.Automation.ISupportErrorInfo', 3],
+      ['Windows.Win32.Com.IBindCtx', 3],
+      ['Windows.Win32.Com.IClassFactory', 3],
+      ['Windows.Win32.Com.IEnumMoniker', 3],
+      ['Windows.Win32.Com.IEnumString', 3],
+      ['Windows.Win32.Com.IMoniker', 8],
+      ['Windows.Win32.Com.IPersist', 3],
+      ['Windows.Win32.Com.IPersistStream', 4],
+      ['Windows.Win32.Com.IProvideClassInfo', 3],
+      ['Windows.Win32.Com.IRunningObjectTable', 3],
+      ['Windows.Win32.Intl.IEnumSpellingError', 3],
+      ['Windows.Win32.Intl.ISpellChecker', 3],
+      ['Windows.Win32.Intl.ISpellCheckerChangedEventHandler', 3],
+      ['Windows.Win32.Intl.ISpellCheckerFactory', 3],
+      ['Windows.Win32.Intl.ISpellingError', 3],
+      ['Windows.Win32.NetworkListManager.IEnumNetworkConnections', 7],
+      ['Windows.Win32.NetworkListManager.IEnumNetworks', 7],
+      ['Windows.Win32.NetworkListManager.INetwork', 7],
+      ['Windows.Win32.NetworkListManager.INetworkConnection', 7],
+      ['Windows.Win32.NetworkListManager.INetworkListManager', 7],
+      ['Windows.Win32.Shell.IApplicationActivationManager', 3],
+      ['Windows.Win32.Shell.IDesktopWallpaper', 3],
+      ['Windows.Win32.Shell.IEnumIDList', 3],
+      ['Windows.Win32.Shell.IFileDialog', 4],
+      ['Windows.Win32.Shell.IFileDialog2', 27],
+      ['Windows.Win32.Shell.IFileDialogCustomize', 3],
+      ['Windows.Win32.Shell.IFileIsInUse', 3],
+      ['Windows.Win32.Shell.IFileOpenDialog', 27],
+      ['Windows.Win32.Shell.IFileSaveDialog', 27],
+      ['Windows.Win32.Shell.IKnownFolder', 3],
+      ['Windows.Win32.Shell.IKnownFolderManager', 3],
+      ['Windows.Win32.Shell.IModalWindow', 3],
+      ['Windows.Win32.Shell.IShellFolder', 3],
+      ['Windows.Win32.Shell.IShellItem', 3],
+      ['Windows.Win32.Shell.IShellItem2', 8],
+      ['Windows.Win32.Shell.IShellItemArray', 3],
+      ['Windows.Win32.Shell.IShellItemFilter', 3],
+      ['Windows.Win32.StructuredStorage.ISequentialStream', 3],
+      ['Windows.Win32.StructuredStorage.IStream', 5],
+      ['Windows.Win32.WinRT.IInspectable', 3],
+      ['Windows.Win32.Wmi.IEnumWbemClassObject', 3],
+      ['Windows.Win32.Wmi.IWbemClassObject', 3],
+      ['Windows.Win32.Wmi.IWbemContext', 3],
+      ['Windows.Win32.Wmi.IWbemLocator', 3],
+      ['Windows.Win32.Wmi.IWbemServices', 3],
+    ];
+
+    final scope = MetadataStore.getScopeForFile(
+        File('tool/metadata/Windows.Win32.winmd'));
+
+    for (final type in typesList) {
+      final calculatedVTableStart =
+          vTableStart(scope.findTypeDef(type.first as String));
+
+      expect(calculatedVTableStart, equals(type.last));
+    }
+  });
+}

--- a/test/vtablestart_test.dart
+++ b/test/vtablestart_test.dart
@@ -1,3 +1,5 @@
+@TestOn('windows')
+
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/tool/metadata/generate_com_apis.dart
+++ b/tool/metadata/generate_com_apis.dart
@@ -9,78 +9,83 @@ late final Scope scope;
 
 class COMType {
   final String typeName;
-  final int vTableStart;
   final bool generateClass;
 
-  const COMType(this.typeName,
-      {this.vTableStart = 0, this.generateClass = false});
+  const COMType(this.typeName, {this.generateClass = false});
 }
 
 const interfacesToGenerate = <COMType>[
-  COMType('Windows.Win32.Automation.IDispatch', vTableStart: 3),
-  COMType('Windows.Win32.Automation.IEnumVARIANT', vTableStart: 3),
-  COMType('Windows.Win32.Automation.IErrorInfo', vTableStart: 3),
-  COMType('Windows.Win32.Automation.ISupportErrorInfo', vTableStart: 3),
-  COMType('Windows.Win32.Com.IBindCtx', vTableStart: 3),
-  COMType('Windows.Win32.Com.IClassFactory', vTableStart: 3),
-  COMType('Windows.Win32.Com.IEnumMoniker', vTableStart: 3),
-  COMType('Windows.Win32.Com.IEnumString', vTableStart: 3),
-  COMType('Windows.Win32.Com.IMoniker', vTableStart: 8),
-  COMType('Windows.Win32.Com.IPersist', vTableStart: 3),
-  COMType('Windows.Win32.Com.IPersistStream', vTableStart: 4),
-  COMType('Windows.Win32.Com.IProvideClassInfo', vTableStart: 3),
-  COMType('Windows.Win32.Com.IRunningObjectTable', vTableStart: 3),
+  COMType('Windows.Win32.Automation.IDispatch'),
+  COMType('Windows.Win32.Automation.IEnumVARIANT'),
+  COMType('Windows.Win32.Automation.IErrorInfo'),
+  COMType('Windows.Win32.Automation.ISupportErrorInfo'),
+  COMType('Windows.Win32.Com.IBindCtx'),
+  COMType('Windows.Win32.Com.IClassFactory'),
+  COMType('Windows.Win32.Com.IEnumMoniker'),
+  COMType('Windows.Win32.Com.IEnumString'),
+  COMType('Windows.Win32.Com.IMoniker'),
+  COMType('Windows.Win32.Com.IPersist'),
+  COMType('Windows.Win32.Com.IPersistStream'),
+  COMType('Windows.Win32.Com.IProvideClassInfo'),
+  COMType('Windows.Win32.Com.IRunningObjectTable'),
   COMType('Windows.Win32.Com.IUnknown'),
-  COMType('Windows.Win32.Intl.IEnumSpellingError',
-      vTableStart: 3, generateClass: true),
-  COMType('Windows.Win32.Intl.ISpellChecker',
-      vTableStart: 3, generateClass: true),
+  COMType('Windows.Win32.Intl.IEnumSpellingError', generateClass: true),
+  COMType('Windows.Win32.Intl.ISpellChecker', generateClass: true),
   COMType('Windows.Win32.Intl.ISpellCheckerChangedEventHandler',
-      vTableStart: 3, generateClass: true),
-  COMType('Windows.Win32.Intl.ISpellCheckerFactory',
-      vTableStart: 3, generateClass: true),
-  COMType('Windows.Win32.Intl.ISpellingError',
-      vTableStart: 3, generateClass: true),
-  COMType('Windows.Win32.NetworkListManager.IEnumNetworkConnections',
-      vTableStart: 7),
-  COMType('Windows.Win32.NetworkListManager.IEnumNetworks', vTableStart: 7),
-  COMType('Windows.Win32.NetworkListManager.INetwork', vTableStart: 7),
-  COMType('Windows.Win32.NetworkListManager.INetworkConnection',
-      vTableStart: 7),
+      generateClass: true),
+  COMType('Windows.Win32.Intl.ISpellCheckerFactory', generateClass: true),
+  COMType('Windows.Win32.Intl.ISpellingError', generateClass: true),
+  COMType('Windows.Win32.NetworkListManager.IEnumNetworkConnections'),
+  COMType('Windows.Win32.NetworkListManager.IEnumNetworks'),
+  COMType('Windows.Win32.NetworkListManager.INetwork'),
+  COMType('Windows.Win32.NetworkListManager.INetworkConnection'),
   COMType('Windows.Win32.NetworkListManager.INetworkListManager',
-      vTableStart: 7, generateClass: true),
+      generateClass: true),
   COMType('Windows.Win32.Shell.IApplicationActivationManager',
-      vTableStart: 3, generateClass: true),
-  COMType('Windows.Win32.Shell.IDesktopWallpaper',
-      vTableStart: 3, generateClass: true),
-  COMType('Windows.Win32.Shell.IEnumIDList', vTableStart: 3),
-  COMType('Windows.Win32.Shell.IFileDialog', vTableStart: 4),
-  COMType('Windows.Win32.Shell.IFileDialog2', vTableStart: 27),
-  COMType('Windows.Win32.Shell.IFileDialogCustomize', vTableStart: 3),
-  COMType('Windows.Win32.Shell.IFileIsInUse', vTableStart: 3),
-  COMType('Windows.Win32.Shell.IFileOpenDialog',
-      vTableStart: 27, generateClass: true),
-  COMType('Windows.Win32.Shell.IFileSaveDialog',
-      vTableStart: 27, generateClass: true),
-  COMType('Windows.Win32.Shell.IKnownFolder', vTableStart: 3),
-  COMType('Windows.Win32.Shell.IKnownFolderManager',
-      vTableStart: 3, generateClass: true),
-  COMType('Windows.Win32.Shell.IModalWindow', vTableStart: 3),
-  COMType('Windows.Win32.Shell.IShellFolder', vTableStart: 3),
-  COMType('Windows.Win32.Shell.IShellItem', vTableStart: 3),
-  COMType('Windows.Win32.Shell.IShellItem2', vTableStart: 8),
-  COMType('Windows.Win32.Shell.IShellItemArray', vTableStart: 3),
-  COMType('Windows.Win32.Shell.IShellItemFilter', vTableStart: 3),
-  COMType('Windows.Win32.StructuredStorage.ISequentialStream', vTableStart: 3),
-  COMType('Windows.Win32.StructuredStorage.IStream', vTableStart: 5),
-  COMType('Windows.Win32.WinRT.IInspectable', vTableStart: 3),
-  COMType('Windows.Win32.Wmi.IEnumWbemClassObject', vTableStart: 3),
-  COMType('Windows.Win32.Wmi.IWbemClassObject', vTableStart: 3),
-  COMType('Windows.Win32.Wmi.IWbemContext', vTableStart: 3),
-  COMType('Windows.Win32.Wmi.IWbemLocator',
-      vTableStart: 3, generateClass: true),
-  COMType('Windows.Win32.Wmi.IWbemServices', vTableStart: 3),
+      generateClass: true),
+  COMType('Windows.Win32.Shell.IDesktopWallpaper', generateClass: true),
+  COMType('Windows.Win32.Shell.IEnumIDList'),
+  COMType('Windows.Win32.Shell.IFileDialog'),
+  COMType('Windows.Win32.Shell.IFileDialog2'),
+  COMType('Windows.Win32.Shell.IFileDialogCustomize'),
+  COMType('Windows.Win32.Shell.IFileIsInUse'),
+  COMType('Windows.Win32.Shell.IFileOpenDialog', generateClass: true),
+  COMType('Windows.Win32.Shell.IFileSaveDialog', generateClass: true),
+  COMType('Windows.Win32.Shell.IKnownFolder'),
+  COMType('Windows.Win32.Shell.IKnownFolderManager', generateClass: true),
+  COMType('Windows.Win32.Shell.IModalWindow'),
+  COMType('Windows.Win32.Shell.IShellFolder'),
+  COMType('Windows.Win32.Shell.IShellItem'),
+  COMType('Windows.Win32.Shell.IShellItem2'),
+  COMType('Windows.Win32.Shell.IShellItemArray'),
+  COMType('Windows.Win32.Shell.IShellItemFilter'),
+  COMType('Windows.Win32.StructuredStorage.ISequentialStream'),
+  COMType('Windows.Win32.StructuredStorage.IStream'),
+  COMType('Windows.Win32.WinRT.IInspectable'),
+  COMType('Windows.Win32.Wmi.IEnumWbemClassObject'),
+  COMType('Windows.Win32.Wmi.IWbemClassObject'),
+  COMType('Windows.Win32.Wmi.IWbemContext'),
+  COMType('Windows.Win32.Wmi.IWbemLocator', generateClass: true),
+  COMType('Windows.Win32.Wmi.IWbemServices'),
 ];
+
+int vTableStart(TypeDef? type) {
+  if (type == null) {
+    return 0;
+  }
+
+  if (type.isInterface && type.interfaces.isNotEmpty) {
+    var sum = 0;
+
+    for (final interface in type.interfaces) {
+      sum += interface.methods.length + vTableStart(interface);
+    }
+
+    return sum;
+  }
+
+  return 0;
+}
 
 void main(List<String> args) {
   scope =
@@ -113,7 +118,7 @@ void main(List<String> args) {
 
     final projection = ClassProjector(mdTypeDef).projection
       ..inherits = parentInterface
-      ..vtableStart = type.vTableStart
+      ..vtableStart = vTableStart(mdTypeDef)
       ..sourceType = SourceType.com
       ..generateClass = type.generateClass
       ..clsid = clsid


### PR DESCRIPTION
This calculates vtable starts from metadata (#163) by summing up number of methods of all parents.

I'm not sure if this is the right way to do this, but all results match with current values. 
