### PR TITLE
Tidy up vtable references

### DIFF
--- a/lib/src/com/IApplicationActivationManager.dart
+++ b/lib/src/com/IApplicationActivationManager.dart
@@ -73,22 +73,28 @@ class IApplicationActivationManager extends IUnknown {
 
   int ActivateApplication(Pointer<Utf16> appUserModelId,
           Pointer<Utf16> arguments, int options, Pointer<Uint32> processId) =>
-      Pointer<NativeFunction<_ActivateApplication_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_ActivateApplication_Native>>>()
+              .value
               .asFunction<_ActivateApplication_Dart>()(
           ptr.ref.lpVtbl, appUserModelId, arguments, options, processId);
 
   int ActivateForFile(Pointer<Utf16> appUserModelId, Pointer itemArray,
           Pointer<Utf16> verb, Pointer<Uint32> processId) =>
-      Pointer<NativeFunction<_ActivateForFile_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_ActivateForFile_Native>>>()
+              .value
               .asFunction<_ActivateForFile_Dart>()(
           ptr.ref.lpVtbl, appUserModelId, itemArray, verb, processId);
 
   int ActivateForProtocol(Pointer<Utf16> appUserModelId, Pointer itemArray,
           Pointer<Uint32> processId) =>
-      Pointer<NativeFunction<_ActivateForProtocol_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_ActivateForProtocol_Native>>>()
+              .value
               .asFunction<_ActivateForProtocol_Dart>()(
           ptr.ref.lpVtbl, appUserModelId, itemArray, processId);
 }

--- a/lib/src/com/IAppxFactory.dart
+++ b/lib/src/com/IAppxFactory.dart
@@ -73,38 +73,47 @@ class IAppxFactory extends IUnknown {
           Pointer outputStream,
           Pointer<APPX_PACKAGE_SETTINGS> settings,
           Pointer<Pointer> packageWriter) =>
-      Pointer<NativeFunction<_CreatePackageWriter_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_CreatePackageWriter_Native>>>()
+              .value
               .asFunction<_CreatePackageWriter_Dart>()(
           ptr.ref.lpVtbl, outputStream, settings, packageWriter);
 
   int CreatePackageReader(
           Pointer inputStream, Pointer<Pointer> packageReader) =>
-      Pointer<NativeFunction<_CreatePackageReader_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_CreatePackageReader_Native>>>()
+              .value
               .asFunction<_CreatePackageReader_Dart>()(
           ptr.ref.lpVtbl, inputStream, packageReader);
 
   int CreateManifestReader(
           Pointer inputStream, Pointer<Pointer> manifestReader) =>
-      Pointer<NativeFunction<_CreateManifestReader_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_CreateManifestReader_Native>>>()
+              .value
               .asFunction<_CreateManifestReader_Dart>()(
           ptr.ref.lpVtbl, inputStream, manifestReader);
 
   int CreateBlockMapReader(
           Pointer inputStream, Pointer<Pointer> blockMapReader) =>
-      Pointer<NativeFunction<_CreateBlockMapReader_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(6)
+              .cast<Pointer<NativeFunction<_CreateBlockMapReader_Native>>>()
+              .value
               .asFunction<_CreateBlockMapReader_Dart>()(
           ptr.ref.lpVtbl, inputStream, blockMapReader);
 
   int CreateValidatedBlockMapReader(Pointer blockMapStream,
           Pointer<Utf16> signatureFileName, Pointer<Pointer> blockMapReader) =>
-      Pointer<
-                      NativeFunction<
-                          _CreateValidatedBlockMapReader_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(7)
+              .cast<
+                  Pointer<NativeFunction<_CreateValidatedBlockMapReader_Native>>>()
+              .value
               .asFunction<_CreateValidatedBlockMapReader_Dart>()(
           ptr.ref.lpVtbl, blockMapStream, signatureFileName, blockMapReader);
 }

--- a/lib/src/com/IAppxFile.dart
+++ b/lib/src/com/IAppxFile.dart
@@ -52,28 +52,35 @@ class IAppxFile extends IUnknown {
   IAppxFile(Pointer<COMObject> ptr) : super(ptr);
 
   int GetCompressionOption(Pointer<Uint32> compressionOption) =>
-      Pointer<NativeFunction<_GetCompressionOption_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_GetCompressionOption_Native>>>()
+              .value
               .asFunction<_GetCompressionOption_Dart>()(
           ptr.ref.lpVtbl, compressionOption);
 
   int GetContentType(Pointer<Pointer<Utf16>> contentType) =>
-      Pointer<NativeFunction<_GetContentType_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(4)
+          .cast<Pointer<NativeFunction<_GetContentType_Native>>>()
+          .value
           .asFunction<_GetContentType_Dart>()(ptr.ref.lpVtbl, contentType);
 
-  int GetName(Pointer<Pointer<Utf16>> fileName) =>
-      Pointer<NativeFunction<_GetName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, fileName);
+  int GetName(Pointer<Pointer<Utf16>> fileName) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_GetName_Native>>>()
+      .value
+      .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, fileName);
 
-  int GetSize(Pointer<Uint64> size) =>
-      Pointer<NativeFunction<_GetSize_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetSize_Dart>()(ptr.ref.lpVtbl, size);
+  int GetSize(Pointer<Uint64> size) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetSize_Native>>>()
+      .value
+      .asFunction<_GetSize_Dart>()(ptr.ref.lpVtbl, size);
 
-  int GetStream(Pointer<Pointer> stream) =>
-      Pointer<NativeFunction<_GetStream_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetStream_Dart>()(ptr.ref.lpVtbl, stream);
+  int GetStream(Pointer<Pointer> stream) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetStream_Native>>>()
+      .value
+      .asFunction<_GetStream_Dart>()(ptr.ref.lpVtbl, stream);
 }

--- a/lib/src/com/IAppxFilesEnumerator.dart
+++ b/lib/src/com/IAppxFilesEnumerator.dart
@@ -40,18 +40,21 @@ class IAppxFilesEnumerator extends IUnknown {
 
   IAppxFilesEnumerator(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetCurrent(Pointer<Pointer> file) =>
-      Pointer<NativeFunction<_GetCurrent_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetCurrent_Dart>()(ptr.ref.lpVtbl, file);
+  int GetCurrent(Pointer<Pointer> file) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetCurrent_Native>>>()
+      .value
+      .asFunction<_GetCurrent_Dart>()(ptr.ref.lpVtbl, file);
 
-  int GetHasCurrent(Pointer<Int32> hasCurrent) =>
-      Pointer<NativeFunction<_GetHasCurrent_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetHasCurrent_Dart>()(ptr.ref.lpVtbl, hasCurrent);
+  int GetHasCurrent(Pointer<Int32> hasCurrent) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetHasCurrent_Native>>>()
+      .value
+      .asFunction<_GetHasCurrent_Dart>()(ptr.ref.lpVtbl, hasCurrent);
 
-  int MoveNext(Pointer<Int32> hasNext) =>
-      Pointer<NativeFunction<_MoveNext_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_MoveNext_Dart>()(ptr.ref.lpVtbl, hasNext);
+  int MoveNext(Pointer<Int32> hasNext) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_MoveNext_Native>>>()
+      .value
+      .asFunction<_MoveNext_Dart>()(ptr.ref.lpVtbl, hasNext);
 }

--- a/lib/src/com/IAppxManifestApplication.dart
+++ b/lib/src/com/IAppxManifestApplication.dart
@@ -40,13 +40,16 @@ class IAppxManifestApplication extends IUnknown {
   IAppxManifestApplication(Pointer<COMObject> ptr) : super(ptr);
 
   int GetStringValue(Pointer<Utf16> name, Pointer<Pointer<Utf16>> value) =>
-      Pointer<NativeFunction<_GetStringValue_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_GetStringValue_Native>>>()
+          .value
           .asFunction<_GetStringValue_Dart>()(ptr.ref.lpVtbl, name, value);
 
-  int GetAppUserModelId(Pointer<Pointer<Utf16>> appUserModelId) =>
-      Pointer<NativeFunction<_GetAppUserModelId_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
-              .asFunction<_GetAppUserModelId_Dart>()(
-          ptr.ref.lpVtbl, appUserModelId);
+  int GetAppUserModelId(Pointer<Pointer<Utf16>> appUserModelId) => ptr
+      .ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetAppUserModelId_Native>>>()
+      .value
+      .asFunction<_GetAppUserModelId_Dart>()(ptr.ref.lpVtbl, appUserModelId);
 }

--- a/lib/src/com/IAppxManifestApplicationsEnumerator.dart
+++ b/lib/src/com/IAppxManifestApplicationsEnumerator.dart
@@ -43,18 +43,21 @@ class IAppxManifestApplicationsEnumerator extends IUnknown {
 
   IAppxManifestApplicationsEnumerator(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetCurrent(Pointer<Pointer> application) =>
-      Pointer<NativeFunction<_GetCurrent_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetCurrent_Dart>()(ptr.ref.lpVtbl, application);
+  int GetCurrent(Pointer<Pointer> application) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetCurrent_Native>>>()
+      .value
+      .asFunction<_GetCurrent_Dart>()(ptr.ref.lpVtbl, application);
 
-  int GetHasCurrent(Pointer<Int32> hasCurrent) =>
-      Pointer<NativeFunction<_GetHasCurrent_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetHasCurrent_Dart>()(ptr.ref.lpVtbl, hasCurrent);
+  int GetHasCurrent(Pointer<Int32> hasCurrent) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetHasCurrent_Native>>>()
+      .value
+      .asFunction<_GetHasCurrent_Dart>()(ptr.ref.lpVtbl, hasCurrent);
 
-  int MoveNext(Pointer<Int32> hasNext) =>
-      Pointer<NativeFunction<_MoveNext_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_MoveNext_Dart>()(ptr.ref.lpVtbl, hasNext);
+  int MoveNext(Pointer<Int32> hasNext) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_MoveNext_Native>>>()
+      .value
+      .asFunction<_MoveNext_Dart>()(ptr.ref.lpVtbl, hasNext);
 }

--- a/lib/src/com/IAppxManifestOSPackageDependency.dart
+++ b/lib/src/com/IAppxManifestOSPackageDependency.dart
@@ -38,13 +38,15 @@ class IAppxManifestOSPackageDependency extends IUnknown {
 
   IAppxManifestOSPackageDependency(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetName(Pointer<Pointer<Utf16>> name) =>
-      Pointer<NativeFunction<_GetName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, name);
+  int GetName(Pointer<Pointer<Utf16>> name) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetName_Native>>>()
+      .value
+      .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, name);
 
-  int GetVersion(Pointer<Uint64> version) =>
-      Pointer<NativeFunction<_GetVersion_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetVersion_Dart>()(ptr.ref.lpVtbl, version);
+  int GetVersion(Pointer<Uint64> version) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetVersion_Native>>>()
+      .value
+      .asFunction<_GetVersion_Dart>()(ptr.ref.lpVtbl, version);
 }

--- a/lib/src/com/IAppxManifestPackageDependenciesEnumerator.dart
+++ b/lib/src/com/IAppxManifestPackageDependenciesEnumerator.dart
@@ -44,18 +44,21 @@ class IAppxManifestPackageDependenciesEnumerator extends IUnknown {
   IAppxManifestPackageDependenciesEnumerator(Pointer<COMObject> ptr)
       : super(ptr);
 
-  int GetCurrent(Pointer<Pointer> dependency) =>
-      Pointer<NativeFunction<_GetCurrent_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetCurrent_Dart>()(ptr.ref.lpVtbl, dependency);
+  int GetCurrent(Pointer<Pointer> dependency) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetCurrent_Native>>>()
+      .value
+      .asFunction<_GetCurrent_Dart>()(ptr.ref.lpVtbl, dependency);
 
-  int GetHasCurrent(Pointer<Int32> hasCurrent) =>
-      Pointer<NativeFunction<_GetHasCurrent_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetHasCurrent_Dart>()(ptr.ref.lpVtbl, hasCurrent);
+  int GetHasCurrent(Pointer<Int32> hasCurrent) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetHasCurrent_Native>>>()
+      .value
+      .asFunction<_GetHasCurrent_Dart>()(ptr.ref.lpVtbl, hasCurrent);
 
-  int MoveNext(Pointer<Int32> hasNext) =>
-      Pointer<NativeFunction<_MoveNext_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_MoveNext_Dart>()(ptr.ref.lpVtbl, hasNext);
+  int MoveNext(Pointer<Int32> hasNext) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_MoveNext_Native>>>()
+      .value
+      .asFunction<_MoveNext_Dart>()(ptr.ref.lpVtbl, hasNext);
 }

--- a/lib/src/com/IAppxManifestPackageDependency.dart
+++ b/lib/src/com/IAppxManifestPackageDependency.dart
@@ -44,18 +44,21 @@ class IAppxManifestPackageDependency extends IUnknown {
 
   IAppxManifestPackageDependency(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetName(Pointer<Pointer<Utf16>> name) =>
-      Pointer<NativeFunction<_GetName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, name);
+  int GetName(Pointer<Pointer<Utf16>> name) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetName_Native>>>()
+      .value
+      .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, name);
 
-  int GetPublisher(Pointer<Pointer<Utf16>> publisher) =>
-      Pointer<NativeFunction<_GetPublisher_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetPublisher_Dart>()(ptr.ref.lpVtbl, publisher);
+  int GetPublisher(Pointer<Pointer<Utf16>> publisher) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetPublisher_Native>>>()
+      .value
+      .asFunction<_GetPublisher_Dart>()(ptr.ref.lpVtbl, publisher);
 
-  int GetMinVersion(Pointer<Uint64> minVersion) =>
-      Pointer<NativeFunction<_GetMinVersion_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_GetMinVersion_Dart>()(ptr.ref.lpVtbl, minVersion);
+  int GetMinVersion(Pointer<Uint64> minVersion) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_GetMinVersion_Native>>>()
+      .value
+      .asFunction<_GetMinVersion_Dart>()(ptr.ref.lpVtbl, minVersion);
 }

--- a/lib/src/com/IAppxManifestPackageId.dart
+++ b/lib/src/com/IAppxManifestPackageId.dart
@@ -68,45 +68,55 @@ class IAppxManifestPackageId extends IUnknown {
 
   IAppxManifestPackageId(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetName(Pointer<Pointer<Utf16>> name) =>
-      Pointer<NativeFunction<_GetName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, name);
+  int GetName(Pointer<Pointer<Utf16>> name) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetName_Native>>>()
+      .value
+      .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, name);
 
-  int GetArchitecture(Pointer<Uint32> architecture) =>
-      Pointer<NativeFunction<_GetArchitecture_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetArchitecture_Dart>()(ptr.ref.lpVtbl, architecture);
+  int GetArchitecture(Pointer<Uint32> architecture) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetArchitecture_Native>>>()
+      .value
+      .asFunction<_GetArchitecture_Dart>()(ptr.ref.lpVtbl, architecture);
 
-  int GetPublisher(Pointer<Pointer<Utf16>> publisher) =>
-      Pointer<NativeFunction<_GetPublisher_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_GetPublisher_Dart>()(ptr.ref.lpVtbl, publisher);
+  int GetPublisher(Pointer<Pointer<Utf16>> publisher) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_GetPublisher_Native>>>()
+      .value
+      .asFunction<_GetPublisher_Dart>()(ptr.ref.lpVtbl, publisher);
 
-  int GetVersion(Pointer<Uint64> packageVersion) =>
-      Pointer<NativeFunction<_GetVersion_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetVersion_Dart>()(ptr.ref.lpVtbl, packageVersion);
+  int GetVersion(Pointer<Uint64> packageVersion) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetVersion_Native>>>()
+      .value
+      .asFunction<_GetVersion_Dart>()(ptr.ref.lpVtbl, packageVersion);
 
-  int GetResourceId(Pointer<Pointer<Utf16>> resourceId) =>
-      Pointer<NativeFunction<_GetResourceId_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetResourceId_Dart>()(ptr.ref.lpVtbl, resourceId);
+  int GetResourceId(Pointer<Pointer<Utf16>> resourceId) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetResourceId_Native>>>()
+      .value
+      .asFunction<_GetResourceId_Dart>()(ptr.ref.lpVtbl, resourceId);
 
   int ComparePublisher(Pointer<Utf16> other, Pointer<Int32> isSame) =>
-      Pointer<NativeFunction<_ComparePublisher_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_ComparePublisher_Native>>>()
+          .value
           .asFunction<_ComparePublisher_Dart>()(ptr.ref.lpVtbl, other, isSame);
 
-  int GetPackageFullName(Pointer<Pointer<Utf16>> packageFullName) =>
-      Pointer<NativeFunction<_GetPackageFullName_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(9).value)
-              .asFunction<_GetPackageFullName_Dart>()(
-          ptr.ref.lpVtbl, packageFullName);
+  int GetPackageFullName(Pointer<Pointer<Utf16>> packageFullName) => ptr
+      .ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_GetPackageFullName_Native>>>()
+      .value
+      .asFunction<_GetPackageFullName_Dart>()(ptr.ref.lpVtbl, packageFullName);
 
   int GetPackageFamilyName(Pointer<Pointer<Utf16>> packageFamilyName) =>
-      Pointer<NativeFunction<_GetPackageFamilyName_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(10)
+              .cast<Pointer<NativeFunction<_GetPackageFamilyName_Native>>>()
+              .value
               .asFunction<_GetPackageFamilyName_Dart>()(
           ptr.ref.lpVtbl, packageFamilyName);
 }

--- a/lib/src/com/IAppxManifestProperties.dart
+++ b/lib/src/com/IAppxManifestProperties.dart
@@ -40,12 +40,16 @@ class IAppxManifestProperties extends IUnknown {
   IAppxManifestProperties(Pointer<COMObject> ptr) : super(ptr);
 
   int GetBoolValue(Pointer<Utf16> name, Pointer<Int32> value) =>
-      Pointer<NativeFunction<_GetBoolValue_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_GetBoolValue_Native>>>()
+          .value
           .asFunction<_GetBoolValue_Dart>()(ptr.ref.lpVtbl, name, value);
 
   int GetStringValue(Pointer<Utf16> name, Pointer<Pointer<Utf16>> value) =>
-      Pointer<NativeFunction<_GetStringValue_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(4)
+          .cast<Pointer<NativeFunction<_GetStringValue_Native>>>()
+          .value
           .asFunction<_GetStringValue_Dart>()(ptr.ref.lpVtbl, name, value);
 }

--- a/lib/src/com/IAppxManifestReader.dart
+++ b/lib/src/com/IAppxManifestReader.dart
@@ -74,50 +74,61 @@ class IAppxManifestReader extends IUnknown {
 
   IAppxManifestReader(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetPackageId(Pointer<Pointer> packageId) =>
-      Pointer<NativeFunction<_GetPackageId_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetPackageId_Dart>()(ptr.ref.lpVtbl, packageId);
+  int GetPackageId(Pointer<Pointer> packageId) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetPackageId_Native>>>()
+      .value
+      .asFunction<_GetPackageId_Dart>()(ptr.ref.lpVtbl, packageId);
 
-  int GetProperties(Pointer<Pointer> packageProperties) =>
-      Pointer<NativeFunction<_GetProperties_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetProperties_Dart>()(ptr.ref.lpVtbl, packageProperties);
+  int GetProperties(Pointer<Pointer> packageProperties) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetProperties_Native>>>()
+      .value
+      .asFunction<_GetProperties_Dart>()(ptr.ref.lpVtbl, packageProperties);
 
-  int GetPackageDependencies(Pointer<Pointer> dependencies) =>
-      Pointer<NativeFunction<_GetPackageDependencies_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
-              .asFunction<_GetPackageDependencies_Dart>()(
-          ptr.ref.lpVtbl, dependencies);
+  int GetPackageDependencies(Pointer<Pointer> dependencies) => ptr
+      .ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_GetPackageDependencies_Native>>>()
+      .value
+      .asFunction<_GetPackageDependencies_Dart>()(ptr.ref.lpVtbl, dependencies);
 
-  int GetCapabilities(Pointer<Uint32> capabilities) =>
-      Pointer<NativeFunction<_GetCapabilities_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetCapabilities_Dart>()(ptr.ref.lpVtbl, capabilities);
+  int GetCapabilities(Pointer<Uint32> capabilities) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetCapabilities_Native>>>()
+      .value
+      .asFunction<_GetCapabilities_Dart>()(ptr.ref.lpVtbl, capabilities);
 
-  int GetResources(Pointer<Pointer> resources) =>
-      Pointer<NativeFunction<_GetResources_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetResources_Dart>()(ptr.ref.lpVtbl, resources);
+  int GetResources(Pointer<Pointer> resources) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetResources_Native>>>()
+      .value
+      .asFunction<_GetResources_Dart>()(ptr.ref.lpVtbl, resources);
 
   int GetDeviceCapabilities(Pointer<Pointer> deviceCapabilities) =>
-      Pointer<NativeFunction<_GetDeviceCapabilities_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(8)
+              .cast<Pointer<NativeFunction<_GetDeviceCapabilities_Native>>>()
+              .value
               .asFunction<_GetDeviceCapabilities_Dart>()(
           ptr.ref.lpVtbl, deviceCapabilities);
 
   int GetPrerequisite(Pointer<Utf16> name, Pointer<Uint64> value) =>
-      Pointer<NativeFunction<_GetPrerequisite_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(9)
+          .cast<Pointer<NativeFunction<_GetPrerequisite_Native>>>()
+          .value
           .asFunction<_GetPrerequisite_Dart>()(ptr.ref.lpVtbl, name, value);
 
-  int GetApplications(Pointer<Pointer> applications) =>
-      Pointer<NativeFunction<_GetApplications_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_GetApplications_Dart>()(ptr.ref.lpVtbl, applications);
+  int GetApplications(Pointer<Pointer> applications) => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_GetApplications_Native>>>()
+      .value
+      .asFunction<_GetApplications_Dart>()(ptr.ref.lpVtbl, applications);
 
-  int GetStream(Pointer<Pointer> manifestStream) =>
-      Pointer<NativeFunction<_GetStream_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_GetStream_Dart>()(ptr.ref.lpVtbl, manifestStream);
+  int GetStream(Pointer<Pointer> manifestStream) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_GetStream_Native>>>()
+      .value
+      .asFunction<_GetStream_Dart>()(ptr.ref.lpVtbl, manifestStream);
 }

--- a/lib/src/com/IAppxManifestReader2.dart
+++ b/lib/src/com/IAppxManifestReader2.dart
@@ -34,8 +34,9 @@ class IAppxManifestReader2 extends IAppxManifestReader {
 
   IAppxManifestReader2(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetQualifiedResources(Pointer<Pointer> resources) =>
-      Pointer<NativeFunction<_GetQualifiedResources_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_GetQualifiedResources_Dart>()(ptr.ref.lpVtbl, resources);
+  int GetQualifiedResources(Pointer<Pointer> resources) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_GetQualifiedResources_Native>>>()
+      .value
+      .asFunction<_GetQualifiedResources_Dart>()(ptr.ref.lpVtbl, resources);
 }

--- a/lib/src/com/IAppxManifestReader3.dart
+++ b/lib/src/com/IAppxManifestReader3.dart
@@ -39,20 +39,24 @@ class IAppxManifestReader3 extends IAppxManifestReader2 {
 
   IAppxManifestReader3(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetCapabilitiesByCapabilityClass(
-          int capabilityClass, Pointer<Pointer> capabilities) =>
-      Pointer<
-                  NativeFunction<
-                      _GetCapabilitiesByCapabilityClass_Native>>.fromAddress(ptr
-                  .ref.vtable
+  int
+      GetCapabilitiesByCapabilityClass(
+              int capabilityClass, Pointer<Pointer> capabilities) =>
+          ptr.ref.lpVtbl.value
                   .elementAt(13)
-                  .value)
-              .asFunction<_GetCapabilitiesByCapabilityClass_Dart>()(
-          ptr.ref.lpVtbl, capabilityClass, capabilities);
+                  .cast<
+                      Pointer<
+                          NativeFunction<
+                              _GetCapabilitiesByCapabilityClass_Native>>>()
+                  .value
+                  .asFunction<_GetCapabilitiesByCapabilityClass_Dart>()(
+              ptr.ref.lpVtbl, capabilityClass, capabilities);
 
   int GetTargetDeviceFamilies(Pointer<Pointer> targetDeviceFamilies) =>
-      Pointer<NativeFunction<_GetTargetDeviceFamilies_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(14).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(14)
+              .cast<Pointer<NativeFunction<_GetTargetDeviceFamilies_Native>>>()
+              .value
               .asFunction<_GetTargetDeviceFamilies_Dart>()(
           ptr.ref.lpVtbl, targetDeviceFamilies);
 }

--- a/lib/src/com/IAppxManifestReader4.dart
+++ b/lib/src/com/IAppxManifestReader4.dart
@@ -35,8 +35,10 @@ class IAppxManifestReader4 extends IAppxManifestReader3 {
   IAppxManifestReader4(Pointer<COMObject> ptr) : super(ptr);
 
   int GetOptionalPackageInfo(Pointer<Pointer> optionalPackageInfo) =>
-      Pointer<NativeFunction<_GetOptionalPackageInfo_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(15).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(15)
+              .cast<Pointer<NativeFunction<_GetOptionalPackageInfo_Native>>>()
+              .value
               .asFunction<_GetOptionalPackageInfo_Dart>()(
           ptr.ref.lpVtbl, optionalPackageInfo);
 }

--- a/lib/src/com/IAppxManifestReader5.dart
+++ b/lib/src/com/IAppxManifestReader5.dart
@@ -34,9 +34,11 @@ class IAppxManifestReader5 extends IUnknown {
 
   IAppxManifestReader5(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetMainPackageDependencies(Pointer<Pointer> mainPackageDependencies) =>
-      Pointer<NativeFunction<_GetMainPackageDependencies_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
-              .asFunction<_GetMainPackageDependencies_Dart>()(
-          ptr.ref.lpVtbl, mainPackageDependencies);
+  int GetMainPackageDependencies(Pointer<Pointer> mainPackageDependencies) => ptr
+          .ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_GetMainPackageDependencies_Native>>>()
+          .value
+          .asFunction<_GetMainPackageDependencies_Dart>()(
+      ptr.ref.lpVtbl, mainPackageDependencies);
 }

--- a/lib/src/com/IAppxManifestReader6.dart
+++ b/lib/src/com/IAppxManifestReader6.dart
@@ -34,14 +34,16 @@ class IAppxManifestReader6 extends IUnknown {
 
   IAppxManifestReader6(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetIsNonQualifiedResourcePackage(
-          Pointer<Int32> isNonQualifiedResourcePackage) =>
-      Pointer<
-                  NativeFunction<
-                      _GetIsNonQualifiedResourcePackage_Native>>.fromAddress(ptr
-                  .ref.vtable
+  int
+      GetIsNonQualifiedResourcePackage(
+              Pointer<Int32> isNonQualifiedResourcePackage) =>
+          ptr.ref.lpVtbl.value
                   .elementAt(3)
-                  .value)
-              .asFunction<_GetIsNonQualifiedResourcePackage_Dart>()(
-          ptr.ref.lpVtbl, isNonQualifiedResourcePackage);
+                  .cast<
+                      Pointer<
+                          NativeFunction<
+                              _GetIsNonQualifiedResourcePackage_Native>>>()
+                  .value
+                  .asFunction<_GetIsNonQualifiedResourcePackage_Dart>()(
+              ptr.ref.lpVtbl, isNonQualifiedResourcePackage);
 }

--- a/lib/src/com/IAppxManifestReader7.dart
+++ b/lib/src/com/IAppxManifestReader7.dart
@@ -45,20 +45,26 @@ class IAppxManifestReader7 extends IUnknown {
   IAppxManifestReader7(Pointer<COMObject> ptr) : super(ptr);
 
   int GetDriverDependencies(Pointer<Pointer> driverDependencies) =>
-      Pointer<NativeFunction<_GetDriverDependencies_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_GetDriverDependencies_Native>>>()
+              .value
               .asFunction<_GetDriverDependencies_Dart>()(
           ptr.ref.lpVtbl, driverDependencies);
 
   int GetOSPackageDependencies(Pointer<Pointer> osPackageDependencies) =>
-      Pointer<NativeFunction<_GetOSPackageDependencies_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_GetOSPackageDependencies_Native>>>()
+              .value
               .asFunction<_GetOSPackageDependencies_Dart>()(
           ptr.ref.lpVtbl, osPackageDependencies);
 
-  int GetHostRuntimeDependencies(Pointer<Pointer> hostRuntimeDependencies) =>
-      Pointer<NativeFunction<_GetHostRuntimeDependencies_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
-              .asFunction<_GetHostRuntimeDependencies_Dart>()(
-          ptr.ref.lpVtbl, hostRuntimeDependencies);
+  int GetHostRuntimeDependencies(Pointer<Pointer> hostRuntimeDependencies) => ptr
+          .ref.lpVtbl.value
+          .elementAt(5)
+          .cast<Pointer<NativeFunction<_GetHostRuntimeDependencies_Native>>>()
+          .value
+          .asFunction<_GetHostRuntimeDependencies_Dart>()(
+      ptr.ref.lpVtbl, hostRuntimeDependencies);
 }

--- a/lib/src/com/IAppxPackageReader.dart
+++ b/lib/src/com/IAppxPackageReader.dart
@@ -54,28 +54,34 @@ class IAppxPackageReader extends IUnknown {
 
   IAppxPackageReader(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetBlockMap(Pointer<Pointer> blockMapReader) =>
-      Pointer<NativeFunction<_GetBlockMap_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetBlockMap_Dart>()(ptr.ref.lpVtbl, blockMapReader);
+  int GetBlockMap(Pointer<Pointer> blockMapReader) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetBlockMap_Native>>>()
+      .value
+      .asFunction<_GetBlockMap_Dart>()(ptr.ref.lpVtbl, blockMapReader);
 
-  int GetFootprintFile(int type, Pointer<Pointer> file) =>
-      Pointer<NativeFunction<_GetFootprintFile_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetFootprintFile_Dart>()(ptr.ref.lpVtbl, type, file);
+  int GetFootprintFile(int type, Pointer<Pointer> file) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetFootprintFile_Native>>>()
+      .value
+      .asFunction<_GetFootprintFile_Dart>()(ptr.ref.lpVtbl, type, file);
 
   int GetPayloadFile(Pointer<Utf16> fileName, Pointer<Pointer> file) =>
-      Pointer<NativeFunction<_GetPayloadFile_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(5)
+          .cast<Pointer<NativeFunction<_GetPayloadFile_Native>>>()
+          .value
           .asFunction<_GetPayloadFile_Dart>()(ptr.ref.lpVtbl, fileName, file);
 
-  int GetPayloadFiles(Pointer<Pointer> filesEnumerator) =>
-      Pointer<NativeFunction<_GetPayloadFiles_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetPayloadFiles_Dart>()(ptr.ref.lpVtbl, filesEnumerator);
+  int GetPayloadFiles(Pointer<Pointer> filesEnumerator) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetPayloadFiles_Native>>>()
+      .value
+      .asFunction<_GetPayloadFiles_Dart>()(ptr.ref.lpVtbl, filesEnumerator);
 
-  int GetManifest(Pointer<Pointer> manifestReader) =>
-      Pointer<NativeFunction<_GetManifest_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetManifest_Dart>()(ptr.ref.lpVtbl, manifestReader);
+  int GetManifest(Pointer<Pointer> manifestReader) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetManifest_Native>>>()
+      .value
+      .asFunction<_GetManifest_Dart>()(ptr.ref.lpVtbl, manifestReader);
 }

--- a/lib/src/com/IAsyncAction.dart
+++ b/lib/src/com/IAsyncAction.dart
@@ -53,9 +53,12 @@ class IAsyncAction extends IAsyncInfo {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Completed_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(12)
+          .cast<Pointer<NativeFunction<_get_Completed_Native>>>()
+          .value
           .asFunction<_get_Completed_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IAsyncAction.dart
+++ b/lib/src/com/IAsyncAction.dart
@@ -65,7 +65,9 @@ class IAsyncAction extends IAsyncInfo {
     }
   }
 
-  int GetResults() => Pointer<NativeFunction<_GetResults_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(13).value)
+  int GetResults() => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_GetResults_Native>>>()
+      .value
       .asFunction<_GetResults_Dart>()(ptr.ref.lpVtbl);
 }

--- a/lib/src/com/IAsyncAction.dart
+++ b/lib/src/com/IAsyncAction.dart
@@ -42,8 +42,10 @@ class IAsyncAction extends IAsyncInfo {
   IAsyncAction(Pointer<COMObject> ptr) : super(ptr);
 
   set Completed(Pointer value) {
-    final hr = Pointer<NativeFunction<_put_Completed_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(11).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(11)
+        .cast<Pointer<NativeFunction<_put_Completed_Native>>>()
+        .value
         .asFunction<_put_Completed_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);

--- a/lib/src/com/IAsyncInfo.dart
+++ b/lib/src/com/IAsyncInfo.dart
@@ -51,9 +51,12 @@ class IAsyncInfo extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Id_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<Pointer<NativeFunction<_get_Id_Native>>>()
+          .value
           .asFunction<_get_Id_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -67,9 +70,12 @@ class IAsyncInfo extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Status_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(7)
+          .cast<Pointer<NativeFunction<_get_Status_Native>>>()
+          .value
           .asFunction<_get_Status_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -83,9 +89,12 @@ class IAsyncInfo extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_ErrorCode_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_get_ErrorCode_Native>>>()
+          .value
           .asFunction<_get_ErrorCode_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IAsyncInfo.dart
+++ b/lib/src/com/IAsyncInfo.dart
@@ -95,11 +95,15 @@ class IAsyncInfo extends IInspectable {
     }
   }
 
-  int Cancel() => Pointer<NativeFunction<_Cancel_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(9).value)
+  int Cancel() => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_Cancel_Native>>>()
+      .value
       .asFunction<_Cancel_Dart>()(ptr.ref.lpVtbl);
 
-  int Close() => Pointer<NativeFunction<_Close_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(10).value)
+  int Close() => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_Close_Native>>>()
+      .value
       .asFunction<_Close_Dart>()(ptr.ref.lpVtbl);
 }

--- a/lib/src/com/IAsyncOperation`1.dart
+++ b/lib/src/com/IAsyncOperation`1.dart
@@ -66,8 +66,9 @@ class IAsyncOperation<TResult> extends IAsyncInfo {
     }
   }
 
-  int GetResults(Pointer<Pointer> result) =>
-      Pointer<NativeFunction<_GetResults_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_GetResults_Dart>()(ptr.ref.lpVtbl, result);
+  int GetResults(Pointer<Pointer> result) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_GetResults_Native>>>()
+      .value
+      .asFunction<_GetResults_Dart>()(ptr.ref.lpVtbl, result);
 }

--- a/lib/src/com/IAsyncOperation`1.dart
+++ b/lib/src/com/IAsyncOperation`1.dart
@@ -54,9 +54,12 @@ class IAsyncOperation<TResult> extends IAsyncInfo {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Completed_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(12)
+          .cast<Pointer<NativeFunction<_get_Completed_Native>>>()
+          .value
           .asFunction<_get_Completed_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IAsyncOperation`1.dart
+++ b/lib/src/com/IAsyncOperation`1.dart
@@ -43,8 +43,10 @@ class IAsyncOperation<TResult> extends IAsyncInfo {
   IAsyncOperation(Pointer<COMObject> ptr) : super(ptr);
 
   set Completed(Pointer value) {
-    final hr = Pointer<NativeFunction<_put_Completed_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(11).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(11)
+        .cast<Pointer<NativeFunction<_put_Completed_Native>>>()
+        .value
         .asFunction<_put_Completed_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);

--- a/lib/src/com/IBindCtx.dart
+++ b/lib/src/com/IBindCtx.dart
@@ -73,54 +73,65 @@ class IBindCtx extends IUnknown {
 
   IBindCtx(Pointer<COMObject> ptr) : super(ptr);
 
-  int RegisterObjectBound(Pointer punk) =>
-      Pointer<NativeFunction<_RegisterObjectBound_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_RegisterObjectBound_Dart>()(ptr.ref.lpVtbl, punk);
+  int RegisterObjectBound(Pointer punk) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_RegisterObjectBound_Native>>>()
+      .value
+      .asFunction<_RegisterObjectBound_Dart>()(ptr.ref.lpVtbl, punk);
 
-  int RevokeObjectBound(Pointer punk) =>
-      Pointer<NativeFunction<_RevokeObjectBound_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_RevokeObjectBound_Dart>()(ptr.ref.lpVtbl, punk);
+  int RevokeObjectBound(Pointer punk) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_RevokeObjectBound_Native>>>()
+      .value
+      .asFunction<_RevokeObjectBound_Dart>()(ptr.ref.lpVtbl, punk);
 
-  int ReleaseBoundObjects() =>
-      Pointer<NativeFunction<_ReleaseBoundObjects_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_ReleaseBoundObjects_Dart>()(ptr.ref.lpVtbl);
+  int ReleaseBoundObjects() => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_ReleaseBoundObjects_Native>>>()
+      .value
+      .asFunction<_ReleaseBoundObjects_Dart>()(ptr.ref.lpVtbl);
 
-  int SetBindOptions(Pointer<BIND_OPTS> pbindopts) =>
-      Pointer<NativeFunction<_SetBindOptions_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_SetBindOptions_Dart>()(ptr.ref.lpVtbl, pbindopts);
+  int SetBindOptions(Pointer<BIND_OPTS> pbindopts) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_SetBindOptions_Native>>>()
+      .value
+      .asFunction<_SetBindOptions_Dart>()(ptr.ref.lpVtbl, pbindopts);
 
-  int GetBindOptions(Pointer<BIND_OPTS> pbindopts) =>
-      Pointer<NativeFunction<_GetBindOptions_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetBindOptions_Dart>()(ptr.ref.lpVtbl, pbindopts);
+  int GetBindOptions(Pointer<BIND_OPTS> pbindopts) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetBindOptions_Native>>>()
+      .value
+      .asFunction<_GetBindOptions_Dart>()(ptr.ref.lpVtbl, pbindopts);
 
-  int GetRunningObjectTable(Pointer<Pointer> pprot) =>
-      Pointer<NativeFunction<_GetRunningObjectTable_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
-          .asFunction<_GetRunningObjectTable_Dart>()(ptr.ref.lpVtbl, pprot);
+  int GetRunningObjectTable(Pointer<Pointer> pprot) => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_GetRunningObjectTable_Native>>>()
+      .value
+      .asFunction<_GetRunningObjectTable_Dart>()(ptr.ref.lpVtbl, pprot);
 
-  int RegisterObjectParam(Pointer<Utf16> pszKey, Pointer punk) =>
-      Pointer<NativeFunction<_RegisterObjectParam_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(9).value)
-              .asFunction<_RegisterObjectParam_Dart>()(
-          ptr.ref.lpVtbl, pszKey, punk);
+  int RegisterObjectParam(Pointer<Utf16> pszKey, Pointer punk) => ptr
+      .ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_RegisterObjectParam_Native>>>()
+      .value
+      .asFunction<_RegisterObjectParam_Dart>()(ptr.ref.lpVtbl, pszKey, punk);
 
   int GetObjectParam(Pointer<Utf16> pszKey, Pointer<Pointer> ppunk) =>
-      Pointer<NativeFunction<_GetObjectParam_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(10)
+          .cast<Pointer<NativeFunction<_GetObjectParam_Native>>>()
+          .value
           .asFunction<_GetObjectParam_Dart>()(ptr.ref.lpVtbl, pszKey, ppunk);
 
-  int EnumObjectParam(Pointer<Pointer> ppenum) =>
-      Pointer<NativeFunction<_EnumObjectParam_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_EnumObjectParam_Dart>()(ptr.ref.lpVtbl, ppenum);
+  int EnumObjectParam(Pointer<Pointer> ppenum) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_EnumObjectParam_Native>>>()
+      .value
+      .asFunction<_EnumObjectParam_Dart>()(ptr.ref.lpVtbl, ppenum);
 
-  int RevokeObjectParam(Pointer<Utf16> pszKey) =>
-      Pointer<NativeFunction<_RevokeObjectParam_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_RevokeObjectParam_Dart>()(ptr.ref.lpVtbl, pszKey);
+  int RevokeObjectParam(Pointer<Utf16> pszKey) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_RevokeObjectParam_Native>>>()
+      .value
+      .asFunction<_RevokeObjectParam_Dart>()(ptr.ref.lpVtbl, pszKey);
 }

--- a/lib/src/com/ICalendar.dart
+++ b/lib/src/com/ICalendar.dart
@@ -495,8 +495,10 @@ class ICalendar extends IInspectable {
   }
 
   set NumeralSystem(int value) {
-    final hr = Pointer<NativeFunction<_put_NumeralSystem_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(11).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(11)
+        .cast<Pointer<NativeFunction<_put_NumeralSystem_Native>>>()
+        .value
         .asFunction<_put_NumeralSystem_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -621,8 +623,10 @@ class ICalendar extends IInspectable {
   }
 
   set Era(int value) {
-    final hr = Pointer<NativeFunction<_put_Era_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(23).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(23)
+        .cast<Pointer<NativeFunction<_put_Era_Native>>>()
+        .value
         .asFunction<_put_Era_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -727,8 +731,10 @@ class ICalendar extends IInspectable {
   }
 
   set Year(int value) {
-    final hr = Pointer<NativeFunction<_put_Year_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(31).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(31)
+        .cast<Pointer<NativeFunction<_put_Year_Native>>>()
+        .value
         .asFunction<_put_Year_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -842,8 +848,10 @@ class ICalendar extends IInspectable {
   }
 
   set Month(int value) {
-    final hr = Pointer<NativeFunction<_put_Month_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(40).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(40)
+        .cast<Pointer<NativeFunction<_put_Month_Native>>>()
+        .value
         .asFunction<_put_Month_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -982,8 +990,10 @@ class ICalendar extends IInspectable {
   }
 
   set Day(int value) {
-    final hr = Pointer<NativeFunction<_put_Day_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(53).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(53)
+        .cast<Pointer<NativeFunction<_put_Day_Native>>>()
+        .value
         .asFunction<_put_Day_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -1135,8 +1145,10 @@ class ICalendar extends IInspectable {
   }
 
   set Period(int value) {
-    final hr = Pointer<NativeFunction<_put_Period_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(66).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(66)
+        .cast<Pointer<NativeFunction<_put_Period_Native>>>()
+        .value
         .asFunction<_put_Period_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -1242,8 +1254,10 @@ class ICalendar extends IInspectable {
   }
 
   set Hour(int value) {
-    final hr = Pointer<NativeFunction<_put_Hour_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(74).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(74)
+        .cast<Pointer<NativeFunction<_put_Hour_Native>>>()
+        .value
         .asFunction<_put_Hour_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -1289,8 +1303,10 @@ class ICalendar extends IInspectable {
   }
 
   set Minute(int value) {
-    final hr = Pointer<NativeFunction<_put_Minute_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(79).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(79)
+        .cast<Pointer<NativeFunction<_put_Minute_Native>>>()
+        .value
         .asFunction<_put_Minute_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -1336,8 +1352,10 @@ class ICalendar extends IInspectable {
   }
 
   set Second(int value) {
-    final hr = Pointer<NativeFunction<_put_Second_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(84).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(84)
+        .cast<Pointer<NativeFunction<_put_Second_Native>>>()
+        .value
         .asFunction<_put_Second_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -1383,8 +1401,10 @@ class ICalendar extends IInspectable {
   }
 
   set Nanosecond(int value) {
-    final hr = Pointer<NativeFunction<_put_Nanosecond_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(89).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(89)
+        .cast<Pointer<NativeFunction<_put_Nanosecond_Native>>>()
+        .value
         .asFunction<_put_Nanosecond_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);

--- a/lib/src/com/ICalendar.dart
+++ b/lib/src/com/ICalendar.dart
@@ -438,17 +438,22 @@ class ICalendar extends IInspectable {
 
   ICalendar(Pointer<COMObject> ptr) : super(ptr);
 
-  int Clone(Pointer<Pointer> result) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, result);
+  int Clone(Pointer<Pointer> result) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, result);
 
-  int SetToMin() => Pointer<NativeFunction<_SetToMin_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(7).value)
+  int SetToMin() => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_SetToMin_Native>>>()
+      .value
       .asFunction<_SetToMin_Dart>()(ptr.ref.lpVtbl);
 
-  int SetToMax() => Pointer<NativeFunction<_SetToMax_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(8).value)
+  int SetToMax() => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_SetToMax_Native>>>()
+      .value
       .asFunction<_SetToMax_Dart>()(ptr.ref.lpVtbl);
 
   int get Languages {
@@ -491,38 +496,46 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int GetCalendarSystem(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_GetCalendarSystem_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_GetCalendarSystem_Dart>()(ptr.ref.lpVtbl, result);
+  int GetCalendarSystem(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_GetCalendarSystem_Native>>>()
+      .value
+      .asFunction<_GetCalendarSystem_Dart>()(ptr.ref.lpVtbl, result);
 
-  int ChangeCalendarSystem(int value) =>
-      Pointer<NativeFunction<_ChangeCalendarSystem_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_ChangeCalendarSystem_Dart>()(ptr.ref.lpVtbl, value);
+  int ChangeCalendarSystem(int value) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_ChangeCalendarSystem_Native>>>()
+      .value
+      .asFunction<_ChangeCalendarSystem_Dart>()(ptr.ref.lpVtbl, value);
 
-  int GetClock(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_GetClock_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(14).value)
-          .asFunction<_GetClock_Dart>()(ptr.ref.lpVtbl, result);
+  int GetClock(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(14)
+      .cast<Pointer<NativeFunction<_GetClock_Native>>>()
+      .value
+      .asFunction<_GetClock_Dart>()(ptr.ref.lpVtbl, result);
 
-  int ChangeClock(int value) =>
-      Pointer<NativeFunction<_ChangeClock_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(15).value)
-          .asFunction<_ChangeClock_Dart>()(ptr.ref.lpVtbl, value);
+  int ChangeClock(int value) => ptr.ref.lpVtbl.value
+      .elementAt(15)
+      .cast<Pointer<NativeFunction<_ChangeClock_Native>>>()
+      .value
+      .asFunction<_ChangeClock_Dart>()(ptr.ref.lpVtbl, value);
 
-  int GetDateTime(Pointer<Uint32> result) =>
-      Pointer<NativeFunction<_GetDateTime_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(16).value)
-          .asFunction<_GetDateTime_Dart>()(ptr.ref.lpVtbl, result);
+  int GetDateTime(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+      .elementAt(16)
+      .cast<Pointer<NativeFunction<_GetDateTime_Native>>>()
+      .value
+      .asFunction<_GetDateTime_Dart>()(ptr.ref.lpVtbl, result);
 
-  int SetDateTime(int value) =>
-      Pointer<NativeFunction<_SetDateTime_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(17).value)
-          .asFunction<_SetDateTime_Dart>()(ptr.ref.lpVtbl, value);
+  int SetDateTime(int value) => ptr.ref.lpVtbl.value
+      .elementAt(17)
+      .cast<Pointer<NativeFunction<_SetDateTime_Native>>>()
+      .value
+      .asFunction<_SetDateTime_Dart>()(ptr.ref.lpVtbl, value);
 
-  int SetToNow() => Pointer<NativeFunction<_SetToNow_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(18).value)
+  int SetToNow() => ptr.ref.lpVtbl.value
+      .elementAt(18)
+      .cast<Pointer<NativeFunction<_SetToNow_Native>>>()
+      .value
       .asFunction<_SetToNow_Dart>()(ptr.ref.lpVtbl);
 
   int get FirstEra {
@@ -597,18 +610,23 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int AddEras(int eras) => Pointer<NativeFunction<_AddEras_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(24).value)
+  int AddEras(int eras) => ptr.ref.lpVtbl.value
+      .elementAt(24)
+      .cast<Pointer<NativeFunction<_AddEras_Native>>>()
+      .value
       .asFunction<_AddEras_Dart>()(ptr.ref.lpVtbl, eras);
 
-  int EraAsFullString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_EraAsFullString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(25).value)
-          .asFunction<_EraAsFullString_Dart>()(ptr.ref.lpVtbl, result);
+  int EraAsFullString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(25)
+      .cast<Pointer<NativeFunction<_EraAsFullString_Native>>>()
+      .value
+      .asFunction<_EraAsFullString_Dart>()(ptr.ref.lpVtbl, result);
 
   int EraAsString(int idealLength, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_EraAsString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(26).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(26)
+          .cast<Pointer<NativeFunction<_EraAsString_Native>>>()
+          .value
           .asFunction<_EraAsString_Dart>()(ptr.ref.lpVtbl, idealLength, result);
 
   int get FirstYearInThisEra {
@@ -690,25 +708,31 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int AddYears(int years) =>
-      Pointer<NativeFunction<_AddYears_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(32).value)
-          .asFunction<_AddYears_Dart>()(ptr.ref.lpVtbl, years);
+  int AddYears(int years) => ptr.ref.lpVtbl.value
+      .elementAt(32)
+      .cast<Pointer<NativeFunction<_AddYears_Native>>>()
+      .value
+      .asFunction<_AddYears_Dart>()(ptr.ref.lpVtbl, years);
 
-  int YearAsString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_YearAsString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(33).value)
-          .asFunction<_YearAsString_Dart>()(ptr.ref.lpVtbl, result);
+  int YearAsString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(33)
+      .cast<Pointer<NativeFunction<_YearAsString_Native>>>()
+      .value
+      .asFunction<_YearAsString_Dart>()(ptr.ref.lpVtbl, result);
 
   int YearAsTruncatedString(int remainingDigits, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_YearAsTruncatedString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(34).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(34)
+              .cast<Pointer<NativeFunction<_YearAsTruncatedString_Native>>>()
+              .value
               .asFunction<_YearAsTruncatedString_Dart>()(
           ptr.ref.lpVtbl, remainingDigits, result);
 
   int YearAsPaddedString(int minDigits, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_YearAsPaddedString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(35).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(35)
+              .cast<Pointer<NativeFunction<_YearAsPaddedString_Native>>>()
+              .value
               .asFunction<_YearAsPaddedString_Dart>()(
           ptr.ref.lpVtbl, minDigits, result);
 
@@ -791,48 +815,58 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int AddMonths(int months) =>
-      Pointer<NativeFunction<_AddMonths_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(41).value)
-          .asFunction<_AddMonths_Dart>()(ptr.ref.lpVtbl, months);
+  int AddMonths(int months) => ptr.ref.lpVtbl.value
+      .elementAt(41)
+      .cast<Pointer<NativeFunction<_AddMonths_Native>>>()
+      .value
+      .asFunction<_AddMonths_Dart>()(ptr.ref.lpVtbl, months);
 
-  int MonthAsFullString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_MonthAsFullString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(42).value)
-          .asFunction<_MonthAsFullString_Dart>()(ptr.ref.lpVtbl, result);
+  int MonthAsFullString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(42)
+      .cast<Pointer<NativeFunction<_MonthAsFullString_Native>>>()
+      .value
+      .asFunction<_MonthAsFullString_Dart>()(ptr.ref.lpVtbl, result);
 
-  int MonthAsString(int idealLength, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_MonthAsString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(43).value)
-              .asFunction<_MonthAsString_Dart>()(
-          ptr.ref.lpVtbl, idealLength, result);
+  int MonthAsString(int idealLength, Pointer<IntPtr> result) => ptr
+      .ref.lpVtbl.value
+      .elementAt(43)
+      .cast<Pointer<NativeFunction<_MonthAsString_Native>>>()
+      .value
+      .asFunction<_MonthAsString_Dart>()(ptr.ref.lpVtbl, idealLength, result);
 
-  int MonthAsFullSoloString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_MonthAsFullSoloString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(44).value)
-          .asFunction<_MonthAsFullSoloString_Dart>()(ptr.ref.lpVtbl, result);
+  int MonthAsFullSoloString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(44)
+      .cast<Pointer<NativeFunction<_MonthAsFullSoloString_Native>>>()
+      .value
+      .asFunction<_MonthAsFullSoloString_Dart>()(ptr.ref.lpVtbl, result);
 
   int MonthAsSoloString(int idealLength, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_MonthAsSoloString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(45).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(45)
+              .cast<Pointer<NativeFunction<_MonthAsSoloString_Native>>>()
+              .value
               .asFunction<_MonthAsSoloString_Dart>()(
           ptr.ref.lpVtbl, idealLength, result);
 
-  int MonthAsNumericString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_MonthAsNumericString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(46).value)
-          .asFunction<_MonthAsNumericString_Dart>()(ptr.ref.lpVtbl, result);
+  int MonthAsNumericString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(46)
+      .cast<Pointer<NativeFunction<_MonthAsNumericString_Native>>>()
+      .value
+      .asFunction<_MonthAsNumericString_Dart>()(ptr.ref.lpVtbl, result);
 
-  int MonthAsPaddedNumericString(int minDigits, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_MonthAsPaddedNumericString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(47).value)
-              .asFunction<_MonthAsPaddedNumericString_Dart>()(
-          ptr.ref.lpVtbl, minDigits, result);
+  int MonthAsPaddedNumericString(int minDigits, Pointer<IntPtr> result) => ptr
+          .ref.lpVtbl.value
+          .elementAt(47)
+          .cast<Pointer<NativeFunction<_MonthAsPaddedNumericString_Native>>>()
+          .value
+          .asFunction<_MonthAsPaddedNumericString_Dart>()(
+      ptr.ref.lpVtbl, minDigits, result);
 
-  int AddWeeks(int weeks) =>
-      Pointer<NativeFunction<_AddWeeks_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(48).value)
-          .asFunction<_AddWeeks_Dart>()(ptr.ref.lpVtbl, weeks);
+  int AddWeeks(int weeks) => ptr.ref.lpVtbl.value
+      .elementAt(48)
+      .cast<Pointer<NativeFunction<_AddWeeks_Native>>>()
+      .value
+      .asFunction<_AddWeeks_Dart>()(ptr.ref.lpVtbl, weeks);
 
   int get FirstDayInThisMonth {
     final retValuePtr = calloc<Int32>();
@@ -913,20 +947,24 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int AddDays(int days) => Pointer<NativeFunction<_AddDays_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(54).value)
+  int AddDays(int days) => ptr.ref.lpVtbl.value
+      .elementAt(54)
+      .cast<Pointer<NativeFunction<_AddDays_Native>>>()
+      .value
       .asFunction<_AddDays_Dart>()(ptr.ref.lpVtbl, days);
 
-  int DayAsString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_DayAsString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(55).value)
-          .asFunction<_DayAsString_Dart>()(ptr.ref.lpVtbl, result);
+  int DayAsString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(55)
+      .cast<Pointer<NativeFunction<_DayAsString_Native>>>()
+      .value
+      .asFunction<_DayAsString_Dart>()(ptr.ref.lpVtbl, result);
 
-  int DayAsPaddedString(int minDigits, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_DayAsPaddedString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(56).value)
-              .asFunction<_DayAsPaddedString_Dart>()(
-          ptr.ref.lpVtbl, minDigits, result);
+  int DayAsPaddedString(int minDigits, Pointer<IntPtr> result) => ptr
+      .ref.lpVtbl.value
+      .elementAt(56)
+      .cast<Pointer<NativeFunction<_DayAsPaddedString_Native>>>()
+      .value
+      .asFunction<_DayAsPaddedString_Dart>()(ptr.ref.lpVtbl, minDigits, result);
 
   int get DayOfWeek {
     final retValuePtr = calloc<Uint32>();
@@ -944,26 +982,31 @@ class ICalendar extends IInspectable {
     }
   }
 
-  int DayOfWeekAsFullString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_DayOfWeekAsFullString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(58).value)
-          .asFunction<_DayOfWeekAsFullString_Dart>()(ptr.ref.lpVtbl, result);
+  int DayOfWeekAsFullString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(58)
+      .cast<Pointer<NativeFunction<_DayOfWeekAsFullString_Native>>>()
+      .value
+      .asFunction<_DayOfWeekAsFullString_Dart>()(ptr.ref.lpVtbl, result);
 
   int DayOfWeekAsString(int idealLength, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_DayOfWeekAsString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(59).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(59)
+              .cast<Pointer<NativeFunction<_DayOfWeekAsString_Native>>>()
+              .value
               .asFunction<_DayOfWeekAsString_Dart>()(
           ptr.ref.lpVtbl, idealLength, result);
 
-  int DayOfWeekAsFullSoloString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_DayOfWeekAsFullSoloString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(60).value)
-              .asFunction<_DayOfWeekAsFullSoloString_Dart>()(
-          ptr.ref.lpVtbl, result);
+  int DayOfWeekAsFullSoloString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(60)
+      .cast<Pointer<NativeFunction<_DayOfWeekAsFullSoloString_Native>>>()
+      .value
+      .asFunction<_DayOfWeekAsFullSoloString_Dart>()(ptr.ref.lpVtbl, result);
 
   int DayOfWeekAsSoloString(int idealLength, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_DayOfWeekAsSoloString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(61).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(61)
+              .cast<Pointer<NativeFunction<_DayOfWeekAsSoloString_Native>>>()
+              .value
               .asFunction<_DayOfWeekAsSoloString_Dart>()(
           ptr.ref.lpVtbl, idealLength, result);
 
@@ -1046,21 +1089,24 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int AddPeriods(int periods) =>
-      Pointer<NativeFunction<_AddPeriods_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(67).value)
-          .asFunction<_AddPeriods_Dart>()(ptr.ref.lpVtbl, periods);
+  int AddPeriods(int periods) => ptr.ref.lpVtbl.value
+      .elementAt(67)
+      .cast<Pointer<NativeFunction<_AddPeriods_Native>>>()
+      .value
+      .asFunction<_AddPeriods_Dart>()(ptr.ref.lpVtbl, periods);
 
-  int PeriodAsFullString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_PeriodAsFullString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(68).value)
-          .asFunction<_PeriodAsFullString_Dart>()(ptr.ref.lpVtbl, result);
+  int PeriodAsFullString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(68)
+      .cast<Pointer<NativeFunction<_PeriodAsFullString_Native>>>()
+      .value
+      .asFunction<_PeriodAsFullString_Dart>()(ptr.ref.lpVtbl, result);
 
-  int PeriodAsString(int idealLength, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_PeriodAsString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(69).value)
-              .asFunction<_PeriodAsString_Dart>()(
-          ptr.ref.lpVtbl, idealLength, result);
+  int PeriodAsString(int idealLength, Pointer<IntPtr> result) => ptr
+      .ref.lpVtbl.value
+      .elementAt(69)
+      .cast<Pointer<NativeFunction<_PeriodAsString_Native>>>()
+      .value
+      .asFunction<_PeriodAsString_Dart>()(ptr.ref.lpVtbl, idealLength, result);
 
   int get FirstHourInThisPeriod {
     final retValuePtr = calloc<Int32>();
@@ -1142,19 +1188,23 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int AddHours(int hours) =>
-      Pointer<NativeFunction<_AddHours_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(75).value)
-          .asFunction<_AddHours_Dart>()(ptr.ref.lpVtbl, hours);
+  int AddHours(int hours) => ptr.ref.lpVtbl.value
+      .elementAt(75)
+      .cast<Pointer<NativeFunction<_AddHours_Native>>>()
+      .value
+      .asFunction<_AddHours_Dart>()(ptr.ref.lpVtbl, hours);
 
-  int HourAsString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_HourAsString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(76).value)
-          .asFunction<_HourAsString_Dart>()(ptr.ref.lpVtbl, result);
+  int HourAsString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(76)
+      .cast<Pointer<NativeFunction<_HourAsString_Native>>>()
+      .value
+      .asFunction<_HourAsString_Dart>()(ptr.ref.lpVtbl, result);
 
   int HourAsPaddedString(int minDigits, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_HourAsPaddedString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(77).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(77)
+              .cast<Pointer<NativeFunction<_HourAsPaddedString_Native>>>()
+              .value
               .asFunction<_HourAsPaddedString_Dart>()(
           ptr.ref.lpVtbl, minDigits, result);
 
@@ -1182,19 +1232,23 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int AddMinutes(int minutes) =>
-      Pointer<NativeFunction<_AddMinutes_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(80).value)
-          .asFunction<_AddMinutes_Dart>()(ptr.ref.lpVtbl, minutes);
+  int AddMinutes(int minutes) => ptr.ref.lpVtbl.value
+      .elementAt(80)
+      .cast<Pointer<NativeFunction<_AddMinutes_Native>>>()
+      .value
+      .asFunction<_AddMinutes_Dart>()(ptr.ref.lpVtbl, minutes);
 
-  int MinuteAsString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_MinuteAsString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(81).value)
-          .asFunction<_MinuteAsString_Dart>()(ptr.ref.lpVtbl, result);
+  int MinuteAsString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(81)
+      .cast<Pointer<NativeFunction<_MinuteAsString_Native>>>()
+      .value
+      .asFunction<_MinuteAsString_Dart>()(ptr.ref.lpVtbl, result);
 
   int MinuteAsPaddedString(int minDigits, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_MinuteAsPaddedString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(82).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(82)
+              .cast<Pointer<NativeFunction<_MinuteAsPaddedString_Native>>>()
+              .value
               .asFunction<_MinuteAsPaddedString_Dart>()(
           ptr.ref.lpVtbl, minDigits, result);
 
@@ -1222,19 +1276,23 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int AddSeconds(int seconds) =>
-      Pointer<NativeFunction<_AddSeconds_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(85).value)
-          .asFunction<_AddSeconds_Dart>()(ptr.ref.lpVtbl, seconds);
+  int AddSeconds(int seconds) => ptr.ref.lpVtbl.value
+      .elementAt(85)
+      .cast<Pointer<NativeFunction<_AddSeconds_Native>>>()
+      .value
+      .asFunction<_AddSeconds_Dart>()(ptr.ref.lpVtbl, seconds);
 
-  int SecondAsString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_SecondAsString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(86).value)
-          .asFunction<_SecondAsString_Dart>()(ptr.ref.lpVtbl, result);
+  int SecondAsString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(86)
+      .cast<Pointer<NativeFunction<_SecondAsString_Native>>>()
+      .value
+      .asFunction<_SecondAsString_Dart>()(ptr.ref.lpVtbl, result);
 
   int SecondAsPaddedString(int minDigits, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_SecondAsPaddedString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(87).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(87)
+              .cast<Pointer<NativeFunction<_SecondAsPaddedString_Native>>>()
+              .value
               .asFunction<_SecondAsPaddedString_Dart>()(
           ptr.ref.lpVtbl, minDigits, result);
 
@@ -1262,36 +1320,43 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int AddNanoseconds(int nanoseconds) =>
-      Pointer<NativeFunction<_AddNanoseconds_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(90).value)
-          .asFunction<_AddNanoseconds_Dart>()(ptr.ref.lpVtbl, nanoseconds);
+  int AddNanoseconds(int nanoseconds) => ptr.ref.lpVtbl.value
+      .elementAt(90)
+      .cast<Pointer<NativeFunction<_AddNanoseconds_Native>>>()
+      .value
+      .asFunction<_AddNanoseconds_Dart>()(ptr.ref.lpVtbl, nanoseconds);
 
-  int NanosecondAsString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_NanosecondAsString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(91).value)
-          .asFunction<_NanosecondAsString_Dart>()(ptr.ref.lpVtbl, result);
+  int NanosecondAsString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(91)
+      .cast<Pointer<NativeFunction<_NanosecondAsString_Native>>>()
+      .value
+      .asFunction<_NanosecondAsString_Dart>()(ptr.ref.lpVtbl, result);
 
   int NanosecondAsPaddedString(int minDigits, Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_NanosecondAsPaddedString_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(92).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(92)
+              .cast<Pointer<NativeFunction<_NanosecondAsPaddedString_Native>>>()
+              .value
               .asFunction<_NanosecondAsPaddedString_Dart>()(
           ptr.ref.lpVtbl, minDigits, result);
 
-  int Compare(Pointer other, Pointer<Int32> result) =>
-      Pointer<NativeFunction<_Compare_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(93).value)
-          .asFunction<_Compare_Dart>()(ptr.ref.lpVtbl, other, result);
+  int Compare(Pointer other, Pointer<Int32> result) => ptr.ref.lpVtbl.value
+      .elementAt(93)
+      .cast<Pointer<NativeFunction<_Compare_Native>>>()
+      .value
+      .asFunction<_Compare_Dart>()(ptr.ref.lpVtbl, other, result);
 
-  int CompareDateTime(int other, Pointer<Int32> result) =>
-      Pointer<NativeFunction<_CompareDateTime_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(94).value)
-          .asFunction<_CompareDateTime_Dart>()(ptr.ref.lpVtbl, other, result);
+  int CompareDateTime(int other, Pointer<Int32> result) => ptr.ref.lpVtbl.value
+      .elementAt(94)
+      .cast<Pointer<NativeFunction<_CompareDateTime_Native>>>()
+      .value
+      .asFunction<_CompareDateTime_Dart>()(ptr.ref.lpVtbl, other, result);
 
-  int CopyTo(Pointer other) =>
-      Pointer<NativeFunction<_CopyTo_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(95).value)
-          .asFunction<_CopyTo_Dart>()(ptr.ref.lpVtbl, other);
+  int CopyTo(Pointer other) => ptr.ref.lpVtbl.value
+      .elementAt(95)
+      .cast<Pointer<NativeFunction<_CopyTo_Native>>>()
+      .value
+      .asFunction<_CopyTo_Dart>()(ptr.ref.lpVtbl, other);
 
   int get FirstMinuteInThisHour {
     final retValuePtr = calloc<Int32>();

--- a/lib/src/com/ICalendar.dart
+++ b/lib/src/com/ICalendar.dart
@@ -460,9 +460,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<IntPtr>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Languages_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(9)
+          .cast<Pointer<NativeFunction<_get_Languages_Native>>>()
+          .value
           .asFunction<_get_Languages_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -476,9 +479,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<IntPtr>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_NumeralSystem_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(10)
+          .cast<Pointer<NativeFunction<_get_NumeralSystem_Native>>>()
+          .value
           .asFunction<_get_NumeralSystem_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -542,9 +548,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_FirstEra_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(19).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(19)
+          .cast<Pointer<NativeFunction<_get_FirstEra_Native>>>()
+          .value
           .asFunction<_get_FirstEra_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -558,9 +567,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_LastEra_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(20).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(20)
+          .cast<Pointer<NativeFunction<_get_LastEra_Native>>>()
+          .value
           .asFunction<_get_LastEra_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -574,9 +586,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_NumberOfEras_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(21).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(21)
+          .cast<Pointer<NativeFunction<_get_NumberOfEras_Native>>>()
+          .value
           .asFunction<_get_NumberOfEras_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -590,9 +605,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Era_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(22).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(22)
+          .cast<Pointer<NativeFunction<_get_Era_Native>>>()
+          .value
           .asFunction<_get_Era_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -633,11 +651,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_FirstYearInThisEra_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(27).value)
-                  .asFunction<_get_FirstYearInThisEra_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(27)
+              .cast<Pointer<NativeFunction<_get_FirstYearInThisEra_Native>>>()
+              .value
+              .asFunction<_get_FirstYearInThisEra_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -651,11 +671,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_LastYearInThisEra_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(28).value)
-                  .asFunction<_get_LastYearInThisEra_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(28)
+              .cast<Pointer<NativeFunction<_get_LastYearInThisEra_Native>>>()
+              .value
+              .asFunction<_get_LastYearInThisEra_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -669,12 +691,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_NumberOfYearsInThisEra_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(29).value)
-              .asFunction<_get_NumberOfYearsInThisEra_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(29)
+          .cast<Pointer<NativeFunction<_get_NumberOfYearsInThisEra_Native>>>()
+          .value
+          .asFunction<
+              _get_NumberOfYearsInThisEra_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -688,9 +711,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Year_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(30).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(30)
+          .cast<Pointer<NativeFunction<_get_Year_Native>>>()
+          .value
           .asFunction<_get_Year_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -740,11 +766,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_FirstMonthInThisYear_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(36).value)
-                  .asFunction<_get_FirstMonthInThisYear_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(36)
+              .cast<Pointer<NativeFunction<_get_FirstMonthInThisYear_Native>>>()
+              .value
+              .asFunction<_get_FirstMonthInThisYear_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -758,11 +786,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_LastMonthInThisYear_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(37).value)
-                  .asFunction<_get_LastMonthInThisYear_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(37)
+              .cast<Pointer<NativeFunction<_get_LastMonthInThisYear_Native>>>()
+              .value
+              .asFunction<_get_LastMonthInThisYear_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -776,12 +806,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_NumberOfMonthsInThisYear_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(38).value)
-              .asFunction<_get_NumberOfMonthsInThisYear_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(38)
+          .cast<Pointer<NativeFunction<_get_NumberOfMonthsInThisYear_Native>>>()
+          .value
+          .asFunction<
+              _get_NumberOfMonthsInThisYear_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -795,9 +826,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Month_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(39).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(39)
+          .cast<Pointer<NativeFunction<_get_Month_Native>>>()
+          .value
           .asFunction<_get_Month_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -872,11 +906,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_FirstDayInThisMonth_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(49).value)
-                  .asFunction<_get_FirstDayInThisMonth_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(49)
+              .cast<Pointer<NativeFunction<_get_FirstDayInThisMonth_Native>>>()
+              .value
+              .asFunction<_get_FirstDayInThisMonth_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -890,11 +926,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_LastDayInThisMonth_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(50).value)
-                  .asFunction<_get_LastDayInThisMonth_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(50)
+              .cast<Pointer<NativeFunction<_get_LastDayInThisMonth_Native>>>()
+              .value
+              .asFunction<_get_LastDayInThisMonth_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -908,12 +946,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_NumberOfDaysInThisMonth_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(51).value)
-              .asFunction<_get_NumberOfDaysInThisMonth_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(51)
+          .cast<Pointer<NativeFunction<_get_NumberOfDaysInThisMonth_Native>>>()
+          .value
+          .asFunction<
+              _get_NumberOfDaysInThisMonth_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -927,9 +966,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Day_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(52).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(52)
+          .cast<Pointer<NativeFunction<_get_Day_Native>>>()
+          .value
           .asFunction<_get_Day_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -970,9 +1012,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_DayOfWeek_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(57).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(57)
+          .cast<Pointer<NativeFunction<_get_DayOfWeek_Native>>>()
+          .value
           .asFunction<_get_DayOfWeek_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1014,11 +1059,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_FirstPeriodInThisDay_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(62).value)
-                  .asFunction<_get_FirstPeriodInThisDay_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(62)
+              .cast<Pointer<NativeFunction<_get_FirstPeriodInThisDay_Native>>>()
+              .value
+              .asFunction<_get_FirstPeriodInThisDay_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1032,11 +1079,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_LastPeriodInThisDay_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(63).value)
-                  .asFunction<_get_LastPeriodInThisDay_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(63)
+              .cast<Pointer<NativeFunction<_get_LastPeriodInThisDay_Native>>>()
+              .value
+              .asFunction<_get_LastPeriodInThisDay_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1050,12 +1099,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_NumberOfPeriodsInThisDay_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(64).value)
-              .asFunction<_get_NumberOfPeriodsInThisDay_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(64)
+          .cast<Pointer<NativeFunction<_get_NumberOfPeriodsInThisDay_Native>>>()
+          .value
+          .asFunction<
+              _get_NumberOfPeriodsInThisDay_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1069,9 +1119,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Period_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(65).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(65)
+          .cast<Pointer<NativeFunction<_get_Period_Native>>>()
+          .value
           .asFunction<_get_Period_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1112,12 +1165,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_FirstHourInThisPeriod_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(70).value)
-              .asFunction<_get_FirstHourInThisPeriod_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(70)
+          .cast<Pointer<NativeFunction<_get_FirstHourInThisPeriod_Native>>>()
+          .value
+          .asFunction<
+              _get_FirstHourInThisPeriod_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1131,11 +1185,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_LastHourInThisPeriod_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(71).value)
-                  .asFunction<_get_LastHourInThisPeriod_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(71)
+              .cast<Pointer<NativeFunction<_get_LastHourInThisPeriod_Native>>>()
+              .value
+              .asFunction<_get_LastHourInThisPeriod_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1149,12 +1205,14 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_NumberOfHoursInThisPeriod_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(72).value)
-              .asFunction<_get_NumberOfHoursInThisPeriod_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(72)
+          .cast<
+              Pointer<NativeFunction<_get_NumberOfHoursInThisPeriod_Native>>>()
+          .value
+          .asFunction<
+              _get_NumberOfHoursInThisPeriod_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1168,9 +1226,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Hour_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(73).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(73)
+          .cast<Pointer<NativeFunction<_get_Hour_Native>>>()
+          .value
           .asFunction<_get_Hour_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1212,9 +1273,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Minute_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(78).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(78)
+          .cast<Pointer<NativeFunction<_get_Minute_Native>>>()
+          .value
           .asFunction<_get_Minute_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1256,9 +1320,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Second_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(83).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(83)
+          .cast<Pointer<NativeFunction<_get_Second_Native>>>()
+          .value
           .asFunction<_get_Second_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1300,9 +1367,12 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Nanosecond_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(88).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(88)
+          .cast<Pointer<NativeFunction<_get_Nanosecond_Native>>>()
+          .value
           .asFunction<_get_Nanosecond_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1362,12 +1432,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_FirstMinuteInThisHour_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(96).value)
-              .asFunction<_get_FirstMinuteInThisHour_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(96)
+          .cast<Pointer<NativeFunction<_get_FirstMinuteInThisHour_Native>>>()
+          .value
+          .asFunction<
+              _get_FirstMinuteInThisHour_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1381,11 +1452,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_LastMinuteInThisHour_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(97).value)
-                  .asFunction<_get_LastMinuteInThisHour_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(97)
+              .cast<Pointer<NativeFunction<_get_LastMinuteInThisHour_Native>>>()
+              .value
+              .asFunction<_get_LastMinuteInThisHour_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1399,12 +1472,14 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_NumberOfMinutesInThisHour_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(98).value)
-              .asFunction<_get_NumberOfMinutesInThisHour_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(98)
+          .cast<
+              Pointer<NativeFunction<_get_NumberOfMinutesInThisHour_Native>>>()
+          .value
+          .asFunction<
+              _get_NumberOfMinutesInThisHour_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1418,12 +1493,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_FirstSecondInThisMinute_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(99).value)
-              .asFunction<_get_FirstSecondInThisMinute_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(99)
+          .cast<Pointer<NativeFunction<_get_FirstSecondInThisMinute_Native>>>()
+          .value
+          .asFunction<
+              _get_FirstSecondInThisMinute_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1437,12 +1513,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_LastSecondInThisMinute_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(100).value)
-              .asFunction<_get_LastSecondInThisMinute_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(100)
+          .cast<Pointer<NativeFunction<_get_LastSecondInThisMinute_Native>>>()
+          .value
+          .asFunction<
+              _get_LastSecondInThisMinute_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1456,12 +1533,17 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_NumberOfSecondsInThisMinute_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(101).value)
-              .asFunction<_get_NumberOfSecondsInThisMinute_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr =
+          ptr.ref.lpVtbl.value
+                  .elementAt(101)
+                  .cast<
+                      Pointer<
+                          NativeFunction<
+                              _get_NumberOfSecondsInThisMinute_Native>>>()
+                  .value
+                  .asFunction<_get_NumberOfSecondsInThisMinute_Dart>()(
+              ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1475,11 +1557,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<IntPtr>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_ResolvedLanguage_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(102).value)
-                  .asFunction<_get_ResolvedLanguage_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(102)
+              .cast<Pointer<NativeFunction<_get_ResolvedLanguage_Native>>>()
+              .value
+              .asFunction<_get_ResolvedLanguage_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -1493,11 +1577,13 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc< /* Boolean */ Uint8>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_IsDaylightSavingTime_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(103).value)
-                  .asFunction<_get_IsDaylightSavingTime_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(103)
+              .cast<Pointer<NativeFunction<_get_IsDaylightSavingTime_Native>>>()
+              .value
+              .asFunction<_get_IsDaylightSavingTime_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IClassFactory.dart
+++ b/lib/src/com/IClassFactory.dart
@@ -39,13 +39,16 @@ class IClassFactory extends IUnknown {
 
   int CreateInstance(
           Pointer pUnkOuter, Pointer<GUID> riid, Pointer<Pointer> ppvObject) =>
-      Pointer<NativeFunction<_CreateInstance_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_CreateInstance_Native>>>()
+              .value
               .asFunction<_CreateInstance_Dart>()(
           ptr.ref.lpVtbl, pUnkOuter, riid, ppvObject);
 
-  int LockServer(int fLock) =>
-      Pointer<NativeFunction<_LockServer_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_LockServer_Dart>()(ptr.ref.lpVtbl, fLock);
+  int LockServer(int fLock) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_LockServer_Native>>>()
+      .value
+      .asFunction<_LockServer_Dart>()(ptr.ref.lpVtbl, fLock);
 }

--- a/lib/src/com/IClosable.dart
+++ b/lib/src/com/IClosable.dart
@@ -34,7 +34,9 @@ class IClosable extends IInspectable {
 
   IClosable(Pointer<COMObject> ptr) : super(ptr);
 
-  int Close() => Pointer<NativeFunction<_Close_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(6).value)
+  int Close() => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Close_Native>>>()
+      .value
       .asFunction<_Close_Dart>()(ptr.ref.lpVtbl);
 }

--- a/lib/src/com/IConnectionPoint.dart
+++ b/lib/src/com/IConnectionPoint.dart
@@ -52,29 +52,35 @@ class IConnectionPoint extends IUnknown {
 
   IConnectionPoint(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetConnectionInterface(Pointer<GUID> pIID) =>
-      Pointer<NativeFunction<_GetConnectionInterface_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetConnectionInterface_Dart>()(ptr.ref.lpVtbl, pIID);
+  int GetConnectionInterface(Pointer<GUID> pIID) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetConnectionInterface_Native>>>()
+      .value
+      .asFunction<_GetConnectionInterface_Dart>()(ptr.ref.lpVtbl, pIID);
 
-  int GetConnectionPointContainer(Pointer<Pointer> ppCPC) =>
-      Pointer<NativeFunction<_GetConnectionPointContainer_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
-              .asFunction<_GetConnectionPointContainer_Dart>()(
-          ptr.ref.lpVtbl, ppCPC);
+  int GetConnectionPointContainer(Pointer<Pointer> ppCPC) => ptr
+      .ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetConnectionPointContainer_Native>>>()
+      .value
+      .asFunction<_GetConnectionPointContainer_Dart>()(ptr.ref.lpVtbl, ppCPC);
 
   int Advise(Pointer pUnkSink, Pointer<Uint32> pdwCookie) =>
-      Pointer<NativeFunction<_Advise_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(5)
+          .cast<Pointer<NativeFunction<_Advise_Native>>>()
+          .value
           .asFunction<_Advise_Dart>()(ptr.ref.lpVtbl, pUnkSink, pdwCookie);
 
-  int Unadvise(int dwCookie) =>
-      Pointer<NativeFunction<_Unadvise_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Unadvise_Dart>()(ptr.ref.lpVtbl, dwCookie);
+  int Unadvise(int dwCookie) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Unadvise_Native>>>()
+      .value
+      .asFunction<_Unadvise_Dart>()(ptr.ref.lpVtbl, dwCookie);
 
-  int EnumConnections(Pointer<Pointer> ppEnum) =>
-      Pointer<NativeFunction<_EnumConnections_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_EnumConnections_Dart>()(ptr.ref.lpVtbl, ppEnum);
+  int EnumConnections(Pointer<Pointer> ppEnum) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_EnumConnections_Native>>>()
+      .value
+      .asFunction<_EnumConnections_Dart>()(ptr.ref.lpVtbl, ppEnum);
 }

--- a/lib/src/com/IConnectionPointContainer.dart
+++ b/lib/src/com/IConnectionPointContainer.dart
@@ -39,13 +39,16 @@ class IConnectionPointContainer extends IUnknown {
 
   IConnectionPointContainer(Pointer<COMObject> ptr) : super(ptr);
 
-  int EnumConnectionPoints(Pointer<Pointer> ppEnum) =>
-      Pointer<NativeFunction<_EnumConnectionPoints_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_EnumConnectionPoints_Dart>()(ptr.ref.lpVtbl, ppEnum);
+  int EnumConnectionPoints(Pointer<Pointer> ppEnum) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_EnumConnectionPoints_Native>>>()
+      .value
+      .asFunction<_EnumConnectionPoints_Dart>()(ptr.ref.lpVtbl, ppEnum);
 
   int FindConnectionPoint(Pointer<GUID> riid, Pointer<Pointer> ppCP) =>
-      Pointer<NativeFunction<_FindConnectionPoint_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(4)
+          .cast<Pointer<NativeFunction<_FindConnectionPoint_Native>>>()
+          .value
           .asFunction<_FindConnectionPoint_Dart>()(ptr.ref.lpVtbl, riid, ppCP);
 }

--- a/lib/src/com/IDesktopWallpaper.dart
+++ b/lib/src/com/IDesktopWallpaper.dart
@@ -100,93 +100,116 @@ class IDesktopWallpaper extends IUnknown {
 
   IDesktopWallpaper(Pointer<COMObject> ptr) : super(ptr);
 
-  int SetWallpaper(Pointer<Utf16> monitorID, Pointer<Utf16> wallpaper) =>
-      Pointer<NativeFunction<_SetWallpaper_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
-              .asFunction<_SetWallpaper_Dart>()(
-          ptr.ref.lpVtbl, monitorID, wallpaper);
+  int SetWallpaper(Pointer<Utf16> monitorID, Pointer<Utf16> wallpaper) => ptr
+      .ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_SetWallpaper_Native>>>()
+      .value
+      .asFunction<_SetWallpaper_Dart>()(ptr.ref.lpVtbl, monitorID, wallpaper);
 
   int GetWallpaper(
           Pointer<Utf16> monitorID, Pointer<Pointer<Utf16>> wallpaper) =>
-      Pointer<NativeFunction<_GetWallpaper_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_GetWallpaper_Native>>>()
+              .value
               .asFunction<_GetWallpaper_Dart>()(
           ptr.ref.lpVtbl, monitorID, wallpaper);
 
   int GetMonitorDevicePathAt(
           int monitorIndex, Pointer<Pointer<Utf16>> monitorID) =>
-      Pointer<NativeFunction<_GetMonitorDevicePathAt_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_GetMonitorDevicePathAt_Native>>>()
+              .value
               .asFunction<_GetMonitorDevicePathAt_Dart>()(
           ptr.ref.lpVtbl, monitorIndex, monitorID);
 
-  int GetMonitorDevicePathCount(Pointer<Uint32> count) =>
-      Pointer<NativeFunction<_GetMonitorDevicePathCount_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetMonitorDevicePathCount_Dart>()(ptr.ref.lpVtbl, count);
+  int GetMonitorDevicePathCount(Pointer<Uint32> count) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetMonitorDevicePathCount_Native>>>()
+      .value
+      .asFunction<_GetMonitorDevicePathCount_Dart>()(ptr.ref.lpVtbl, count);
 
   int GetMonitorRECT(Pointer<Utf16> monitorID, Pointer<RECT> displayRect) =>
-      Pointer<NativeFunction<_GetMonitorRECT_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(7)
+              .cast<Pointer<NativeFunction<_GetMonitorRECT_Native>>>()
+              .value
               .asFunction<_GetMonitorRECT_Dart>()(
           ptr.ref.lpVtbl, monitorID, displayRect);
 
-  int SetBackgroundColor(int color) =>
-      Pointer<NativeFunction<_SetBackgroundColor_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
-          .asFunction<_SetBackgroundColor_Dart>()(ptr.ref.lpVtbl, color);
+  int SetBackgroundColor(int color) => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_SetBackgroundColor_Native>>>()
+      .value
+      .asFunction<_SetBackgroundColor_Dart>()(ptr.ref.lpVtbl, color);
 
-  int GetBackgroundColor(Pointer<Uint32> color) =>
-      Pointer<NativeFunction<_GetBackgroundColor_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_GetBackgroundColor_Dart>()(ptr.ref.lpVtbl, color);
+  int GetBackgroundColor(Pointer<Uint32> color) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_GetBackgroundColor_Native>>>()
+      .value
+      .asFunction<_GetBackgroundColor_Dart>()(ptr.ref.lpVtbl, color);
 
-  int SetPosition(int position) =>
-      Pointer<NativeFunction<_SetPosition_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_SetPosition_Dart>()(ptr.ref.lpVtbl, position);
+  int SetPosition(int position) => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_SetPosition_Native>>>()
+      .value
+      .asFunction<_SetPosition_Dart>()(ptr.ref.lpVtbl, position);
 
-  int GetPosition(Pointer<Uint32> position) =>
-      Pointer<NativeFunction<_GetPosition_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_GetPosition_Dart>()(ptr.ref.lpVtbl, position);
+  int GetPosition(Pointer<Uint32> position) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_GetPosition_Native>>>()
+      .value
+      .asFunction<_GetPosition_Dart>()(ptr.ref.lpVtbl, position);
 
-  int SetSlideshow(Pointer items) =>
-      Pointer<NativeFunction<_SetSlideshow_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_SetSlideshow_Dart>()(ptr.ref.lpVtbl, items);
+  int SetSlideshow(Pointer items) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_SetSlideshow_Native>>>()
+      .value
+      .asFunction<_SetSlideshow_Dart>()(ptr.ref.lpVtbl, items);
 
-  int GetSlideshow(Pointer<Pointer> items) =>
-      Pointer<NativeFunction<_GetSlideshow_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_GetSlideshow_Dart>()(ptr.ref.lpVtbl, items);
+  int GetSlideshow(Pointer<Pointer> items) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_GetSlideshow_Native>>>()
+      .value
+      .asFunction<_GetSlideshow_Dart>()(ptr.ref.lpVtbl, items);
 
   int SetSlideshowOptions(int options, int slideshowTick) =>
-      Pointer<NativeFunction<_SetSlideshowOptions_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(14).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(14)
+              .cast<Pointer<NativeFunction<_SetSlideshowOptions_Native>>>()
+              .value
               .asFunction<_SetSlideshowOptions_Dart>()(
           ptr.ref.lpVtbl, options, slideshowTick);
 
   int GetSlideshowOptions(
           Pointer<Uint32> options, Pointer<Uint32> slideshowTick) =>
-      Pointer<NativeFunction<_GetSlideshowOptions_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(15).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(15)
+              .cast<Pointer<NativeFunction<_GetSlideshowOptions_Native>>>()
+              .value
               .asFunction<_GetSlideshowOptions_Dart>()(
           ptr.ref.lpVtbl, options, slideshowTick);
 
   int AdvanceSlideshow(Pointer<Utf16> monitorID, int direction) =>
-      Pointer<NativeFunction<_AdvanceSlideshow_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(16).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(16)
+              .cast<Pointer<NativeFunction<_AdvanceSlideshow_Native>>>()
+              .value
               .asFunction<_AdvanceSlideshow_Dart>()(
           ptr.ref.lpVtbl, monitorID, direction);
 
-  int GetStatus(Pointer<Uint32> state) =>
-      Pointer<NativeFunction<_GetStatus_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(17).value)
-          .asFunction<_GetStatus_Dart>()(ptr.ref.lpVtbl, state);
+  int GetStatus(Pointer<Uint32> state) => ptr.ref.lpVtbl.value
+      .elementAt(17)
+      .cast<Pointer<NativeFunction<_GetStatus_Native>>>()
+      .value
+      .asFunction<_GetStatus_Dart>()(ptr.ref.lpVtbl, state);
 
-  int Enable(int enable) => Pointer<NativeFunction<_Enable_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(18).value)
+  int Enable(int enable) => ptr.ref.lpVtbl.value
+      .elementAt(18)
+      .cast<Pointer<NativeFunction<_Enable_Native>>>()
+      .value
       .asFunction<_Enable_Dart>()(ptr.ref.lpVtbl, enable);
 }
 

--- a/lib/src/com/IDispatch.dart
+++ b/lib/src/com/IDispatch.dart
@@ -75,21 +75,25 @@ class IDispatch extends IUnknown {
 
   IDispatch(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetTypeInfoCount(Pointer<Uint32> pctinfo) =>
-      Pointer<NativeFunction<_GetTypeInfoCount_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetTypeInfoCount_Dart>()(ptr.ref.lpVtbl, pctinfo);
+  int GetTypeInfoCount(Pointer<Uint32> pctinfo) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetTypeInfoCount_Native>>>()
+      .value
+      .asFunction<_GetTypeInfoCount_Dart>()(ptr.ref.lpVtbl, pctinfo);
 
-  int GetTypeInfo(int iTInfo, int lcid, Pointer<Pointer> ppTInfo) =>
-      Pointer<NativeFunction<_GetTypeInfo_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
-              .asFunction<_GetTypeInfo_Dart>()(
-          ptr.ref.lpVtbl, iTInfo, lcid, ppTInfo);
+  int GetTypeInfo(int iTInfo, int lcid, Pointer<Pointer> ppTInfo) => ptr
+      .ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetTypeInfo_Native>>>()
+      .value
+      .asFunction<_GetTypeInfo_Dart>()(ptr.ref.lpVtbl, iTInfo, lcid, ppTInfo);
 
   int GetIDsOfNames(Pointer<GUID> riid, Pointer<Pointer<Utf16>> rgszNames,
           int cNames, int lcid, Pointer<Int32> rgDispId) =>
-      Pointer<NativeFunction<_GetIDsOfNames_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_GetIDsOfNames_Native>>>()
+              .value
               .asFunction<_GetIDsOfNames_Dart>()(
           ptr.ref.lpVtbl, riid, rgszNames, cNames, lcid, rgDispId);
 
@@ -102,8 +106,10 @@ class IDispatch extends IUnknown {
           Pointer<VARIANT> pVarResult,
           Pointer<EXCEPINFO> pExcepInfo,
           Pointer<Uint32> puArgErr) =>
-      Pointer<NativeFunction<_Invoke_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(6)
+              .cast<Pointer<NativeFunction<_Invoke_Native>>>()
+              .value
               .asFunction<_Invoke_Dart>()(ptr.ref.lpVtbl, dispIdMember, riid,
           lcid, wFlags, pDispParams, pVarResult, pExcepInfo, puArgErr);
 }

--- a/lib/src/com/IEnumIDList.dart
+++ b/lib/src/com/IEnumIDList.dart
@@ -45,20 +45,27 @@ class IEnumIDList extends IUnknown {
 
   int Next(int celt, Pointer<Pointer<ITEMIDLIST>> rgelt,
           Pointer<Uint32> pceltFetched) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_Next_Native>>>()
+          .value
           .asFunction<_Next_Dart>()(ptr.ref.lpVtbl, celt, rgelt, pceltFetched);
 
-  int Skip(int celt) => Pointer<NativeFunction<_Skip_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(4).value)
+  int Skip(int celt) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_Skip_Native>>>()
+      .value
       .asFunction<_Skip_Dart>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => Pointer<NativeFunction<_Reset_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(5).value)
+  int Reset() => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_Reset_Native>>>()
+      .value
       .asFunction<_Reset_Dart>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer> ppenum) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppenum);
+  int Clone(Pointer<Pointer> ppenum) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppenum);
 }

--- a/lib/src/com/IEnumMoniker.dart
+++ b/lib/src/com/IEnumMoniker.dart
@@ -44,20 +44,27 @@ class IEnumMoniker extends IUnknown {
   IEnumMoniker(Pointer<COMObject> ptr) : super(ptr);
 
   int Next(int celt, Pointer<Pointer> rgelt, Pointer<Uint32> pceltFetched) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_Next_Native>>>()
+          .value
           .asFunction<_Next_Dart>()(ptr.ref.lpVtbl, celt, rgelt, pceltFetched);
 
-  int Skip(int celt) => Pointer<NativeFunction<_Skip_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(4).value)
+  int Skip(int celt) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_Skip_Native>>>()
+      .value
       .asFunction<_Skip_Dart>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => Pointer<NativeFunction<_Reset_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(5).value)
+  int Reset() => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_Reset_Native>>>()
+      .value
       .asFunction<_Reset_Dart>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer> ppenum) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppenum);
+  int Clone(Pointer<Pointer> ppenum) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppenum);
 }

--- a/lib/src/com/IEnumNetworkConnections.dart
+++ b/lib/src/com/IEnumNetworkConnections.dart
@@ -66,20 +66,27 @@ class IEnumNetworkConnections extends IDispatch {
   }
 
   int Next(int celt, Pointer<Pointer> rgelt, Pointer<Uint32> pceltFetched) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_Next_Native>>>()
+          .value
           .asFunction<_Next_Dart>()(ptr.ref.lpVtbl, celt, rgelt, pceltFetched);
 
-  int Skip(int celt) => Pointer<NativeFunction<_Skip_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(9).value)
+  int Skip(int celt) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_Skip_Native>>>()
+      .value
       .asFunction<_Skip_Dart>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => Pointer<NativeFunction<_Reset_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(10).value)
+  int Reset() => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_Reset_Native>>>()
+      .value
       .asFunction<_Reset_Dart>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer> ppEnumNetwork) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppEnumNetwork);
+  int Clone(Pointer<Pointer> ppEnumNetwork) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppEnumNetwork);
 }

--- a/lib/src/com/IEnumNetworkConnections.dart
+++ b/lib/src/com/IEnumNetworkConnections.dart
@@ -53,9 +53,12 @@ class IEnumNetworkConnections extends IDispatch {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr = Pointer<NativeFunction<_get__NewEnum_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(7)
+          .cast<Pointer<NativeFunction<_get__NewEnum_Native>>>()
+          .value
           .asFunction<_get__NewEnum_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IEnumNetworks.dart
+++ b/lib/src/com/IEnumNetworks.dart
@@ -66,20 +66,27 @@ class IEnumNetworks extends IDispatch {
   }
 
   int Next(int celt, Pointer<Pointer> rgelt, Pointer<Uint32> pceltFetched) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_Next_Native>>>()
+          .value
           .asFunction<_Next_Dart>()(ptr.ref.lpVtbl, celt, rgelt, pceltFetched);
 
-  int Skip(int celt) => Pointer<NativeFunction<_Skip_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(9).value)
+  int Skip(int celt) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_Skip_Native>>>()
+      .value
       .asFunction<_Skip_Dart>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => Pointer<NativeFunction<_Reset_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(10).value)
+  int Reset() => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_Reset_Native>>>()
+      .value
       .asFunction<_Reset_Dart>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer> ppEnumNetwork) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppEnumNetwork);
+  int Clone(Pointer<Pointer> ppEnumNetwork) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppEnumNetwork);
 }

--- a/lib/src/com/IEnumNetworks.dart
+++ b/lib/src/com/IEnumNetworks.dart
@@ -53,9 +53,12 @@ class IEnumNetworks extends IDispatch {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr = Pointer<NativeFunction<_get__NewEnum_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(7)
+          .cast<Pointer<NativeFunction<_get__NewEnum_Native>>>()
+          .value
           .asFunction<_get__NewEnum_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IEnumResources.dart
+++ b/lib/src/com/IEnumResources.dart
@@ -45,20 +45,27 @@ class IEnumResources extends IUnknown {
 
   int Next(int celt, Pointer<SHELL_ITEM_RESOURCE> psir,
           Pointer<Uint32> pceltFetched) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_Next_Native>>>()
+          .value
           .asFunction<_Next_Dart>()(ptr.ref.lpVtbl, celt, psir, pceltFetched);
 
-  int Skip(int celt) => Pointer<NativeFunction<_Skip_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(4).value)
+  int Skip(int celt) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_Skip_Native>>>()
+      .value
       .asFunction<_Skip_Dart>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => Pointer<NativeFunction<_Reset_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(5).value)
+  int Reset() => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_Reset_Native>>>()
+      .value
       .asFunction<_Reset_Dart>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer> ppenumr) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppenumr);
+  int Clone(Pointer<Pointer> ppenumr) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppenumr);
 }

--- a/lib/src/com/IEnumSpellingError.dart
+++ b/lib/src/com/IEnumSpellingError.dart
@@ -32,8 +32,9 @@ class IEnumSpellingError extends IUnknown {
 
   IEnumSpellingError(Pointer<COMObject> ptr) : super(ptr);
 
-  int Next(Pointer<Pointer> value) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_Next_Dart>()(ptr.ref.lpVtbl, value);
+  int Next(Pointer<Pointer> value) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_Next_Native>>>()
+      .value
+      .asFunction<_Next_Dart>()(ptr.ref.lpVtbl, value);
 }

--- a/lib/src/com/IEnumString.dart
+++ b/lib/src/com/IEnumString.dart
@@ -45,20 +45,27 @@ class IEnumString extends IUnknown {
 
   int Next(int celt, Pointer<Pointer<Utf16>> rgelt,
           Pointer<Uint32> pceltFetched) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_Next_Native>>>()
+          .value
           .asFunction<_Next_Dart>()(ptr.ref.lpVtbl, celt, rgelt, pceltFetched);
 
-  int Skip(int celt) => Pointer<NativeFunction<_Skip_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(4).value)
+  int Skip(int celt) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_Skip_Native>>>()
+      .value
       .asFunction<_Skip_Dart>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => Pointer<NativeFunction<_Reset_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(5).value)
+  int Reset() => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_Reset_Native>>>()
+      .value
       .asFunction<_Reset_Dart>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer> ppenum) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppenum);
+  int Clone(Pointer<Pointer> ppenum) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppenum);
 }

--- a/lib/src/com/IEnumVARIANT.dart
+++ b/lib/src/com/IEnumVARIANT.dart
@@ -44,20 +44,27 @@ class IEnumVARIANT extends IUnknown {
   IEnumVARIANT(Pointer<COMObject> ptr) : super(ptr);
 
   int Next(int celt, Pointer<VARIANT> rgVar, Pointer<Uint32> pCeltFetched) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_Next_Native>>>()
+          .value
           .asFunction<_Next_Dart>()(ptr.ref.lpVtbl, celt, rgVar, pCeltFetched);
 
-  int Skip(int celt) => Pointer<NativeFunction<_Skip_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(4).value)
+  int Skip(int celt) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_Skip_Native>>>()
+      .value
       .asFunction<_Skip_Dart>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => Pointer<NativeFunction<_Reset_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(5).value)
+  int Reset() => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_Reset_Native>>>()
+      .value
       .asFunction<_Reset_Dart>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer> ppEnum) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppEnum);
+  int Clone(Pointer<Pointer> ppEnum) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppEnum);
 }

--- a/lib/src/com/IEnumWbemClassObject.dart
+++ b/lib/src/com/IEnumWbemClassObject.dart
@@ -48,29 +48,36 @@ class IEnumWbemClassObject extends IUnknown {
 
   IEnumWbemClassObject(Pointer<COMObject> ptr) : super(ptr);
 
-  int Reset() => Pointer<NativeFunction<_Reset_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(3).value)
+  int Reset() => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_Reset_Native>>>()
+      .value
       .asFunction<_Reset_Dart>()(ptr.ref.lpVtbl);
 
   int Next(int lTimeout, int uCount, Pointer<Pointer> apObjects,
           Pointer<Uint32> puReturned) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_Next_Native>>>()
+              .value
               .asFunction<_Next_Dart>()(
           ptr.ref.lpVtbl, lTimeout, uCount, apObjects, puReturned);
 
-  int NextAsync(int uCount, Pointer pSink) =>
-      Pointer<NativeFunction<_NextAsync_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_NextAsync_Dart>()(ptr.ref.lpVtbl, uCount, pSink);
+  int NextAsync(int uCount, Pointer pSink) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_NextAsync_Native>>>()
+      .value
+      .asFunction<_NextAsync_Dart>()(ptr.ref.lpVtbl, uCount, pSink);
 
-  int Clone(Pointer<Pointer> ppEnum) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppEnum);
+  int Clone(Pointer<Pointer> ppEnum) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppEnum);
 
-  int Skip(int lTimeout, int nCount) =>
-      Pointer<NativeFunction<_Skip_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_Skip_Dart>()(ptr.ref.lpVtbl, lTimeout, nCount);
+  int Skip(int lTimeout, int nCount) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_Skip_Native>>>()
+      .value
+      .asFunction<_Skip_Dart>()(ptr.ref.lpVtbl, lTimeout, nCount);
 }

--- a/lib/src/com/IErrorInfo.dart
+++ b/lib/src/com/IErrorInfo.dart
@@ -52,28 +52,34 @@ class IErrorInfo extends IUnknown {
 
   IErrorInfo(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetGUID(Pointer<GUID> pGUID) =>
-      Pointer<NativeFunction<_GetGUID_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetGUID_Dart>()(ptr.ref.lpVtbl, pGUID);
+  int GetGUID(Pointer<GUID> pGUID) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetGUID_Native>>>()
+      .value
+      .asFunction<_GetGUID_Dart>()(ptr.ref.lpVtbl, pGUID);
 
-  int GetSource(Pointer<Pointer<Utf16>> pBstrSource) =>
-      Pointer<NativeFunction<_GetSource_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetSource_Dart>()(ptr.ref.lpVtbl, pBstrSource);
+  int GetSource(Pointer<Pointer<Utf16>> pBstrSource) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetSource_Native>>>()
+      .value
+      .asFunction<_GetSource_Dart>()(ptr.ref.lpVtbl, pBstrSource);
 
   int GetDescription(Pointer<Pointer<Utf16>> pBstrDescription) =>
-      Pointer<NativeFunction<_GetDescription_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(5)
+          .cast<Pointer<NativeFunction<_GetDescription_Native>>>()
+          .value
           .asFunction<_GetDescription_Dart>()(ptr.ref.lpVtbl, pBstrDescription);
 
-  int GetHelpFile(Pointer<Pointer<Utf16>> pBstrHelpFile) =>
-      Pointer<NativeFunction<_GetHelpFile_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetHelpFile_Dart>()(ptr.ref.lpVtbl, pBstrHelpFile);
+  int GetHelpFile(Pointer<Pointer<Utf16>> pBstrHelpFile) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetHelpFile_Native>>>()
+      .value
+      .asFunction<_GetHelpFile_Dart>()(ptr.ref.lpVtbl, pBstrHelpFile);
 
-  int GetHelpContext(Pointer<Uint32> pdwHelpContext) =>
-      Pointer<NativeFunction<_GetHelpContext_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetHelpContext_Dart>()(ptr.ref.lpVtbl, pdwHelpContext);
+  int GetHelpContext(Pointer<Uint32> pdwHelpContext) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetHelpContext_Native>>>()
+      .value
+      .asFunction<_GetHelpContext_Dart>()(ptr.ref.lpVtbl, pdwHelpContext);
 }

--- a/lib/src/com/IFileDialog.dart
+++ b/lib/src/com/IFileDialog.dart
@@ -118,118 +118,144 @@ class IFileDialog extends IModalWindow {
   IFileDialog(Pointer<COMObject> ptr) : super(ptr);
 
   int SetFileTypes(int cFileTypes, Pointer<COMDLG_FILTERSPEC> rgFilterSpec) =>
-      Pointer<NativeFunction<_SetFileTypes_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_SetFileTypes_Native>>>()
+              .value
               .asFunction<_SetFileTypes_Dart>()(
           ptr.ref.lpVtbl, cFileTypes, rgFilterSpec);
 
-  int SetFileTypeIndex(int iFileType) =>
-      Pointer<NativeFunction<_SetFileTypeIndex_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_SetFileTypeIndex_Dart>()(ptr.ref.lpVtbl, iFileType);
+  int SetFileTypeIndex(int iFileType) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_SetFileTypeIndex_Native>>>()
+      .value
+      .asFunction<_SetFileTypeIndex_Dart>()(ptr.ref.lpVtbl, iFileType);
 
-  int GetFileTypeIndex(Pointer<Uint32> piFileType) =>
-      Pointer<NativeFunction<_GetFileTypeIndex_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetFileTypeIndex_Dart>()(ptr.ref.lpVtbl, piFileType);
+  int GetFileTypeIndex(Pointer<Uint32> piFileType) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetFileTypeIndex_Native>>>()
+      .value
+      .asFunction<_GetFileTypeIndex_Dart>()(ptr.ref.lpVtbl, piFileType);
 
-  int Advise(Pointer pfde, Pointer<Uint32> pdwCookie) =>
-      Pointer<NativeFunction<_Advise_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_Advise_Dart>()(ptr.ref.lpVtbl, pfde, pdwCookie);
+  int Advise(Pointer pfde, Pointer<Uint32> pdwCookie) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_Advise_Native>>>()
+      .value
+      .asFunction<_Advise_Dart>()(ptr.ref.lpVtbl, pfde, pdwCookie);
 
-  int Unadvise(int dwCookie) =>
-      Pointer<NativeFunction<_Unadvise_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
-          .asFunction<_Unadvise_Dart>()(ptr.ref.lpVtbl, dwCookie);
+  int Unadvise(int dwCookie) => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_Unadvise_Native>>>()
+      .value
+      .asFunction<_Unadvise_Dart>()(ptr.ref.lpVtbl, dwCookie);
 
-  int SetOptions(int fos) =>
-      Pointer<NativeFunction<_SetOptions_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_SetOptions_Dart>()(ptr.ref.lpVtbl, fos);
+  int SetOptions(int fos) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_SetOptions_Native>>>()
+      .value
+      .asFunction<_SetOptions_Dart>()(ptr.ref.lpVtbl, fos);
 
-  int GetOptions(Pointer<Uint32> pfos) =>
-      Pointer<NativeFunction<_GetOptions_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_GetOptions_Dart>()(ptr.ref.lpVtbl, pfos);
+  int GetOptions(Pointer<Uint32> pfos) => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_GetOptions_Native>>>()
+      .value
+      .asFunction<_GetOptions_Dart>()(ptr.ref.lpVtbl, pfos);
 
-  int SetDefaultFolder(Pointer psi) =>
-      Pointer<NativeFunction<_SetDefaultFolder_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_SetDefaultFolder_Dart>()(ptr.ref.lpVtbl, psi);
+  int SetDefaultFolder(Pointer psi) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_SetDefaultFolder_Native>>>()
+      .value
+      .asFunction<_SetDefaultFolder_Dart>()(ptr.ref.lpVtbl, psi);
 
-  int SetFolder(Pointer psi) =>
-      Pointer<NativeFunction<_SetFolder_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_SetFolder_Dart>()(ptr.ref.lpVtbl, psi);
+  int SetFolder(Pointer psi) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_SetFolder_Native>>>()
+      .value
+      .asFunction<_SetFolder_Dart>()(ptr.ref.lpVtbl, psi);
 
-  int GetFolder(Pointer<Pointer> ppsi) =>
-      Pointer<NativeFunction<_GetFolder_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_GetFolder_Dart>()(ptr.ref.lpVtbl, ppsi);
+  int GetFolder(Pointer<Pointer> ppsi) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_GetFolder_Native>>>()
+      .value
+      .asFunction<_GetFolder_Dart>()(ptr.ref.lpVtbl, ppsi);
 
-  int GetCurrentSelection(Pointer<Pointer> ppsi) =>
-      Pointer<NativeFunction<_GetCurrentSelection_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(14).value)
-          .asFunction<_GetCurrentSelection_Dart>()(ptr.ref.lpVtbl, ppsi);
+  int GetCurrentSelection(Pointer<Pointer> ppsi) => ptr.ref.lpVtbl.value
+      .elementAt(14)
+      .cast<Pointer<NativeFunction<_GetCurrentSelection_Native>>>()
+      .value
+      .asFunction<_GetCurrentSelection_Dart>()(ptr.ref.lpVtbl, ppsi);
 
-  int SetFileName(Pointer<Utf16> pszName) =>
-      Pointer<NativeFunction<_SetFileName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(15).value)
-          .asFunction<_SetFileName_Dart>()(ptr.ref.lpVtbl, pszName);
+  int SetFileName(Pointer<Utf16> pszName) => ptr.ref.lpVtbl.value
+      .elementAt(15)
+      .cast<Pointer<NativeFunction<_SetFileName_Native>>>()
+      .value
+      .asFunction<_SetFileName_Dart>()(ptr.ref.lpVtbl, pszName);
 
-  int GetFileName(Pointer<Pointer<Utf16>> pszName) =>
-      Pointer<NativeFunction<_GetFileName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(16).value)
-          .asFunction<_GetFileName_Dart>()(ptr.ref.lpVtbl, pszName);
+  int GetFileName(Pointer<Pointer<Utf16>> pszName) => ptr.ref.lpVtbl.value
+      .elementAt(16)
+      .cast<Pointer<NativeFunction<_GetFileName_Native>>>()
+      .value
+      .asFunction<_GetFileName_Dart>()(ptr.ref.lpVtbl, pszName);
 
-  int SetTitle(Pointer<Utf16> pszTitle) =>
-      Pointer<NativeFunction<_SetTitle_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(17).value)
-          .asFunction<_SetTitle_Dart>()(ptr.ref.lpVtbl, pszTitle);
+  int SetTitle(Pointer<Utf16> pszTitle) => ptr.ref.lpVtbl.value
+      .elementAt(17)
+      .cast<Pointer<NativeFunction<_SetTitle_Native>>>()
+      .value
+      .asFunction<_SetTitle_Dart>()(ptr.ref.lpVtbl, pszTitle);
 
-  int SetOkButtonLabel(Pointer<Utf16> pszText) =>
-      Pointer<NativeFunction<_SetOkButtonLabel_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(18).value)
-          .asFunction<_SetOkButtonLabel_Dart>()(ptr.ref.lpVtbl, pszText);
+  int SetOkButtonLabel(Pointer<Utf16> pszText) => ptr.ref.lpVtbl.value
+      .elementAt(18)
+      .cast<Pointer<NativeFunction<_SetOkButtonLabel_Native>>>()
+      .value
+      .asFunction<_SetOkButtonLabel_Dart>()(ptr.ref.lpVtbl, pszText);
 
-  int SetFileNameLabel(Pointer<Utf16> pszLabel) =>
-      Pointer<NativeFunction<_SetFileNameLabel_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(19).value)
-          .asFunction<_SetFileNameLabel_Dart>()(ptr.ref.lpVtbl, pszLabel);
+  int SetFileNameLabel(Pointer<Utf16> pszLabel) => ptr.ref.lpVtbl.value
+      .elementAt(19)
+      .cast<Pointer<NativeFunction<_SetFileNameLabel_Native>>>()
+      .value
+      .asFunction<_SetFileNameLabel_Dart>()(ptr.ref.lpVtbl, pszLabel);
 
-  int GetResult(Pointer<Pointer> ppsi) =>
-      Pointer<NativeFunction<_GetResult_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(20).value)
-          .asFunction<_GetResult_Dart>()(ptr.ref.lpVtbl, ppsi);
+  int GetResult(Pointer<Pointer> ppsi) => ptr.ref.lpVtbl.value
+      .elementAt(20)
+      .cast<Pointer<NativeFunction<_GetResult_Native>>>()
+      .value
+      .asFunction<_GetResult_Dart>()(ptr.ref.lpVtbl, ppsi);
 
-  int AddPlace(Pointer psi, int fdap) =>
-      Pointer<NativeFunction<_AddPlace_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(21).value)
-          .asFunction<_AddPlace_Dart>()(ptr.ref.lpVtbl, psi, fdap);
+  int AddPlace(Pointer psi, int fdap) => ptr.ref.lpVtbl.value
+      .elementAt(21)
+      .cast<Pointer<NativeFunction<_AddPlace_Native>>>()
+      .value
+      .asFunction<_AddPlace_Dart>()(ptr.ref.lpVtbl, psi, fdap);
 
   int SetDefaultExtension(Pointer<Utf16> pszDefaultExtension) =>
-      Pointer<NativeFunction<_SetDefaultExtension_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(22).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(22)
+              .cast<Pointer<NativeFunction<_SetDefaultExtension_Native>>>()
+              .value
               .asFunction<_SetDefaultExtension_Dart>()(
           ptr.ref.lpVtbl, pszDefaultExtension);
 
-  int Close(int hr) => Pointer<NativeFunction<_Close_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(23).value)
+  int Close(int hr) => ptr.ref.lpVtbl.value
+      .elementAt(23)
+      .cast<Pointer<NativeFunction<_Close_Native>>>()
+      .value
       .asFunction<_Close_Dart>()(ptr.ref.lpVtbl, hr);
 
-  int SetClientGuid(Pointer<GUID> guid) =>
-      Pointer<NativeFunction<_SetClientGuid_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(24).value)
-          .asFunction<_SetClientGuid_Dart>()(ptr.ref.lpVtbl, guid);
+  int SetClientGuid(Pointer<GUID> guid) => ptr.ref.lpVtbl.value
+      .elementAt(24)
+      .cast<Pointer<NativeFunction<_SetClientGuid_Native>>>()
+      .value
+      .asFunction<_SetClientGuid_Dart>()(ptr.ref.lpVtbl, guid);
 
-  int ClearClientData() =>
-      Pointer<NativeFunction<_ClearClientData_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(25).value)
-          .asFunction<_ClearClientData_Dart>()(ptr.ref.lpVtbl);
+  int ClearClientData() => ptr.ref.lpVtbl.value
+      .elementAt(25)
+      .cast<Pointer<NativeFunction<_ClearClientData_Native>>>()
+      .value
+      .asFunction<_ClearClientData_Dart>()(ptr.ref.lpVtbl);
 
-  int SetFilter(Pointer pFilter) =>
-      Pointer<NativeFunction<_SetFilter_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(26).value)
-          .asFunction<_SetFilter_Dart>()(ptr.ref.lpVtbl, pFilter);
+  int SetFilter(Pointer pFilter) => ptr.ref.lpVtbl.value
+      .elementAt(26)
+      .cast<Pointer<NativeFunction<_SetFilter_Native>>>()
+      .value
+      .asFunction<_SetFilter_Dart>()(ptr.ref.lpVtbl, pFilter);
 }

--- a/lib/src/com/IFileDialog2.dart
+++ b/lib/src/com/IFileDialog2.dart
@@ -37,13 +37,15 @@ class IFileDialog2 extends IFileDialog {
 
   IFileDialog2(Pointer<COMObject> ptr) : super(ptr);
 
-  int SetCancelButtonLabel(Pointer<Utf16> pszLabel) =>
-      Pointer<NativeFunction<_SetCancelButtonLabel_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(27).value)
-          .asFunction<_SetCancelButtonLabel_Dart>()(ptr.ref.lpVtbl, pszLabel);
+  int SetCancelButtonLabel(Pointer<Utf16> pszLabel) => ptr.ref.lpVtbl.value
+      .elementAt(27)
+      .cast<Pointer<NativeFunction<_SetCancelButtonLabel_Native>>>()
+      .value
+      .asFunction<_SetCancelButtonLabel_Dart>()(ptr.ref.lpVtbl, pszLabel);
 
-  int SetNavigationRoot(Pointer psi) =>
-      Pointer<NativeFunction<_SetNavigationRoot_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(28).value)
-          .asFunction<_SetNavigationRoot_Dart>()(ptr.ref.lpVtbl, psi);
+  int SetNavigationRoot(Pointer psi) => ptr.ref.lpVtbl.value
+      .elementAt(28)
+      .cast<Pointer<NativeFunction<_SetNavigationRoot_Native>>>()
+      .value
+      .asFunction<_SetNavigationRoot_Dart>()(ptr.ref.lpVtbl, psi);
 }

--- a/lib/src/com/IFileDialogCustomize.dart
+++ b/lib/src/com/IFileDialogCustomize.dart
@@ -153,154 +153,188 @@ class IFileDialogCustomize extends IUnknown {
 
   IFileDialogCustomize(Pointer<COMObject> ptr) : super(ptr);
 
-  int EnableOpenDropDown(int dwIDCtl) =>
-      Pointer<NativeFunction<_EnableOpenDropDown_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_EnableOpenDropDown_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
+  int EnableOpenDropDown(int dwIDCtl) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_EnableOpenDropDown_Native>>>()
+      .value
+      .asFunction<_EnableOpenDropDown_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
 
-  int AddMenu(int dwIDCtl, Pointer<Utf16> pszLabel) =>
-      Pointer<NativeFunction<_AddMenu_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_AddMenu_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pszLabel);
+  int AddMenu(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_AddMenu_Native>>>()
+      .value
+      .asFunction<_AddMenu_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pszLabel);
 
   int AddPushButton(int dwIDCtl, Pointer<Utf16> pszLabel) =>
-      Pointer<NativeFunction<_AddPushButton_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(5)
+          .cast<Pointer<NativeFunction<_AddPushButton_Native>>>()
+          .value
           .asFunction<_AddPushButton_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pszLabel);
 
-  int AddComboBox(int dwIDCtl) =>
-      Pointer<NativeFunction<_AddComboBox_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_AddComboBox_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
+  int AddComboBox(int dwIDCtl) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_AddComboBox_Native>>>()
+      .value
+      .asFunction<_AddComboBox_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
 
-  int AddRadioButtonList(int dwIDCtl) =>
-      Pointer<NativeFunction<_AddRadioButtonList_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_AddRadioButtonList_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
+  int AddRadioButtonList(int dwIDCtl) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_AddRadioButtonList_Native>>>()
+      .value
+      .asFunction<_AddRadioButtonList_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
 
   int AddCheckButton(int dwIDCtl, Pointer<Utf16> pszLabel, int bChecked) =>
-      Pointer<NativeFunction<_AddCheckButton_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(8)
+              .cast<Pointer<NativeFunction<_AddCheckButton_Native>>>()
+              .value
               .asFunction<_AddCheckButton_Dart>()(
           ptr.ref.lpVtbl, dwIDCtl, pszLabel, bChecked);
 
-  int AddEditBox(int dwIDCtl, Pointer<Utf16> pszText) =>
-      Pointer<NativeFunction<_AddEditBox_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_AddEditBox_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pszText);
+  int AddEditBox(int dwIDCtl, Pointer<Utf16> pszText) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_AddEditBox_Native>>>()
+      .value
+      .asFunction<_AddEditBox_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pszText);
 
-  int AddSeparator(int dwIDCtl) =>
-      Pointer<NativeFunction<_AddSeparator_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_AddSeparator_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
+  int AddSeparator(int dwIDCtl) => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_AddSeparator_Native>>>()
+      .value
+      .asFunction<_AddSeparator_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
 
-  int AddText(int dwIDCtl, Pointer<Utf16> pszText) =>
-      Pointer<NativeFunction<_AddText_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_AddText_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pszText);
+  int AddText(int dwIDCtl, Pointer<Utf16> pszText) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_AddText_Native>>>()
+      .value
+      .asFunction<_AddText_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pszText);
 
-  int SetControlLabel(int dwIDCtl, Pointer<Utf16> pszLabel) =>
-      Pointer<NativeFunction<_SetControlLabel_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(12).value)
-              .asFunction<_SetControlLabel_Dart>()(
-          ptr.ref.lpVtbl, dwIDCtl, pszLabel);
+  int SetControlLabel(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr
+      .ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_SetControlLabel_Native>>>()
+      .value
+      .asFunction<_SetControlLabel_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pszLabel);
 
-  int GetControlState(int dwIDCtl, Pointer<Uint32> pdwState) =>
-      Pointer<NativeFunction<_GetControlState_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(13).value)
-              .asFunction<_GetControlState_Dart>()(
-          ptr.ref.lpVtbl, dwIDCtl, pdwState);
+  int GetControlState(int dwIDCtl, Pointer<Uint32> pdwState) => ptr
+      .ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_GetControlState_Native>>>()
+      .value
+      .asFunction<_GetControlState_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pdwState);
 
-  int SetControlState(int dwIDCtl, int dwState) =>
-      Pointer<NativeFunction<_SetControlState_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(14).value)
-              .asFunction<_SetControlState_Dart>()(
-          ptr.ref.lpVtbl, dwIDCtl, dwState);
+  int SetControlState(int dwIDCtl, int dwState) => ptr.ref.lpVtbl.value
+      .elementAt(14)
+      .cast<Pointer<NativeFunction<_SetControlState_Native>>>()
+      .value
+      .asFunction<_SetControlState_Dart>()(ptr.ref.lpVtbl, dwIDCtl, dwState);
 
-  int GetEditBoxText(int dwIDCtl, Pointer<Pointer<Uint16>> ppszText) =>
-      Pointer<NativeFunction<_GetEditBoxText_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(15).value)
-              .asFunction<_GetEditBoxText_Dart>()(
-          ptr.ref.lpVtbl, dwIDCtl, ppszText);
+  int GetEditBoxText(int dwIDCtl, Pointer<Pointer<Uint16>> ppszText) => ptr
+      .ref.lpVtbl.value
+      .elementAt(15)
+      .cast<Pointer<NativeFunction<_GetEditBoxText_Native>>>()
+      .value
+      .asFunction<_GetEditBoxText_Dart>()(ptr.ref.lpVtbl, dwIDCtl, ppszText);
 
   int SetEditBoxText(int dwIDCtl, Pointer<Utf16> pszText) =>
-      Pointer<NativeFunction<_SetEditBoxText_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(16).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(16)
+          .cast<Pointer<NativeFunction<_SetEditBoxText_Native>>>()
+          .value
           .asFunction<_SetEditBoxText_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pszText);
 
   int GetCheckButtonState(int dwIDCtl, Pointer<Int32> pbChecked) =>
-      Pointer<NativeFunction<_GetCheckButtonState_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(17).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(17)
+              .cast<Pointer<NativeFunction<_GetCheckButtonState_Native>>>()
+              .value
               .asFunction<_GetCheckButtonState_Dart>()(
           ptr.ref.lpVtbl, dwIDCtl, pbChecked);
 
-  int SetCheckButtonState(int dwIDCtl, int bChecked) =>
-      Pointer<NativeFunction<_SetCheckButtonState_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(18).value)
-              .asFunction<_SetCheckButtonState_Dart>()(
-          ptr.ref.lpVtbl, dwIDCtl, bChecked);
+  int SetCheckButtonState(int dwIDCtl, int bChecked) => ptr.ref.lpVtbl.value
+          .elementAt(18)
+          .cast<Pointer<NativeFunction<_SetCheckButtonState_Native>>>()
+          .value
+          .asFunction<_SetCheckButtonState_Dart>()(
+      ptr.ref.lpVtbl, dwIDCtl, bChecked);
 
   int AddControlItem(int dwIDCtl, int dwIDItem, Pointer<Utf16> pszLabel) =>
-      Pointer<NativeFunction<_AddControlItem_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(19).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(19)
+              .cast<Pointer<NativeFunction<_AddControlItem_Native>>>()
+              .value
               .asFunction<_AddControlItem_Dart>()(
           ptr.ref.lpVtbl, dwIDCtl, dwIDItem, pszLabel);
 
-  int RemoveControlItem(int dwIDCtl, int dwIDItem) =>
-      Pointer<NativeFunction<_RemoveControlItem_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(20).value)
-              .asFunction<_RemoveControlItem_Dart>()(
-          ptr.ref.lpVtbl, dwIDCtl, dwIDItem);
+  int RemoveControlItem(int dwIDCtl, int dwIDItem) => ptr.ref.lpVtbl.value
+      .elementAt(20)
+      .cast<Pointer<NativeFunction<_RemoveControlItem_Native>>>()
+      .value
+      .asFunction<_RemoveControlItem_Dart>()(ptr.ref.lpVtbl, dwIDCtl, dwIDItem);
 
-  int RemoveAllControlItems(int dwIDCtl) =>
-      Pointer<NativeFunction<_RemoveAllControlItems_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(21).value)
-          .asFunction<_RemoveAllControlItems_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
+  int RemoveAllControlItems(int dwIDCtl) => ptr.ref.lpVtbl.value
+      .elementAt(21)
+      .cast<Pointer<NativeFunction<_RemoveAllControlItems_Native>>>()
+      .value
+      .asFunction<_RemoveAllControlItems_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
 
   int GetControlItemState(
           int dwIDCtl, int dwIDItem, Pointer<Uint32> pdwState) =>
-      Pointer<NativeFunction<_GetControlItemState_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(22).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(22)
+              .cast<Pointer<NativeFunction<_GetControlItemState_Native>>>()
+              .value
               .asFunction<_GetControlItemState_Dart>()(
           ptr.ref.lpVtbl, dwIDCtl, dwIDItem, pdwState);
 
   int SetControlItemState(int dwIDCtl, int dwIDItem, int dwState) =>
-      Pointer<NativeFunction<_SetControlItemState_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(23).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(23)
+              .cast<Pointer<NativeFunction<_SetControlItemState_Native>>>()
+              .value
               .asFunction<_SetControlItemState_Dart>()(
           ptr.ref.lpVtbl, dwIDCtl, dwIDItem, dwState);
 
   int GetSelectedControlItem(int dwIDCtl, Pointer<Uint32> pdwIDItem) =>
-      Pointer<NativeFunction<_GetSelectedControlItem_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(24).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(24)
+              .cast<Pointer<NativeFunction<_GetSelectedControlItem_Native>>>()
+              .value
               .asFunction<_GetSelectedControlItem_Dart>()(
           ptr.ref.lpVtbl, dwIDCtl, pdwIDItem);
 
-  int SetSelectedControlItem(int dwIDCtl, int dwIDItem) =>
-      Pointer<NativeFunction<_SetSelectedControlItem_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(25).value)
-              .asFunction<_SetSelectedControlItem_Dart>()(
-          ptr.ref.lpVtbl, dwIDCtl, dwIDItem);
+  int SetSelectedControlItem(int dwIDCtl, int dwIDItem) => ptr.ref.lpVtbl.value
+          .elementAt(25)
+          .cast<Pointer<NativeFunction<_SetSelectedControlItem_Native>>>()
+          .value
+          .asFunction<_SetSelectedControlItem_Dart>()(
+      ptr.ref.lpVtbl, dwIDCtl, dwIDItem);
 
-  int StartVisualGroup(int dwIDCtl, Pointer<Utf16> pszLabel) =>
-      Pointer<NativeFunction<_StartVisualGroup_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(26).value)
-              .asFunction<_StartVisualGroup_Dart>()(
-          ptr.ref.lpVtbl, dwIDCtl, pszLabel);
+  int StartVisualGroup(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr
+      .ref.lpVtbl.value
+      .elementAt(26)
+      .cast<Pointer<NativeFunction<_StartVisualGroup_Native>>>()
+      .value
+      .asFunction<_StartVisualGroup_Dart>()(ptr.ref.lpVtbl, dwIDCtl, pszLabel);
 
-  int EndVisualGroup() =>
-      Pointer<NativeFunction<_EndVisualGroup_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(27).value)
-          .asFunction<_EndVisualGroup_Dart>()(ptr.ref.lpVtbl);
+  int EndVisualGroup() => ptr.ref.lpVtbl.value
+      .elementAt(27)
+      .cast<Pointer<NativeFunction<_EndVisualGroup_Native>>>()
+      .value
+      .asFunction<_EndVisualGroup_Dart>()(ptr.ref.lpVtbl);
 
-  int MakeProminent(int dwIDCtl) =>
-      Pointer<NativeFunction<_MakeProminent_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(28).value)
-          .asFunction<_MakeProminent_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
+  int MakeProminent(int dwIDCtl) => ptr.ref.lpVtbl.value
+      .elementAt(28)
+      .cast<Pointer<NativeFunction<_MakeProminent_Native>>>()
+      .value
+      .asFunction<_MakeProminent_Dart>()(ptr.ref.lpVtbl, dwIDCtl);
 
   int SetControlItemText(int dwIDCtl, int dwIDItem, Pointer<Utf16> pszLabel) =>
-      Pointer<NativeFunction<_SetControlItemText_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(29).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(29)
+              .cast<Pointer<NativeFunction<_SetControlItemText_Native>>>()
+              .value
               .asFunction<_SetControlItemText_Dart>()(
           ptr.ref.lpVtbl, dwIDCtl, dwIDItem, pszLabel);
 }

--- a/lib/src/com/IFileIsInUse.dart
+++ b/lib/src/com/IFileIsInUse.dart
@@ -50,27 +50,33 @@ class IFileIsInUse extends IUnknown {
 
   IFileIsInUse(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetAppName(Pointer<Pointer<Utf16>> ppszName) =>
-      Pointer<NativeFunction<_GetAppName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetAppName_Dart>()(ptr.ref.lpVtbl, ppszName);
+  int GetAppName(Pointer<Pointer<Utf16>> ppszName) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetAppName_Native>>>()
+      .value
+      .asFunction<_GetAppName_Dart>()(ptr.ref.lpVtbl, ppszName);
 
-  int GetUsage(Pointer<Uint32> pfut) =>
-      Pointer<NativeFunction<_GetUsage_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetUsage_Dart>()(ptr.ref.lpVtbl, pfut);
+  int GetUsage(Pointer<Uint32> pfut) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetUsage_Native>>>()
+      .value
+      .asFunction<_GetUsage_Dart>()(ptr.ref.lpVtbl, pfut);
 
-  int GetCapabilities(Pointer<Uint32> pdwCapFlags) =>
-      Pointer<NativeFunction<_GetCapabilities_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_GetCapabilities_Dart>()(ptr.ref.lpVtbl, pdwCapFlags);
+  int GetCapabilities(Pointer<Uint32> pdwCapFlags) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_GetCapabilities_Native>>>()
+      .value
+      .asFunction<_GetCapabilities_Dart>()(ptr.ref.lpVtbl, pdwCapFlags);
 
-  int GetSwitchToHWND(Pointer<IntPtr> phwnd) =>
-      Pointer<NativeFunction<_GetSwitchToHWND_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetSwitchToHWND_Dart>()(ptr.ref.lpVtbl, phwnd);
+  int GetSwitchToHWND(Pointer<IntPtr> phwnd) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetSwitchToHWND_Native>>>()
+      .value
+      .asFunction<_GetSwitchToHWND_Dart>()(ptr.ref.lpVtbl, phwnd);
 
-  int CloseFile() => Pointer<NativeFunction<_CloseFile_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(7).value)
+  int CloseFile() => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_CloseFile_Native>>>()
+      .value
       .asFunction<_CloseFile_Dart>()(ptr.ref.lpVtbl);
 }

--- a/lib/src/com/IFileOpenDialog.dart
+++ b/lib/src/com/IFileOpenDialog.dart
@@ -41,15 +41,17 @@ class IFileOpenDialog extends IFileDialog {
 
   IFileOpenDialog(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetResults(Pointer<Pointer> ppenum) =>
-      Pointer<NativeFunction<_GetResults_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(27).value)
-          .asFunction<_GetResults_Dart>()(ptr.ref.lpVtbl, ppenum);
+  int GetResults(Pointer<Pointer> ppenum) => ptr.ref.lpVtbl.value
+      .elementAt(27)
+      .cast<Pointer<NativeFunction<_GetResults_Native>>>()
+      .value
+      .asFunction<_GetResults_Dart>()(ptr.ref.lpVtbl, ppenum);
 
-  int GetSelectedItems(Pointer<Pointer> ppsai) =>
-      Pointer<NativeFunction<_GetSelectedItems_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(28).value)
-          .asFunction<_GetSelectedItems_Dart>()(ptr.ref.lpVtbl, ppsai);
+  int GetSelectedItems(Pointer<Pointer> ppsai) => ptr.ref.lpVtbl.value
+      .elementAt(28)
+      .cast<Pointer<NativeFunction<_GetSelectedItems_Native>>>()
+      .value
+      .asFunction<_GetSelectedItems_Dart>()(ptr.ref.lpVtbl, ppsai);
 }
 
 /// {@category com}

--- a/lib/src/com/IFileOpenPicker.dart
+++ b/lib/src/com/IFileOpenPicker.dart
@@ -100,8 +100,10 @@ class IFileOpenPicker extends IInspectable {
   }
 
   set ViewMode(int value) {
-    final hr = Pointer<NativeFunction<_put_ViewMode_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(7).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(7)
+        .cast<Pointer<NativeFunction<_put_ViewMode_Native>>>()
+        .value
         .asFunction<_put_ViewMode_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -128,10 +130,11 @@ class IFileOpenPicker extends IInspectable {
   }
 
   set SettingsIdentifier(int value) {
-    final hr =
-        Pointer<NativeFunction<_put_SettingsIdentifier_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(9).value)
-            .asFunction<_put_SettingsIdentifier_Dart>()(ptr.ref.lpVtbl, value);
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(9)
+        .cast<Pointer<NativeFunction<_put_SettingsIdentifier_Native>>>()
+        .value
+        .asFunction<_put_SettingsIdentifier_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -157,11 +160,11 @@ class IFileOpenPicker extends IInspectable {
   }
 
   set SuggestedStartLocation(int value) {
-    final hr =
-        Pointer<NativeFunction<_put_SuggestedStartLocation_Native>>.fromAddress(
-                    ptr.ref.vtable.elementAt(11).value)
-                .asFunction<_put_SuggestedStartLocation_Dart>()(
-            ptr.ref.lpVtbl, value);
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(11)
+        .cast<Pointer<NativeFunction<_put_SuggestedStartLocation_Native>>>()
+        .value
+        .asFunction<_put_SuggestedStartLocation_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -187,10 +190,11 @@ class IFileOpenPicker extends IInspectable {
   }
 
   set CommitButtonText(int value) {
-    final hr =
-        Pointer<NativeFunction<_put_CommitButtonText_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(13).value)
-            .asFunction<_put_CommitButtonText_Dart>()(ptr.ref.lpVtbl, value);
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(13)
+        .cast<Pointer<NativeFunction<_put_CommitButtonText_Native>>>()
+        .value
+        .asFunction<_put_CommitButtonText_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/lib/src/com/IFileOpenPicker.dart
+++ b/lib/src/com/IFileOpenPicker.dart
@@ -205,13 +205,15 @@ class IFileOpenPicker extends IInspectable {
     }
   }
 
-  int PickSingleFileAsync(Pointer<Pointer> result) =>
-      Pointer<NativeFunction<_PickSingleFileAsync_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(15).value)
-          .asFunction<_PickSingleFileAsync_Dart>()(ptr.ref.lpVtbl, result);
+  int PickSingleFileAsync(Pointer<Pointer> result) => ptr.ref.lpVtbl.value
+      .elementAt(15)
+      .cast<Pointer<NativeFunction<_PickSingleFileAsync_Native>>>()
+      .value
+      .asFunction<_PickSingleFileAsync_Dart>()(ptr.ref.lpVtbl, result);
 
-  int PickMultipleFilesAsync(Pointer<Pointer> result) =>
-      Pointer<NativeFunction<_PickMultipleFilesAsync_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(16).value)
-          .asFunction<_PickMultipleFilesAsync_Dart>()(ptr.ref.lpVtbl, result);
+  int PickMultipleFilesAsync(Pointer<Pointer> result) => ptr.ref.lpVtbl.value
+      .elementAt(16)
+      .cast<Pointer<NativeFunction<_PickMultipleFilesAsync_Native>>>()
+      .value
+      .asFunction<_PickMultipleFilesAsync_Dart>()(ptr.ref.lpVtbl, result);
 }

--- a/lib/src/com/IFileOpenPicker.dart
+++ b/lib/src/com/IFileOpenPicker.dart
@@ -84,9 +84,12 @@ class IFileOpenPicker extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_ViewMode_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<Pointer<NativeFunction<_get_ViewMode_Native>>>()
+          .value
           .asFunction<_get_ViewMode_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -108,11 +111,13 @@ class IFileOpenPicker extends IInspectable {
     final retValuePtr = calloc<IntPtr>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_SettingsIdentifier_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(8).value)
-                  .asFunction<_get_SettingsIdentifier_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(8)
+              .cast<Pointer<NativeFunction<_get_SettingsIdentifier_Native>>>()
+              .value
+              .asFunction<_get_SettingsIdentifier_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -135,12 +140,13 @@ class IFileOpenPicker extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_SuggestedStartLocation_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
-              .asFunction<_get_SuggestedStartLocation_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(10)
+          .cast<Pointer<NativeFunction<_get_SuggestedStartLocation_Native>>>()
+          .value
+          .asFunction<
+              _get_SuggestedStartLocation_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -164,11 +170,13 @@ class IFileOpenPicker extends IInspectable {
     final retValuePtr = calloc<IntPtr>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_CommitButtonText_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(12).value)
-                  .asFunction<_get_CommitButtonText_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(12)
+              .cast<Pointer<NativeFunction<_get_CommitButtonText_Native>>>()
+              .value
+              .asFunction<_get_CommitButtonText_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -191,11 +199,12 @@ class IFileOpenPicker extends IInspectable {
     final retValuePtr = calloc<IntPtr>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_FileTypeFilter_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(14).value)
-                  .asFunction<_get_FileTypeFilter_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(14)
+          .cast<Pointer<NativeFunction<_get_FileTypeFilter_Native>>>()
+          .value
+          .asFunction<_get_FileTypeFilter_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IFileSaveDialog.dart
+++ b/lib/src/com/IFileSaveDialog.dart
@@ -53,30 +53,37 @@ class IFileSaveDialog extends IFileDialog {
 
   IFileSaveDialog(Pointer<COMObject> ptr) : super(ptr);
 
-  int SetSaveAsItem(Pointer psi) =>
-      Pointer<NativeFunction<_SetSaveAsItem_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(27).value)
-          .asFunction<_SetSaveAsItem_Dart>()(ptr.ref.lpVtbl, psi);
+  int SetSaveAsItem(Pointer psi) => ptr.ref.lpVtbl.value
+      .elementAt(27)
+      .cast<Pointer<NativeFunction<_SetSaveAsItem_Native>>>()
+      .value
+      .asFunction<_SetSaveAsItem_Dart>()(ptr.ref.lpVtbl, psi);
 
-  int SetProperties(Pointer pStore) =>
-      Pointer<NativeFunction<_SetProperties_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(28).value)
-          .asFunction<_SetProperties_Dart>()(ptr.ref.lpVtbl, pStore);
+  int SetProperties(Pointer pStore) => ptr.ref.lpVtbl.value
+      .elementAt(28)
+      .cast<Pointer<NativeFunction<_SetProperties_Native>>>()
+      .value
+      .asFunction<_SetProperties_Dart>()(ptr.ref.lpVtbl, pStore);
 
   int SetCollectedProperties(Pointer pList, int fAppendDefault) =>
-      Pointer<NativeFunction<_SetCollectedProperties_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(29).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(29)
+              .cast<Pointer<NativeFunction<_SetCollectedProperties_Native>>>()
+              .value
               .asFunction<_SetCollectedProperties_Dart>()(
           ptr.ref.lpVtbl, pList, fAppendDefault);
 
-  int GetProperties(Pointer<Pointer> ppStore) =>
-      Pointer<NativeFunction<_GetProperties_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(30).value)
-          .asFunction<_GetProperties_Dart>()(ptr.ref.lpVtbl, ppStore);
+  int GetProperties(Pointer<Pointer> ppStore) => ptr.ref.lpVtbl.value
+      .elementAt(30)
+      .cast<Pointer<NativeFunction<_GetProperties_Native>>>()
+      .value
+      .asFunction<_GetProperties_Dart>()(ptr.ref.lpVtbl, ppStore);
 
   int ApplyProperties(Pointer psi, Pointer pStore, int hwnd, Pointer pSink) =>
-      Pointer<NativeFunction<_ApplyProperties_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(31).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(31)
+              .cast<Pointer<NativeFunction<_ApplyProperties_Native>>>()
+              .value
               .asFunction<_ApplyProperties_Dart>()(
           ptr.ref.lpVtbl, psi, pStore, hwnd, pSink);
 }

--- a/lib/src/com/IGamepadStatics.dart
+++ b/lib/src/com/IGamepadStatics.dart
@@ -82,9 +82,12 @@ class IGamepadStatics extends IInspectable {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Gamepads_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(10)
+          .cast<Pointer<NativeFunction<_get_Gamepads_Native>>>()
+          .value
           .asFunction<_get_Gamepads_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IGamepadStatics.dart
+++ b/lib/src/com/IGamepadStatics.dart
@@ -53,25 +53,30 @@ class IGamepadStatics extends IInspectable {
   IGamepadStatics(Pointer<COMObject> ptr) : super(ptr);
 
   int add_GamepadAdded(Pointer value, Pointer<Uint32> result) =>
-      Pointer<NativeFunction<_add_GamepadAdded_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<Pointer<NativeFunction<_add_GamepadAdded_Native>>>()
+          .value
           .asFunction<_add_GamepadAdded_Dart>()(ptr.ref.lpVtbl, value, result);
 
-  int remove_GamepadAdded(int token) =>
-      Pointer<NativeFunction<_remove_GamepadAdded_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_remove_GamepadAdded_Dart>()(ptr.ref.lpVtbl, token);
+  int remove_GamepadAdded(int token) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_remove_GamepadAdded_Native>>>()
+      .value
+      .asFunction<_remove_GamepadAdded_Dart>()(ptr.ref.lpVtbl, token);
 
-  int add_GamepadRemoved(Pointer value, Pointer<Uint32> result) =>
-      Pointer<NativeFunction<_add_GamepadRemoved_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
-              .asFunction<_add_GamepadRemoved_Dart>()(
-          ptr.ref.lpVtbl, value, result);
+  int add_GamepadRemoved(Pointer value, Pointer<Uint32> result) => ptr
+      .ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_add_GamepadRemoved_Native>>>()
+      .value
+      .asFunction<_add_GamepadRemoved_Dart>()(ptr.ref.lpVtbl, value, result);
 
-  int remove_GamepadRemoved(int token) =>
-      Pointer<NativeFunction<_remove_GamepadRemoved_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_remove_GamepadRemoved_Dart>()(ptr.ref.lpVtbl, token);
+  int remove_GamepadRemoved(int token) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_remove_GamepadRemoved_Native>>>()
+      .value
+      .asFunction<_remove_GamepadRemoved_Dart>()(ptr.ref.lpVtbl, token);
 
   Pointer get Gamepads {
     final retValuePtr = calloc<Pointer>();

--- a/lib/src/com/IInspectable.dart
+++ b/lib/src/com/IInspectable.dart
@@ -45,17 +45,21 @@ class IInspectable extends IUnknown {
   IInspectable(Pointer<COMObject> ptr) : super(ptr);
 
   int GetIids(Pointer<Uint32> iidCount, Pointer<Pointer<GUID>> iids) =>
-      Pointer<NativeFunction<_GetIids_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_GetIids_Native>>>()
+          .value
           .asFunction<_GetIids_Dart>()(ptr.ref.lpVtbl, iidCount, iids);
 
-  int GetRuntimeClassName(Pointer<IntPtr> className) =>
-      Pointer<NativeFunction<_GetRuntimeClassName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetRuntimeClassName_Dart>()(ptr.ref.lpVtbl, className);
+  int GetRuntimeClassName(Pointer<IntPtr> className) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetRuntimeClassName_Native>>>()
+      .value
+      .asFunction<_GetRuntimeClassName_Dart>()(ptr.ref.lpVtbl, className);
 
-  int GetTrustLevel(Pointer<Uint32> trustLevel) =>
-      Pointer<NativeFunction<_GetTrustLevel_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_GetTrustLevel_Dart>()(ptr.ref.lpVtbl, trustLevel);
+  int GetTrustLevel(Pointer<Uint32> trustLevel) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_GetTrustLevel_Native>>>()
+      .value
+      .asFunction<_GetTrustLevel_Dart>()(ptr.ref.lpVtbl, trustLevel);
 }

--- a/lib/src/com/IKnownFolder.dart
+++ b/lib/src/com/IKnownFolder.dart
@@ -71,49 +71,63 @@ class IKnownFolder extends IUnknown {
 
   IKnownFolder(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetId(Pointer<GUID> pkfid) =>
-      Pointer<NativeFunction<_GetId_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetId_Dart>()(ptr.ref.lpVtbl, pkfid);
+  int GetId(Pointer<GUID> pkfid) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetId_Native>>>()
+      .value
+      .asFunction<_GetId_Dart>()(ptr.ref.lpVtbl, pkfid);
 
-  int GetCategory(Pointer<Uint32> pCategory) =>
-      Pointer<NativeFunction<_GetCategory_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetCategory_Dart>()(ptr.ref.lpVtbl, pCategory);
+  int GetCategory(Pointer<Uint32> pCategory) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetCategory_Native>>>()
+      .value
+      .asFunction<_GetCategory_Dart>()(ptr.ref.lpVtbl, pCategory);
 
   int GetShellItem(int dwFlags, Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_GetShellItem_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(5)
+          .cast<Pointer<NativeFunction<_GetShellItem_Native>>>()
+          .value
           .asFunction<_GetShellItem_Dart>()(ptr.ref.lpVtbl, dwFlags, riid, ppv);
 
   int GetPath(int dwFlags, Pointer<Pointer<Utf16>> ppszPath) =>
-      Pointer<NativeFunction<_GetPath_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<Pointer<NativeFunction<_GetPath_Native>>>()
+          .value
           .asFunction<_GetPath_Dart>()(ptr.ref.lpVtbl, dwFlags, ppszPath);
 
-  int SetPath(int dwFlags, Pointer<Utf16> pszPath) =>
-      Pointer<NativeFunction<_SetPath_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_SetPath_Dart>()(ptr.ref.lpVtbl, dwFlags, pszPath);
+  int SetPath(int dwFlags, Pointer<Utf16> pszPath) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_SetPath_Native>>>()
+      .value
+      .asFunction<_SetPath_Dart>()(ptr.ref.lpVtbl, dwFlags, pszPath);
 
   int GetIDList(int dwFlags, Pointer<Pointer<ITEMIDLIST>> ppidl) =>
-      Pointer<NativeFunction<_GetIDList_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_GetIDList_Native>>>()
+          .value
           .asFunction<_GetIDList_Dart>()(ptr.ref.lpVtbl, dwFlags, ppidl);
 
-  int GetFolderType(Pointer<GUID> pftid) =>
-      Pointer<NativeFunction<_GetFolderType_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_GetFolderType_Dart>()(ptr.ref.lpVtbl, pftid);
+  int GetFolderType(Pointer<GUID> pftid) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_GetFolderType_Native>>>()
+      .value
+      .asFunction<_GetFolderType_Dart>()(ptr.ref.lpVtbl, pftid);
 
-  int GetRedirectionCapabilities(Pointer<Uint32> pCapabilities) =>
-      Pointer<NativeFunction<_GetRedirectionCapabilities_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
-              .asFunction<_GetRedirectionCapabilities_Dart>()(
-          ptr.ref.lpVtbl, pCapabilities);
+  int GetRedirectionCapabilities(Pointer<Uint32> pCapabilities) => ptr
+          .ref.lpVtbl.value
+          .elementAt(10)
+          .cast<Pointer<NativeFunction<_GetRedirectionCapabilities_Native>>>()
+          .value
+          .asFunction<_GetRedirectionCapabilities_Dart>()(
+      ptr.ref.lpVtbl, pCapabilities);
 
   int GetFolderDefinition(Pointer<KNOWNFOLDER_DEFINITION> pKFD) =>
-      Pointer<NativeFunction<_GetFolderDefinition_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(11)
+          .cast<Pointer<NativeFunction<_GetFolderDefinition_Native>>>()
+          .value
           .asFunction<_GetFolderDefinition_Dart>()(ptr.ref.lpVtbl, pKFD);
 }

--- a/lib/src/com/IKnownFolderManager.dart
+++ b/lib/src/com/IKnownFolderManager.dart
@@ -95,53 +95,69 @@ class IKnownFolderManager extends IUnknown {
 
   IKnownFolderManager(Pointer<COMObject> ptr) : super(ptr);
 
-  int FolderIdFromCsidl(int nCsidl, Pointer<GUID> pfid) =>
-      Pointer<NativeFunction<_FolderIdFromCsidl_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_FolderIdFromCsidl_Dart>()(ptr.ref.lpVtbl, nCsidl, pfid);
+  int FolderIdFromCsidl(int nCsidl, Pointer<GUID> pfid) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_FolderIdFromCsidl_Native>>>()
+      .value
+      .asFunction<_FolderIdFromCsidl_Dart>()(ptr.ref.lpVtbl, nCsidl, pfid);
 
   int FolderIdToCsidl(Pointer<GUID> rfid, Pointer<Int32> pnCsidl) =>
-      Pointer<NativeFunction<_FolderIdToCsidl_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(4)
+          .cast<Pointer<NativeFunction<_FolderIdToCsidl_Native>>>()
+          .value
           .asFunction<_FolderIdToCsidl_Dart>()(ptr.ref.lpVtbl, rfid, pnCsidl);
 
   int GetFolderIds(Pointer<Pointer<GUID>> ppKFId, Pointer<Uint32> pCount) =>
-      Pointer<NativeFunction<_GetFolderIds_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(5)
+          .cast<Pointer<NativeFunction<_GetFolderIds_Native>>>()
+          .value
           .asFunction<_GetFolderIds_Dart>()(ptr.ref.lpVtbl, ppKFId, pCount);
 
   int GetFolder(Pointer<GUID> rfid, Pointer<Pointer> ppkf) =>
-      Pointer<NativeFunction<_GetFolder_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<Pointer<NativeFunction<_GetFolder_Native>>>()
+          .value
           .asFunction<_GetFolder_Dart>()(ptr.ref.lpVtbl, rfid, ppkf);
 
   int GetFolderByName(Pointer<Utf16> pszCanonicalName, Pointer<Pointer> ppkf) =>
-      Pointer<NativeFunction<_GetFolderByName_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(7)
+              .cast<Pointer<NativeFunction<_GetFolderByName_Native>>>()
+              .value
               .asFunction<_GetFolderByName_Dart>()(
           ptr.ref.lpVtbl, pszCanonicalName, ppkf);
 
   int RegisterFolder(
           Pointer<GUID> rfid, Pointer<KNOWNFOLDER_DEFINITION> pKFD) =>
-      Pointer<NativeFunction<_RegisterFolder_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_RegisterFolder_Native>>>()
+          .value
           .asFunction<_RegisterFolder_Dart>()(ptr.ref.lpVtbl, rfid, pKFD);
 
-  int UnregisterFolder(Pointer<GUID> rfid) =>
-      Pointer<NativeFunction<_UnregisterFolder_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_UnregisterFolder_Dart>()(ptr.ref.lpVtbl, rfid);
+  int UnregisterFolder(Pointer<GUID> rfid) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_UnregisterFolder_Native>>>()
+      .value
+      .asFunction<_UnregisterFolder_Dart>()(ptr.ref.lpVtbl, rfid);
 
   int FindFolderFromPath(
           Pointer<Utf16> pszPath, int mode, Pointer<Pointer> ppkf) =>
-      Pointer<NativeFunction<_FindFolderFromPath_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(10)
+              .cast<Pointer<NativeFunction<_FindFolderFromPath_Native>>>()
+              .value
               .asFunction<_FindFolderFromPath_Dart>()(
           ptr.ref.lpVtbl, pszPath, mode, ppkf);
 
   int FindFolderFromIDList(Pointer<ITEMIDLIST> pidl, Pointer<Pointer> ppkf) =>
-      Pointer<NativeFunction<_FindFolderFromIDList_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(11)
+          .cast<Pointer<NativeFunction<_FindFolderFromIDList_Native>>>()
+          .value
           .asFunction<_FindFolderFromIDList_Dart>()(ptr.ref.lpVtbl, pidl, ppkf);
 
   int Redirect(
@@ -152,8 +168,10 @@ class IKnownFolderManager extends IUnknown {
           int cFolders,
           Pointer<GUID> pExclusion,
           Pointer<Pointer<Utf16>> ppszError) =>
-      Pointer<NativeFunction<_Redirect_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(12).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(12)
+              .cast<Pointer<NativeFunction<_Redirect_Native>>>()
+              .value
               .asFunction<_Redirect_Dart>()(ptr.ref.lpVtbl, rfid, hwnd, flags,
           pszTargetPath, cFolders, pExclusion, ppszError);
 }

--- a/lib/src/com/IModalWindow.dart
+++ b/lib/src/com/IModalWindow.dart
@@ -32,7 +32,9 @@ class IModalWindow extends IUnknown {
 
   IModalWindow(Pointer<COMObject> ptr) : super(ptr);
 
-  int Show(int hwndOwner) => Pointer<NativeFunction<_Show_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(3).value)
+  int Show(int hwndOwner) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_Show_Native>>>()
+      .value
       .asFunction<_Show_Dart>()(ptr.ref.lpVtbl, hwndOwner);
 }

--- a/lib/src/com/IMoniker.dart
+++ b/lib/src/com/IMoniker.dart
@@ -118,81 +118,103 @@ class IMoniker extends IPersistStream {
 
   int BindToObject(Pointer pbc, Pointer pmkToLeft, Pointer<GUID> riidResult,
           Pointer<Pointer> ppvResult) =>
-      Pointer<NativeFunction<_BindToObject_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(8)
+              .cast<Pointer<NativeFunction<_BindToObject_Native>>>()
+              .value
               .asFunction<_BindToObject_Dart>()(
           ptr.ref.lpVtbl, pbc, pmkToLeft, riidResult, ppvResult);
 
   int BindToStorage(Pointer pbc, Pointer pmkToLeft, Pointer<GUID> riid,
           Pointer<Pointer> ppvObj) =>
-      Pointer<NativeFunction<_BindToStorage_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(9).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(9)
+              .cast<Pointer<NativeFunction<_BindToStorage_Native>>>()
+              .value
               .asFunction<_BindToStorage_Dart>()(
           ptr.ref.lpVtbl, pbc, pmkToLeft, riid, ppvObj);
 
   int Reduce(Pointer pbc, int dwReduceHowFar, Pointer<Pointer> ppmkToLeft,
           Pointer<Pointer> ppmkReduced) =>
-      Pointer<NativeFunction<_Reduce_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(10)
+              .cast<Pointer<NativeFunction<_Reduce_Native>>>()
+              .value
               .asFunction<_Reduce_Dart>()(
           ptr.ref.lpVtbl, pbc, dwReduceHowFar, ppmkToLeft, ppmkReduced);
 
   int ComposeWith(Pointer pmkRight, int fOnlyIfNotGeneric,
           Pointer<Pointer> ppmkComposite) =>
-      Pointer<NativeFunction<_ComposeWith_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(11)
+              .cast<Pointer<NativeFunction<_ComposeWith_Native>>>()
+              .value
               .asFunction<_ComposeWith_Dart>()(
           ptr.ref.lpVtbl, pmkRight, fOnlyIfNotGeneric, ppmkComposite);
 
-  int Enum(int fForward, Pointer<Pointer> ppenumMoniker) =>
-      Pointer<NativeFunction<_Enum_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_Enum_Dart>()(ptr.ref.lpVtbl, fForward, ppenumMoniker);
+  int Enum(int fForward, Pointer<Pointer> ppenumMoniker) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_Enum_Native>>>()
+      .value
+      .asFunction<_Enum_Dart>()(ptr.ref.lpVtbl, fForward, ppenumMoniker);
 
-  int IsEqual(Pointer pmkOtherMoniker) =>
-      Pointer<NativeFunction<_IsEqual_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_IsEqual_Dart>()(ptr.ref.lpVtbl, pmkOtherMoniker);
+  int IsEqual(Pointer pmkOtherMoniker) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_IsEqual_Native>>>()
+      .value
+      .asFunction<_IsEqual_Dart>()(ptr.ref.lpVtbl, pmkOtherMoniker);
 
-  int Hash(Pointer<Uint32> pdwHash) =>
-      Pointer<NativeFunction<_Hash_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(14).value)
-          .asFunction<_Hash_Dart>()(ptr.ref.lpVtbl, pdwHash);
+  int Hash(Pointer<Uint32> pdwHash) => ptr.ref.lpVtbl.value
+      .elementAt(14)
+      .cast<Pointer<NativeFunction<_Hash_Native>>>()
+      .value
+      .asFunction<_Hash_Dart>()(ptr.ref.lpVtbl, pdwHash);
 
   int IsRunning(Pointer pbc, Pointer pmkToLeft, Pointer pmkNewlyRunning) =>
-      Pointer<NativeFunction<_IsRunning_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(15).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(15)
+              .cast<Pointer<NativeFunction<_IsRunning_Native>>>()
+              .value
               .asFunction<_IsRunning_Dart>()(
           ptr.ref.lpVtbl, pbc, pmkToLeft, pmkNewlyRunning);
 
   int GetTimeOfLastChange(
           Pointer pbc, Pointer pmkToLeft, Pointer<FILETIME> pFileTime) =>
-      Pointer<NativeFunction<_GetTimeOfLastChange_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(16).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(16)
+              .cast<Pointer<NativeFunction<_GetTimeOfLastChange_Native>>>()
+              .value
               .asFunction<_GetTimeOfLastChange_Dart>()(
           ptr.ref.lpVtbl, pbc, pmkToLeft, pFileTime);
 
-  int Inverse(Pointer<Pointer> ppmk) =>
-      Pointer<NativeFunction<_Inverse_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(17).value)
-          .asFunction<_Inverse_Dart>()(ptr.ref.lpVtbl, ppmk);
+  int Inverse(Pointer<Pointer> ppmk) => ptr.ref.lpVtbl.value
+      .elementAt(17)
+      .cast<Pointer<NativeFunction<_Inverse_Native>>>()
+      .value
+      .asFunction<_Inverse_Dart>()(ptr.ref.lpVtbl, ppmk);
 
   int CommonPrefixWith(Pointer pmkOther, Pointer<Pointer> ppmkPrefix) =>
-      Pointer<NativeFunction<_CommonPrefixWith_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(18).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(18)
+              .cast<Pointer<NativeFunction<_CommonPrefixWith_Native>>>()
+              .value
               .asFunction<_CommonPrefixWith_Dart>()(
           ptr.ref.lpVtbl, pmkOther, ppmkPrefix);
 
   int RelativePathTo(Pointer pmkOther, Pointer<Pointer> ppmkRelPath) =>
-      Pointer<NativeFunction<_RelativePathTo_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(19).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(19)
+              .cast<Pointer<NativeFunction<_RelativePathTo_Native>>>()
+              .value
               .asFunction<_RelativePathTo_Dart>()(
           ptr.ref.lpVtbl, pmkOther, ppmkRelPath);
 
   int GetDisplayName(Pointer pbc, Pointer pmkToLeft,
           Pointer<Pointer<Utf16>> ppszDisplayName) =>
-      Pointer<NativeFunction<_GetDisplayName_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(20).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(20)
+              .cast<Pointer<NativeFunction<_GetDisplayName_Native>>>()
+              .value
               .asFunction<_GetDisplayName_Dart>()(
           ptr.ref.lpVtbl, pbc, pmkToLeft, ppszDisplayName);
 
@@ -202,13 +224,16 @@ class IMoniker extends IPersistStream {
           Pointer<Utf16> pszDisplayName,
           Pointer<Uint32> pchEaten,
           Pointer<Pointer> ppmkOut) =>
-      Pointer<NativeFunction<_ParseDisplayName_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(21).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(21)
+              .cast<Pointer<NativeFunction<_ParseDisplayName_Native>>>()
+              .value
               .asFunction<_ParseDisplayName_Dart>()(
           ptr.ref.lpVtbl, pbc, pmkToLeft, pszDisplayName, pchEaten, ppmkOut);
 
-  int IsSystemMoniker(Pointer<Uint32> pdwMksys) =>
-      Pointer<NativeFunction<_IsSystemMoniker_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(22).value)
-          .asFunction<_IsSystemMoniker_Dart>()(ptr.ref.lpVtbl, pdwMksys);
+  int IsSystemMoniker(Pointer<Uint32> pdwMksys) => ptr.ref.lpVtbl.value
+      .elementAt(22)
+      .cast<Pointer<NativeFunction<_IsSystemMoniker_Native>>>()
+      .value
+      .asFunction<_IsSystemMoniker_Dart>()(ptr.ref.lpVtbl, pdwMksys);
 }

--- a/lib/src/com/INetwork.dart
+++ b/lib/src/com/INetwork.dart
@@ -165,12 +165,13 @@ class INetwork extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_IsConnectedToInternet_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(15).value)
-              .asFunction<_get_IsConnectedToInternet_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(15)
+          .cast<Pointer<NativeFunction<_get_IsConnectedToInternet_Native>>>()
+          .value
+          .asFunction<
+              _get_IsConnectedToInternet_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -184,9 +185,12 @@ class INetwork extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_IsConnected_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(16).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(16)
+          .cast<Pointer<NativeFunction<_get_IsConnected_Native>>>()
+          .value
           .asFunction<_get_IsConnected_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/INetwork.dart
+++ b/lib/src/com/INetwork.dart
@@ -100,39 +100,48 @@ class INetwork extends IDispatch {
 
   INetwork(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetName(Pointer<Pointer<Utf16>> pszNetworkName) =>
-      Pointer<NativeFunction<_GetName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, pszNetworkName);
+  int GetName(Pointer<Pointer<Utf16>> pszNetworkName) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetName_Native>>>()
+      .value
+      .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, pszNetworkName);
 
-  int SetName(Pointer<Utf16> szNetworkNewName) =>
-      Pointer<NativeFunction<_SetName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
-          .asFunction<_SetName_Dart>()(ptr.ref.lpVtbl, szNetworkNewName);
+  int SetName(Pointer<Utf16> szNetworkNewName) => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_SetName_Native>>>()
+      .value
+      .asFunction<_SetName_Dart>()(ptr.ref.lpVtbl, szNetworkNewName);
 
   int GetDescription(Pointer<Pointer<Utf16>> pszDescription) =>
-      Pointer<NativeFunction<_GetDescription_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(9)
+          .cast<Pointer<NativeFunction<_GetDescription_Native>>>()
+          .value
           .asFunction<_GetDescription_Dart>()(ptr.ref.lpVtbl, pszDescription);
 
-  int SetDescription(Pointer<Utf16> szDescription) =>
-      Pointer<NativeFunction<_SetDescription_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_SetDescription_Dart>()(ptr.ref.lpVtbl, szDescription);
+  int SetDescription(Pointer<Utf16> szDescription) => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_SetDescription_Native>>>()
+      .value
+      .asFunction<_SetDescription_Dart>()(ptr.ref.lpVtbl, szDescription);
 
-  int GetNetworkId(Pointer<GUID> pgdGuidNetworkId) =>
-      Pointer<NativeFunction<_GetNetworkId_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_GetNetworkId_Dart>()(ptr.ref.lpVtbl, pgdGuidNetworkId);
+  int GetNetworkId(Pointer<GUID> pgdGuidNetworkId) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_GetNetworkId_Native>>>()
+      .value
+      .asFunction<_GetNetworkId_Dart>()(ptr.ref.lpVtbl, pgdGuidNetworkId);
 
-  int GetDomainType(Pointer<Uint32> pNetworkType) =>
-      Pointer<NativeFunction<_GetDomainType_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_GetDomainType_Dart>()(ptr.ref.lpVtbl, pNetworkType);
+  int GetDomainType(Pointer<Uint32> pNetworkType) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_GetDomainType_Native>>>()
+      .value
+      .asFunction<_GetDomainType_Dart>()(ptr.ref.lpVtbl, pNetworkType);
 
   int GetNetworkConnections(Pointer<Pointer> ppEnumNetworkConnection) =>
-      Pointer<NativeFunction<_GetNetworkConnections_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(13).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(13)
+              .cast<Pointer<NativeFunction<_GetNetworkConnections_Native>>>()
+              .value
               .asFunction<_GetNetworkConnections_Dart>()(
           ptr.ref.lpVtbl, ppEnumNetworkConnection);
 
@@ -141,8 +150,10 @@ class INetwork extends IDispatch {
           Pointer<Uint32> pdwHighDateTimeCreated,
           Pointer<Uint32> pdwLowDateTimeConnected,
           Pointer<Uint32> pdwHighDateTimeConnected) =>
-      Pointer<NativeFunction<_GetTimeCreatedAndConnected_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(14).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(14)
+              .cast<Pointer<NativeFunction<_GetTimeCreatedAndConnected_Native>>>()
+              .value
               .asFunction<_GetTimeCreatedAndConnected_Dart>()(
           ptr.ref.lpVtbl,
           pdwLowDateTimeCreated,
@@ -185,18 +196,21 @@ class INetwork extends IDispatch {
     }
   }
 
-  int GetConnectivity(Pointer<Uint32> pConnectivity) =>
-      Pointer<NativeFunction<_GetConnectivity_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(17).value)
-          .asFunction<_GetConnectivity_Dart>()(ptr.ref.lpVtbl, pConnectivity);
+  int GetConnectivity(Pointer<Uint32> pConnectivity) => ptr.ref.lpVtbl.value
+      .elementAt(17)
+      .cast<Pointer<NativeFunction<_GetConnectivity_Native>>>()
+      .value
+      .asFunction<_GetConnectivity_Dart>()(ptr.ref.lpVtbl, pConnectivity);
 
-  int GetCategory(Pointer<Uint32> pCategory) =>
-      Pointer<NativeFunction<_GetCategory_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(18).value)
-          .asFunction<_GetCategory_Dart>()(ptr.ref.lpVtbl, pCategory);
+  int GetCategory(Pointer<Uint32> pCategory) => ptr.ref.lpVtbl.value
+      .elementAt(18)
+      .cast<Pointer<NativeFunction<_GetCategory_Native>>>()
+      .value
+      .asFunction<_GetCategory_Dart>()(ptr.ref.lpVtbl, pCategory);
 
-  int SetCategory(int NewCategory) =>
-      Pointer<NativeFunction<_SetCategory_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(19).value)
-          .asFunction<_SetCategory_Dart>()(ptr.ref.lpVtbl, NewCategory);
+  int SetCategory(int NewCategory) => ptr.ref.lpVtbl.value
+      .elementAt(19)
+      .cast<Pointer<NativeFunction<_SetCategory_Native>>>()
+      .value
+      .asFunction<_SetCategory_Dart>()(ptr.ref.lpVtbl, NewCategory);
 }

--- a/lib/src/com/INetworkConnection.dart
+++ b/lib/src/com/INetworkConnection.dart
@@ -64,10 +64,11 @@ class INetworkConnection extends IDispatch {
 
   INetworkConnection(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetNetwork(Pointer<Pointer> ppNetwork) =>
-      Pointer<NativeFunction<_GetNetwork_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetNetwork_Dart>()(ptr.ref.lpVtbl, ppNetwork);
+  int GetNetwork(Pointer<Pointer> ppNetwork) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetNetwork_Native>>>()
+      .value
+      .asFunction<_GetNetwork_Dart>()(ptr.ref.lpVtbl, ppNetwork);
 
   int get IsConnectedToInternet {
     final retValuePtr = calloc<Int16>();
@@ -104,23 +105,27 @@ class INetworkConnection extends IDispatch {
     }
   }
 
-  int GetConnectivity(Pointer<Uint32> pConnectivity) =>
-      Pointer<NativeFunction<_GetConnectivity_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_GetConnectivity_Dart>()(ptr.ref.lpVtbl, pConnectivity);
+  int GetConnectivity(Pointer<Uint32> pConnectivity) => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_GetConnectivity_Native>>>()
+      .value
+      .asFunction<_GetConnectivity_Dart>()(ptr.ref.lpVtbl, pConnectivity);
 
-  int GetConnectionId(Pointer<GUID> pgdConnectionId) =>
-      Pointer<NativeFunction<_GetConnectionId_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_GetConnectionId_Dart>()(ptr.ref.lpVtbl, pgdConnectionId);
+  int GetConnectionId(Pointer<GUID> pgdConnectionId) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_GetConnectionId_Native>>>()
+      .value
+      .asFunction<_GetConnectionId_Dart>()(ptr.ref.lpVtbl, pgdConnectionId);
 
-  int GetAdapterId(Pointer<GUID> pgdAdapterId) =>
-      Pointer<NativeFunction<_GetAdapterId_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_GetAdapterId_Dart>()(ptr.ref.lpVtbl, pgdAdapterId);
+  int GetAdapterId(Pointer<GUID> pgdAdapterId) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_GetAdapterId_Native>>>()
+      .value
+      .asFunction<_GetAdapterId_Dart>()(ptr.ref.lpVtbl, pgdAdapterId);
 
-  int GetDomainType(Pointer<Uint32> pDomainType) =>
-      Pointer<NativeFunction<_GetDomainType_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_GetDomainType_Dart>()(ptr.ref.lpVtbl, pDomainType);
+  int GetDomainType(Pointer<Uint32> pDomainType) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_GetDomainType_Native>>>()
+      .value
+      .asFunction<_GetDomainType_Dart>()(ptr.ref.lpVtbl, pDomainType);
 }

--- a/lib/src/com/INetworkConnection.dart
+++ b/lib/src/com/INetworkConnection.dart
@@ -74,12 +74,13 @@ class INetworkConnection extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_IsConnectedToInternet_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
-              .asFunction<_get_IsConnectedToInternet_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_get_IsConnectedToInternet_Native>>>()
+          .value
+          .asFunction<
+              _get_IsConnectedToInternet_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -93,9 +94,12 @@ class INetworkConnection extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_IsConnected_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(9)
+          .cast<Pointer<NativeFunction<_get_IsConnected_Native>>>()
+          .value
           .asFunction<_get_IsConnected_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/INetworkListManager.dart
+++ b/lib/src/com/INetworkListManager.dart
@@ -108,12 +108,13 @@ class INetworkListManager extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = Pointer<
-                      NativeFunction<
-                          _get_IsConnectedToInternet_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(11).value)
-              .asFunction<_get_IsConnectedToInternet_Dart>()(
-          ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(11)
+          .cast<Pointer<NativeFunction<_get_IsConnectedToInternet_Native>>>()
+          .value
+          .asFunction<
+              _get_IsConnectedToInternet_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -127,9 +128,12 @@ class INetworkListManager extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_IsConnected_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(12)
+          .cast<Pointer<NativeFunction<_get_IsConnected_Native>>>()
+          .value
           .asFunction<_get_IsConnected_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/INetworkListManager.dart
+++ b/lib/src/com/INetworkListManager.dart
@@ -75,27 +75,32 @@ class INetworkListManager extends IDispatch {
 
   INetworkListManager(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetNetworks(int Flags, Pointer<Pointer> ppEnumNetwork) =>
-      Pointer<NativeFunction<_GetNetworks_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(7).value)
-              .asFunction<_GetNetworks_Dart>()(
-          ptr.ref.lpVtbl, Flags, ppEnumNetwork);
+  int GetNetworks(int Flags, Pointer<Pointer> ppEnumNetwork) => ptr
+      .ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetNetworks_Native>>>()
+      .value
+      .asFunction<_GetNetworks_Dart>()(ptr.ref.lpVtbl, Flags, ppEnumNetwork);
 
-  int GetNetwork(GUID gdNetworkId, Pointer<Pointer> ppNetwork) =>
-      Pointer<NativeFunction<_GetNetwork_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
-              .asFunction<_GetNetwork_Dart>()(
-          ptr.ref.lpVtbl, gdNetworkId, ppNetwork);
+  int GetNetwork(GUID gdNetworkId, Pointer<Pointer> ppNetwork) => ptr
+      .ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_GetNetwork_Native>>>()
+      .value
+      .asFunction<_GetNetwork_Dart>()(ptr.ref.lpVtbl, gdNetworkId, ppNetwork);
 
-  int GetNetworkConnections(Pointer<Pointer> ppEnum) =>
-      Pointer<NativeFunction<_GetNetworkConnections_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_GetNetworkConnections_Dart>()(ptr.ref.lpVtbl, ppEnum);
+  int GetNetworkConnections(Pointer<Pointer> ppEnum) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_GetNetworkConnections_Native>>>()
+      .value
+      .asFunction<_GetNetworkConnections_Dart>()(ptr.ref.lpVtbl, ppEnum);
 
   int GetNetworkConnection(
           GUID gdNetworkConnectionId, Pointer<Pointer> ppNetworkConnection) =>
-      Pointer<NativeFunction<_GetNetworkConnection_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(10)
+              .cast<Pointer<NativeFunction<_GetNetworkConnection_Native>>>()
+              .value
               .asFunction<_GetNetworkConnection_Dart>()(
           ptr.ref.lpVtbl, gdNetworkConnectionId, ppNetworkConnection);
 
@@ -134,22 +139,26 @@ class INetworkListManager extends IDispatch {
     }
   }
 
-  int GetConnectivity(Pointer<Uint32> pConnectivity) =>
-      Pointer<NativeFunction<_GetConnectivity_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_GetConnectivity_Dart>()(ptr.ref.lpVtbl, pConnectivity);
+  int GetConnectivity(Pointer<Uint32> pConnectivity) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_GetConnectivity_Native>>>()
+      .value
+      .asFunction<_GetConnectivity_Dart>()(ptr.ref.lpVtbl, pConnectivity);
 
   int SetSimulatedProfileInfo(
           Pointer<NLM_SIMULATED_PROFILE_INFO> pSimulatedInfo) =>
-      Pointer<NativeFunction<_SetSimulatedProfileInfo_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(14).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(14)
+              .cast<Pointer<NativeFunction<_SetSimulatedProfileInfo_Native>>>()
+              .value
               .asFunction<_SetSimulatedProfileInfo_Dart>()(
           ptr.ref.lpVtbl, pSimulatedInfo);
 
-  int ClearSimulatedProfileInfo() =>
-      Pointer<NativeFunction<_ClearSimulatedProfileInfo_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(15).value)
-          .asFunction<_ClearSimulatedProfileInfo_Dart>()(ptr.ref.lpVtbl);
+  int ClearSimulatedProfileInfo() => ptr.ref.lpVtbl.value
+      .elementAt(15)
+      .cast<Pointer<NativeFunction<_ClearSimulatedProfileInfo_Native>>>()
+      .value
+      .asFunction<_ClearSimulatedProfileInfo_Dart>()(ptr.ref.lpVtbl);
 }
 
 /// {@category com}

--- a/lib/src/com/INetworkListManagerEvents.dart
+++ b/lib/src/com/INetworkListManagerEvents.dart
@@ -34,9 +34,9 @@ class INetworkListManagerEvents extends IUnknown {
 
   INetworkListManagerEvents(Pointer<COMObject> ptr) : super(ptr);
 
-  int ConnectivityChanged(int newConnectivity) =>
-      Pointer<NativeFunction<_ConnectivityChanged_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
-              .asFunction<_ConnectivityChanged_Dart>()(
-          ptr.ref.lpVtbl, newConnectivity);
+  int ConnectivityChanged(int newConnectivity) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_ConnectivityChanged_Native>>>()
+      .value
+      .asFunction<_ConnectivityChanged_Dart>()(ptr.ref.lpVtbl, newConnectivity);
 }

--- a/lib/src/com/IPersist.dart
+++ b/lib/src/com/IPersist.dart
@@ -33,8 +33,9 @@ class IPersist extends IUnknown {
 
   IPersist(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetClassID(Pointer<GUID> pClassID) =>
-      Pointer<NativeFunction<_GetClassID_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetClassID_Dart>()(ptr.ref.lpVtbl, pClassID);
+  int GetClassID(Pointer<GUID> pClassID) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetClassID_Native>>>()
+      .value
+      .asFunction<_GetClassID_Dart>()(ptr.ref.lpVtbl, pClassID);
 }

--- a/lib/src/com/IPersistFile.dart
+++ b/lib/src/com/IPersistFile.dart
@@ -52,27 +52,33 @@ class IPersistFile extends IPersist {
 
   IPersistFile(Pointer<COMObject> ptr) : super(ptr);
 
-  int IsDirty() => Pointer<NativeFunction<_IsDirty_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(4).value)
+  int IsDirty() => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_IsDirty_Native>>>()
+      .value
       .asFunction<_IsDirty_Dart>()(ptr.ref.lpVtbl);
 
-  int Load(Pointer<Utf16> pszFileName, int dwMode) =>
-      Pointer<NativeFunction<_Load_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_Load_Dart>()(ptr.ref.lpVtbl, pszFileName, dwMode);
+  int Load(Pointer<Utf16> pszFileName, int dwMode) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_Load_Native>>>()
+      .value
+      .asFunction<_Load_Dart>()(ptr.ref.lpVtbl, pszFileName, dwMode);
 
-  int Save(Pointer<Utf16> pszFileName, int fRemember) =>
-      Pointer<NativeFunction<_Save_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Save_Dart>()(ptr.ref.lpVtbl, pszFileName, fRemember);
+  int Save(Pointer<Utf16> pszFileName, int fRemember) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Save_Native>>>()
+      .value
+      .asFunction<_Save_Dart>()(ptr.ref.lpVtbl, pszFileName, fRemember);
 
-  int SaveCompleted(Pointer<Utf16> pszFileName) =>
-      Pointer<NativeFunction<_SaveCompleted_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_SaveCompleted_Dart>()(ptr.ref.lpVtbl, pszFileName);
+  int SaveCompleted(Pointer<Utf16> pszFileName) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_SaveCompleted_Native>>>()
+      .value
+      .asFunction<_SaveCompleted_Dart>()(ptr.ref.lpVtbl, pszFileName);
 
-  int GetCurFile(Pointer<Pointer<Utf16>> ppszFileName) =>
-      Pointer<NativeFunction<_GetCurFile_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
-          .asFunction<_GetCurFile_Dart>()(ptr.ref.lpVtbl, ppszFileName);
+  int GetCurFile(Pointer<Pointer<Utf16>> ppszFileName) => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_GetCurFile_Native>>>()
+      .value
+      .asFunction<_GetCurFile_Dart>()(ptr.ref.lpVtbl, ppszFileName);
 }

--- a/lib/src/com/IPersistMemory.dart
+++ b/lib/src/com/IPersistMemory.dart
@@ -47,26 +47,33 @@ class IPersistMemory extends IPersist {
 
   IPersistMemory(Pointer<COMObject> ptr) : super(ptr);
 
-  int IsDirty() => Pointer<NativeFunction<_IsDirty_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(4).value)
+  int IsDirty() => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_IsDirty_Native>>>()
+      .value
       .asFunction<_IsDirty_Dart>()(ptr.ref.lpVtbl);
 
-  int Load(Pointer pMem, int cbSize) =>
-      Pointer<NativeFunction<_Load_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_Load_Dart>()(ptr.ref.lpVtbl, pMem, cbSize);
+  int Load(Pointer pMem, int cbSize) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_Load_Native>>>()
+      .value
+      .asFunction<_Load_Dart>()(ptr.ref.lpVtbl, pMem, cbSize);
 
-  int Save(Pointer pMem, int fClearDirty, int cbSize) =>
-      Pointer<NativeFunction<_Save_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Save_Dart>()(ptr.ref.lpVtbl, pMem, fClearDirty, cbSize);
+  int Save(Pointer pMem, int fClearDirty, int cbSize) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Save_Native>>>()
+      .value
+      .asFunction<_Save_Dart>()(ptr.ref.lpVtbl, pMem, fClearDirty, cbSize);
 
-  int GetSizeMax(Pointer<Uint32> pCbSize) =>
-      Pointer<NativeFunction<_GetSizeMax_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetSizeMax_Dart>()(ptr.ref.lpVtbl, pCbSize);
+  int GetSizeMax(Pointer<Uint32> pCbSize) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetSizeMax_Native>>>()
+      .value
+      .asFunction<_GetSizeMax_Dart>()(ptr.ref.lpVtbl, pCbSize);
 
-  int InitNew() => Pointer<NativeFunction<_InitNew_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(8).value)
+  int InitNew() => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_InitNew_Native>>>()
+      .value
       .asFunction<_InitNew_Dart>()(ptr.ref.lpVtbl);
 }

--- a/lib/src/com/IPersistStream.dart
+++ b/lib/src/com/IPersistStream.dart
@@ -43,21 +43,27 @@ class IPersistStream extends IPersist {
 
   IPersistStream(Pointer<COMObject> ptr) : super(ptr);
 
-  int IsDirty() => Pointer<NativeFunction<_IsDirty_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(4).value)
+  int IsDirty() => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_IsDirty_Native>>>()
+      .value
       .asFunction<_IsDirty_Dart>()(ptr.ref.lpVtbl);
 
-  int Load(Pointer pStm) => Pointer<NativeFunction<_Load_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(5).value)
+  int Load(Pointer pStm) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_Load_Native>>>()
+      .value
       .asFunction<_Load_Dart>()(ptr.ref.lpVtbl, pStm);
 
-  int Save(Pointer pStm, int fClearDirty) =>
-      Pointer<NativeFunction<_Save_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Save_Dart>()(ptr.ref.lpVtbl, pStm, fClearDirty);
+  int Save(Pointer pStm, int fClearDirty) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Save_Native>>>()
+      .value
+      .asFunction<_Save_Dart>()(ptr.ref.lpVtbl, pStm, fClearDirty);
 
-  int GetSizeMax(Pointer<Uint64> pcbSize) =>
-      Pointer<NativeFunction<_GetSizeMax_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetSizeMax_Dart>()(ptr.ref.lpVtbl, pcbSize);
+  int GetSizeMax(Pointer<Uint64> pcbSize) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetSizeMax_Native>>>()
+      .value
+      .asFunction<_GetSizeMax_Dart>()(ptr.ref.lpVtbl, pcbSize);
 }

--- a/lib/src/com/IPropertyValue.dart
+++ b/lib/src/com/IPropertyValue.dart
@@ -196,9 +196,12 @@ class IPropertyValue extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Type_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<Pointer<NativeFunction<_get_Type_Native>>>()
+          .value
           .asFunction<_get_Type_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -212,11 +215,12 @@ class IPropertyValue extends IInspectable {
     final retValuePtr = calloc< /* Boolean */ Uint8>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_IsNumericScalar_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(7).value)
-                  .asFunction<_get_IsNumericScalar_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(7)
+          .cast<Pointer<NativeFunction<_get_IsNumericScalar_Native>>>()
+          .value
+          .asFunction<_get_IsNumericScalar_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IPropertyValue.dart
+++ b/lib/src/com/IPropertyValue.dart
@@ -226,206 +226,250 @@ class IPropertyValue extends IInspectable {
     }
   }
 
-  int GetUInt8(Pointer<Uint8> result) =>
-      Pointer<NativeFunction<_GetUInt8_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
-          .asFunction<_GetUInt8_Dart>()(ptr.ref.lpVtbl, result);
+  int GetUInt8(Pointer<Uint8> result) => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_GetUInt8_Native>>>()
+      .value
+      .asFunction<_GetUInt8_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetInt16(Pointer<Int16> result) =>
-      Pointer<NativeFunction<_GetInt16_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_GetInt16_Dart>()(ptr.ref.lpVtbl, result);
+  int GetInt16(Pointer<Int16> result) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_GetInt16_Native>>>()
+      .value
+      .asFunction<_GetInt16_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetUInt16(Pointer<Uint16> result) =>
-      Pointer<NativeFunction<_GetUInt16_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_GetUInt16_Dart>()(ptr.ref.lpVtbl, result);
+  int GetUInt16(Pointer<Uint16> result) => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_GetUInt16_Native>>>()
+      .value
+      .asFunction<_GetUInt16_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetInt32(Pointer<Int32> result) =>
-      Pointer<NativeFunction<_GetInt32_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_GetInt32_Dart>()(ptr.ref.lpVtbl, result);
+  int GetInt32(Pointer<Int32> result) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_GetInt32_Native>>>()
+      .value
+      .asFunction<_GetInt32_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetUInt32(Pointer<Uint32> result) =>
-      Pointer<NativeFunction<_GetUInt32_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_GetUInt32_Dart>()(ptr.ref.lpVtbl, result);
+  int GetUInt32(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_GetUInt32_Native>>>()
+      .value
+      .asFunction<_GetUInt32_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetInt64(Pointer<Int64> result) =>
-      Pointer<NativeFunction<_GetInt64_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_GetInt64_Dart>()(ptr.ref.lpVtbl, result);
+  int GetInt64(Pointer<Int64> result) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_GetInt64_Native>>>()
+      .value
+      .asFunction<_GetInt64_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetUInt64(Pointer<Uint64> result) =>
-      Pointer<NativeFunction<_GetUInt64_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(14).value)
-          .asFunction<_GetUInt64_Dart>()(ptr.ref.lpVtbl, result);
+  int GetUInt64(Pointer<Uint64> result) => ptr.ref.lpVtbl.value
+      .elementAt(14)
+      .cast<Pointer<NativeFunction<_GetUInt64_Native>>>()
+      .value
+      .asFunction<_GetUInt64_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetSingle(Pointer<Float> result) =>
-      Pointer<NativeFunction<_GetSingle_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(15).value)
-          .asFunction<_GetSingle_Dart>()(ptr.ref.lpVtbl, result);
+  int GetSingle(Pointer<Float> result) => ptr.ref.lpVtbl.value
+      .elementAt(15)
+      .cast<Pointer<NativeFunction<_GetSingle_Native>>>()
+      .value
+      .asFunction<_GetSingle_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetDouble(Pointer<Double> result) =>
-      Pointer<NativeFunction<_GetDouble_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(16).value)
-          .asFunction<_GetDouble_Dart>()(ptr.ref.lpVtbl, result);
+  int GetDouble(Pointer<Double> result) => ptr.ref.lpVtbl.value
+      .elementAt(16)
+      .cast<Pointer<NativeFunction<_GetDouble_Native>>>()
+      .value
+      .asFunction<_GetDouble_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetChar16(Pointer<Uint16> result) =>
-      Pointer<NativeFunction<_GetChar16_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(17).value)
-          .asFunction<_GetChar16_Dart>()(ptr.ref.lpVtbl, result);
+  int GetChar16(Pointer<Uint16> result) => ptr.ref.lpVtbl.value
+      .elementAt(17)
+      .cast<Pointer<NativeFunction<_GetChar16_Native>>>()
+      .value
+      .asFunction<_GetChar16_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetBoolean(Pointer< /* Boolean */ Uint8> result) =>
-      Pointer<NativeFunction<_GetBoolean_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(18).value)
-          .asFunction<_GetBoolean_Dart>()(ptr.ref.lpVtbl, result);
+  int GetBoolean(Pointer< /* Boolean */ Uint8> result) => ptr.ref.lpVtbl.value
+      .elementAt(18)
+      .cast<Pointer<NativeFunction<_GetBoolean_Native>>>()
+      .value
+      .asFunction<_GetBoolean_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_GetString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(19).value)
-          .asFunction<_GetString_Dart>()(ptr.ref.lpVtbl, result);
+  int GetString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(19)
+      .cast<Pointer<NativeFunction<_GetString_Native>>>()
+      .value
+      .asFunction<_GetString_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetGuid(Pointer<GUID> result) =>
-      Pointer<NativeFunction<_GetGuid_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(20).value)
-          .asFunction<_GetGuid_Dart>()(ptr.ref.lpVtbl, result);
+  int GetGuid(Pointer<GUID> result) => ptr.ref.lpVtbl.value
+      .elementAt(20)
+      .cast<Pointer<NativeFunction<_GetGuid_Native>>>()
+      .value
+      .asFunction<_GetGuid_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetDateTime(Pointer<Uint32> result) =>
-      Pointer<NativeFunction<_GetDateTime_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(21).value)
-          .asFunction<_GetDateTime_Dart>()(ptr.ref.lpVtbl, result);
+  int GetDateTime(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+      .elementAt(21)
+      .cast<Pointer<NativeFunction<_GetDateTime_Native>>>()
+      .value
+      .asFunction<_GetDateTime_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetTimeSpan(Pointer<Uint32> result) =>
-      Pointer<NativeFunction<_GetTimeSpan_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(22).value)
-          .asFunction<_GetTimeSpan_Dart>()(ptr.ref.lpVtbl, result);
+  int GetTimeSpan(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+      .elementAt(22)
+      .cast<Pointer<NativeFunction<_GetTimeSpan_Native>>>()
+      .value
+      .asFunction<_GetTimeSpan_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetPoint(Pointer<Uint32> result) =>
-      Pointer<NativeFunction<_GetPoint_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(23).value)
-          .asFunction<_GetPoint_Dart>()(ptr.ref.lpVtbl, result);
+  int GetPoint(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+      .elementAt(23)
+      .cast<Pointer<NativeFunction<_GetPoint_Native>>>()
+      .value
+      .asFunction<_GetPoint_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetSize(Pointer<Uint32> result) =>
-      Pointer<NativeFunction<_GetSize_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(24).value)
-          .asFunction<_GetSize_Dart>()(ptr.ref.lpVtbl, result);
+  int GetSize(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+      .elementAt(24)
+      .cast<Pointer<NativeFunction<_GetSize_Native>>>()
+      .value
+      .asFunction<_GetSize_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetRect(Pointer<Uint32> result) =>
-      Pointer<NativeFunction<_GetRect_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(25).value)
-          .asFunction<_GetRect_Dart>()(ptr.ref.lpVtbl, result);
+  int GetRect(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+      .elementAt(25)
+      .cast<Pointer<NativeFunction<_GetRect_Native>>>()
+      .value
+      .asFunction<_GetRect_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetUInt8Array(Pointer<Uint32> __valueSize, Pointer<Uint8> value) =>
-      Pointer<NativeFunction<_GetUInt8Array_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(26).value)
-              .asFunction<_GetUInt8Array_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetUInt8Array(Pointer<Uint32> __valueSize, Pointer<Uint8> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(26)
+      .cast<Pointer<NativeFunction<_GetUInt8Array_Native>>>()
+      .value
+      .asFunction<_GetUInt8Array_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetInt16Array(Pointer<Uint32> __valueSize, Pointer<Int16> value) =>
-      Pointer<NativeFunction<_GetInt16Array_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(27).value)
-              .asFunction<_GetInt16Array_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetInt16Array(Pointer<Uint32> __valueSize, Pointer<Int16> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(27)
+      .cast<Pointer<NativeFunction<_GetInt16Array_Native>>>()
+      .value
+      .asFunction<_GetInt16Array_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetUInt16Array(Pointer<Uint32> __valueSize, Pointer<Uint16> value) =>
-      Pointer<NativeFunction<_GetUInt16Array_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(28).value)
-              .asFunction<_GetUInt16Array_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetUInt16Array(Pointer<Uint32> __valueSize, Pointer<Uint16> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(28)
+      .cast<Pointer<NativeFunction<_GetUInt16Array_Native>>>()
+      .value
+      .asFunction<_GetUInt16Array_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetInt32Array(Pointer<Uint32> __valueSize, Pointer<Int32> value) =>
-      Pointer<NativeFunction<_GetInt32Array_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(29).value)
-              .asFunction<_GetInt32Array_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetInt32Array(Pointer<Uint32> __valueSize, Pointer<Int32> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(29)
+      .cast<Pointer<NativeFunction<_GetInt32Array_Native>>>()
+      .value
+      .asFunction<_GetInt32Array_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetUInt32Array(Pointer<Uint32> __valueSize, Pointer<Uint32> value) =>
-      Pointer<NativeFunction<_GetUInt32Array_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(30).value)
-              .asFunction<_GetUInt32Array_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetUInt32Array(Pointer<Uint32> __valueSize, Pointer<Uint32> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(30)
+      .cast<Pointer<NativeFunction<_GetUInt32Array_Native>>>()
+      .value
+      .asFunction<_GetUInt32Array_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetInt64Array(Pointer<Uint32> __valueSize, Pointer<Int64> value) =>
-      Pointer<NativeFunction<_GetInt64Array_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(31).value)
-              .asFunction<_GetInt64Array_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetInt64Array(Pointer<Uint32> __valueSize, Pointer<Int64> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(31)
+      .cast<Pointer<NativeFunction<_GetInt64Array_Native>>>()
+      .value
+      .asFunction<_GetInt64Array_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetUInt64Array(Pointer<Uint32> __valueSize, Pointer<Uint64> value) =>
-      Pointer<NativeFunction<_GetUInt64Array_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(32).value)
-              .asFunction<_GetUInt64Array_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetUInt64Array(Pointer<Uint32> __valueSize, Pointer<Uint64> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(32)
+      .cast<Pointer<NativeFunction<_GetUInt64Array_Native>>>()
+      .value
+      .asFunction<_GetUInt64Array_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetSingleArray(Pointer<Uint32> __valueSize, Pointer<Float> value) =>
-      Pointer<NativeFunction<_GetSingleArray_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(33).value)
-              .asFunction<_GetSingleArray_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetSingleArray(Pointer<Uint32> __valueSize, Pointer<Float> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(33)
+      .cast<Pointer<NativeFunction<_GetSingleArray_Native>>>()
+      .value
+      .asFunction<_GetSingleArray_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetDoubleArray(Pointer<Uint32> __valueSize, Pointer<Double> value) =>
-      Pointer<NativeFunction<_GetDoubleArray_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(34).value)
-              .asFunction<_GetDoubleArray_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetDoubleArray(Pointer<Uint32> __valueSize, Pointer<Double> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(34)
+      .cast<Pointer<NativeFunction<_GetDoubleArray_Native>>>()
+      .value
+      .asFunction<_GetDoubleArray_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetChar16Array(Pointer<Uint32> __valueSize, Pointer<Uint16> value) =>
-      Pointer<NativeFunction<_GetChar16Array_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(35).value)
-              .asFunction<_GetChar16Array_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetChar16Array(Pointer<Uint32> __valueSize, Pointer<Uint16> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(35)
+      .cast<Pointer<NativeFunction<_GetChar16Array_Native>>>()
+      .value
+      .asFunction<_GetChar16Array_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
   int GetBooleanArray(
           Pointer<Uint32> __valueSize, Pointer< /* Boolean */ Uint8> value) =>
-      Pointer<NativeFunction<_GetBooleanArray_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(36).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(36)
+              .cast<Pointer<NativeFunction<_GetBooleanArray_Native>>>()
+              .value
               .asFunction<_GetBooleanArray_Dart>()(
           ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetStringArray(Pointer<Uint32> __valueSize, Pointer<IntPtr> value) =>
-      Pointer<NativeFunction<_GetStringArray_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(37).value)
-              .asFunction<_GetStringArray_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetStringArray(Pointer<Uint32> __valueSize, Pointer<IntPtr> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(37)
+      .cast<Pointer<NativeFunction<_GetStringArray_Native>>>()
+      .value
+      .asFunction<_GetStringArray_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
   int GetInspectableArray(
           Pointer<Uint32> __valueSize, Pointer<COMObject> value) =>
-      Pointer<NativeFunction<_GetInspectableArray_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(38).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(38)
+              .cast<Pointer<NativeFunction<_GetInspectableArray_Native>>>()
+              .value
               .asFunction<_GetInspectableArray_Dart>()(
           ptr.ref.lpVtbl, __valueSize, value);
 
   int GetGuidArray(Pointer<Uint32> __valueSize, Pointer<GUID> value) =>
-      Pointer<NativeFunction<_GetGuidArray_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(39).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(39)
+          .cast<Pointer<NativeFunction<_GetGuidArray_Native>>>()
+          .value
           .asFunction<_GetGuidArray_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
   int GetDateTimeArray(Pointer<Uint32> __valueSize, Pointer<Uint32> value) =>
-      Pointer<NativeFunction<_GetDateTimeArray_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(40).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(40)
+              .cast<Pointer<NativeFunction<_GetDateTimeArray_Native>>>()
+              .value
               .asFunction<_GetDateTimeArray_Dart>()(
           ptr.ref.lpVtbl, __valueSize, value);
 
   int GetTimeSpanArray(Pointer<Uint32> __valueSize, Pointer<Uint32> value) =>
-      Pointer<NativeFunction<_GetTimeSpanArray_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(41).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(41)
+              .cast<Pointer<NativeFunction<_GetTimeSpanArray_Native>>>()
+              .value
               .asFunction<_GetTimeSpanArray_Dart>()(
           ptr.ref.lpVtbl, __valueSize, value);
 
-  int GetPointArray(Pointer<Uint32> __valueSize, Pointer<Uint32> value) =>
-      Pointer<NativeFunction<_GetPointArray_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(42).value)
-              .asFunction<_GetPointArray_Dart>()(
-          ptr.ref.lpVtbl, __valueSize, value);
+  int GetPointArray(Pointer<Uint32> __valueSize, Pointer<Uint32> value) => ptr
+      .ref.lpVtbl.value
+      .elementAt(42)
+      .cast<Pointer<NativeFunction<_GetPointArray_Native>>>()
+      .value
+      .asFunction<_GetPointArray_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
   int GetSizeArray(Pointer<Uint32> __valueSize, Pointer<Uint32> value) =>
-      Pointer<NativeFunction<_GetSizeArray_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(43).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(43)
+          .cast<Pointer<NativeFunction<_GetSizeArray_Native>>>()
+          .value
           .asFunction<_GetSizeArray_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
   int GetRectArray(Pointer<Uint32> __valueSize, Pointer<Uint32> value) =>
-      Pointer<NativeFunction<_GetRectArray_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(44).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(44)
+          .cast<Pointer<NativeFunction<_GetRectArray_Native>>>()
+          .value
           .asFunction<_GetRectArray_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 }

--- a/lib/src/com/IProvideClassInfo.dart
+++ b/lib/src/com/IProvideClassInfo.dart
@@ -33,8 +33,9 @@ class IProvideClassInfo extends IUnknown {
 
   IProvideClassInfo(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetClassInfo(Pointer<Pointer> ppTI) =>
-      Pointer<NativeFunction<_GetClassInfo_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetClassInfo_Dart>()(ptr.ref.lpVtbl, ppTI);
+  int GetClassInfo(Pointer<Pointer> ppTI) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetClassInfo_Native>>>()
+      .value
+      .asFunction<_GetClassInfo_Dart>()(ptr.ref.lpVtbl, ppTI);
 }

--- a/lib/src/com/IRunningObjectTable.dart
+++ b/lib/src/com/IRunningObjectTable.dart
@@ -62,41 +62,52 @@ class IRunningObjectTable extends IUnknown {
 
   int Register(int grfFlags, Pointer punkObject, Pointer pmkObjectName,
           Pointer<Uint32> pdwRegister) =>
-      Pointer<NativeFunction<_Register_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_Register_Native>>>()
+              .value
               .asFunction<_Register_Dart>()(
           ptr.ref.lpVtbl, grfFlags, punkObject, pmkObjectName, pdwRegister);
 
-  int Revoke(int dwRegister) =>
-      Pointer<NativeFunction<_Revoke_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_Revoke_Dart>()(ptr.ref.lpVtbl, dwRegister);
+  int Revoke(int dwRegister) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_Revoke_Native>>>()
+      .value
+      .asFunction<_Revoke_Dart>()(ptr.ref.lpVtbl, dwRegister);
 
-  int IsRunning(Pointer pmkObjectName) =>
-      Pointer<NativeFunction<_IsRunning_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_IsRunning_Dart>()(ptr.ref.lpVtbl, pmkObjectName);
+  int IsRunning(Pointer pmkObjectName) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_IsRunning_Native>>>()
+      .value
+      .asFunction<_IsRunning_Dart>()(ptr.ref.lpVtbl, pmkObjectName);
 
   int GetObject(Pointer pmkObjectName, Pointer<Pointer> ppunkObject) =>
-      Pointer<NativeFunction<_GetObject_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(6)
+              .cast<Pointer<NativeFunction<_GetObject_Native>>>()
+              .value
               .asFunction<_GetObject_Dart>()(
           ptr.ref.lpVtbl, pmkObjectName, ppunkObject);
 
   int NoteChangeTime(int dwRegister, Pointer<FILETIME> pfiletime) =>
-      Pointer<NativeFunction<_NoteChangeTime_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(7)
+              .cast<Pointer<NativeFunction<_NoteChangeTime_Native>>>()
+              .value
               .asFunction<_NoteChangeTime_Dart>()(
           ptr.ref.lpVtbl, dwRegister, pfiletime);
 
   int GetTimeOfLastChange(Pointer pmkObjectName, Pointer<FILETIME> pfiletime) =>
-      Pointer<NativeFunction<_GetTimeOfLastChange_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(8)
+              .cast<Pointer<NativeFunction<_GetTimeOfLastChange_Native>>>()
+              .value
               .asFunction<_GetTimeOfLastChange_Dart>()(
           ptr.ref.lpVtbl, pmkObjectName, pfiletime);
 
-  int EnumRunning(Pointer<Pointer> ppenumMoniker) =>
-      Pointer<NativeFunction<_EnumRunning_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_EnumRunning_Dart>()(ptr.ref.lpVtbl, ppenumMoniker);
+  int EnumRunning(Pointer<Pointer> ppenumMoniker) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_EnumRunning_Native>>>()
+      .value
+      .asFunction<_EnumRunning_Dart>()(ptr.ref.lpVtbl, ppenumMoniker);
 }

--- a/lib/src/com/ISequentialStream.dart
+++ b/lib/src/com/ISequentialStream.dart
@@ -39,13 +39,16 @@ class ISequentialStream extends IUnknown {
 
   ISequentialStream(Pointer<COMObject> ptr) : super(ptr);
 
-  int Read(Pointer pv, int cb, Pointer<Uint32> pcbRead) =>
-      Pointer<NativeFunction<_Read_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_Read_Dart>()(ptr.ref.lpVtbl, pv, cb, pcbRead);
+  int Read(Pointer pv, int cb, Pointer<Uint32> pcbRead) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_Read_Native>>>()
+      .value
+      .asFunction<_Read_Dart>()(ptr.ref.lpVtbl, pv, cb, pcbRead);
 
   int Write(Pointer pv, int cb, Pointer<Uint32> pcbWritten) =>
-      Pointer<NativeFunction<_Write_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(4)
+          .cast<Pointer<NativeFunction<_Write_Native>>>()
+          .value
           .asFunction<_Write_Dart>()(ptr.ref.lpVtbl, pv, cb, pcbWritten);
 }

--- a/lib/src/com/IShellFolder.dart
+++ b/lib/src/com/IShellFolder.dart
@@ -132,48 +132,62 @@ class IShellFolder extends IUnknown {
           Pointer<Uint32> pchEaten,
           Pointer<Pointer<ITEMIDLIST>> ppidl,
           Pointer<Uint32> pdwAttributes) =>
-      Pointer<NativeFunction<_ParseDisplayName_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_ParseDisplayName_Native>>>()
+              .value
               .asFunction<_ParseDisplayName_Dart>()(ptr.ref.lpVtbl, hwnd, pbc,
           pszDisplayName, pchEaten, ppidl, pdwAttributes);
 
   int EnumObjects(int hwnd, int grfFlags, Pointer<Pointer> ppenumIDList) =>
-      Pointer<NativeFunction<_EnumObjects_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_EnumObjects_Native>>>()
+              .value
               .asFunction<_EnumObjects_Dart>()(
           ptr.ref.lpVtbl, hwnd, grfFlags, ppenumIDList);
 
   int BindToObject(Pointer<ITEMIDLIST> pidl, Pointer pbc, Pointer<GUID> riid,
           Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_BindToObject_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_BindToObject_Native>>>()
+              .value
               .asFunction<_BindToObject_Dart>()(
           ptr.ref.lpVtbl, pidl, pbc, riid, ppv);
 
   int BindToStorage(Pointer<ITEMIDLIST> pidl, Pointer pbc, Pointer<GUID> riid,
           Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_BindToStorage_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(6)
+              .cast<Pointer<NativeFunction<_BindToStorage_Native>>>()
+              .value
               .asFunction<_BindToStorage_Dart>()(
           ptr.ref.lpVtbl, pidl, pbc, riid, ppv);
 
   int CompareIDs(
           int lParam, Pointer<ITEMIDLIST> pidl1, Pointer<ITEMIDLIST> pidl2) =>
-      Pointer<NativeFunction<_CompareIDs_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(7)
+          .cast<Pointer<NativeFunction<_CompareIDs_Native>>>()
+          .value
           .asFunction<_CompareIDs_Dart>()(ptr.ref.lpVtbl, lParam, pidl1, pidl2);
 
   int CreateViewObject(
           int hwndOwner, Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_CreateViewObject_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(8)
+              .cast<Pointer<NativeFunction<_CreateViewObject_Native>>>()
+              .value
               .asFunction<_CreateViewObject_Dart>()(
           ptr.ref.lpVtbl, hwndOwner, riid, ppv);
 
   int GetAttributesOf(int cidl, Pointer<Pointer<ITEMIDLIST>> apidl,
           Pointer<Uint32> rgfInOut) =>
-      Pointer<NativeFunction<_GetAttributesOf_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(9).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(9)
+              .cast<Pointer<NativeFunction<_GetAttributesOf_Native>>>()
+              .value
               .asFunction<_GetAttributesOf_Dart>()(
           ptr.ref.lpVtbl, cidl, apidl, rgfInOut);
 
@@ -184,22 +198,28 @@ class IShellFolder extends IUnknown {
           Pointer<GUID> riid,
           Pointer<Uint32> rgfReserved,
           Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_GetUIObjectOf_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(10)
+              .cast<Pointer<NativeFunction<_GetUIObjectOf_Native>>>()
+              .value
               .asFunction<_GetUIObjectOf_Dart>()(
           ptr.ref.lpVtbl, hwndOwner, cidl, apidl, riid, rgfReserved, ppv);
 
   int GetDisplayNameOf(
           Pointer<ITEMIDLIST> pidl, int uFlags, Pointer<STRRET> pName) =>
-      Pointer<NativeFunction<_GetDisplayNameOf_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(11)
+              .cast<Pointer<NativeFunction<_GetDisplayNameOf_Native>>>()
+              .value
               .asFunction<_GetDisplayNameOf_Dart>()(
           ptr.ref.lpVtbl, pidl, uFlags, pName);
 
   int SetNameOf(int hwnd, Pointer<ITEMIDLIST> pidl, Pointer<Utf16> pszName,
           int uFlags, Pointer<Pointer<ITEMIDLIST>> ppidlOut) =>
-      Pointer<NativeFunction<_SetNameOf_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(12).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(12)
+              .cast<Pointer<NativeFunction<_SetNameOf_Native>>>()
+              .value
               .asFunction<_SetNameOf_Dart>()(
           ptr.ref.lpVtbl, hwnd, pidl, pszName, uFlags, ppidlOut);
 }

--- a/lib/src/com/IShellItem.dart
+++ b/lib/src/com/IShellItem.dart
@@ -57,31 +57,39 @@ class IShellItem extends IUnknown {
 
   int BindToHandler(Pointer pbc, Pointer<GUID> bhid, Pointer<GUID> riid,
           Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_BindToHandler_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_BindToHandler_Native>>>()
+              .value
               .asFunction<_BindToHandler_Dart>()(
           ptr.ref.lpVtbl, pbc, bhid, riid, ppv);
 
-  int GetParent(Pointer<Pointer> ppsi) =>
-      Pointer<NativeFunction<_GetParent_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetParent_Dart>()(ptr.ref.lpVtbl, ppsi);
+  int GetParent(Pointer<Pointer> ppsi) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetParent_Native>>>()
+      .value
+      .asFunction<_GetParent_Dart>()(ptr.ref.lpVtbl, ppsi);
 
-  int GetDisplayName(int sigdnName, Pointer<Pointer<Utf16>> ppszName) =>
-      Pointer<NativeFunction<_GetDisplayName_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
-              .asFunction<_GetDisplayName_Dart>()(
-          ptr.ref.lpVtbl, sigdnName, ppszName);
+  int GetDisplayName(int sigdnName, Pointer<Pointer<Utf16>> ppszName) => ptr
+      .ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_GetDisplayName_Native>>>()
+      .value
+      .asFunction<_GetDisplayName_Dart>()(ptr.ref.lpVtbl, sigdnName, ppszName);
 
   int GetAttributes(int sfgaoMask, Pointer<Uint32> psfgaoAttribs) =>
-      Pointer<NativeFunction<_GetAttributes_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(6)
+              .cast<Pointer<NativeFunction<_GetAttributes_Native>>>()
+              .value
               .asFunction<_GetAttributes_Dart>()(
           ptr.ref.lpVtbl, sfgaoMask, psfgaoAttribs);
 
   int Compare(Pointer psi, int hint, Pointer<Int32> piOrder) =>
-      Pointer<NativeFunction<_Compare_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(7)
+          .cast<Pointer<NativeFunction<_Compare_Native>>>()
+          .value
           .asFunction<_Compare_Dart>()(ptr.ref.lpVtbl, psi, hint, piOrder);
 }
 

--- a/lib/src/com/IShellItem2.dart
+++ b/lib/src/com/IShellItem2.dart
@@ -111,78 +111,103 @@ class IShellItem2 extends IShellItem {
   IShellItem2(Pointer<COMObject> ptr) : super(ptr);
 
   int GetPropertyStore(int flags, Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_GetPropertyStore_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(8)
+              .cast<Pointer<NativeFunction<_GetPropertyStore_Native>>>()
+              .value
               .asFunction<_GetPropertyStore_Dart>()(
           ptr.ref.lpVtbl, flags, riid, ppv);
 
-  int GetPropertyStoreWithCreateObject(int flags, Pointer punkCreateObject,
-          Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      Pointer<
-                  NativeFunction<
-                      _GetPropertyStoreWithCreateObject_Native>>.fromAddress(ptr
-                  .ref.vtable
+  int
+      GetPropertyStoreWithCreateObject(int flags, Pointer punkCreateObject,
+              Pointer<GUID> riid, Pointer<Pointer> ppv) =>
+          ptr.ref.lpVtbl.value
                   .elementAt(9)
-                  .value)
-              .asFunction<_GetPropertyStoreWithCreateObject_Dart>()(
-          ptr.ref.lpVtbl, flags, punkCreateObject, riid, ppv);
+                  .cast<
+                      Pointer<
+                          NativeFunction<
+                              _GetPropertyStoreWithCreateObject_Native>>>()
+                  .value
+                  .asFunction<_GetPropertyStoreWithCreateObject_Dart>()(
+              ptr.ref.lpVtbl, flags, punkCreateObject, riid, ppv);
 
   int GetPropertyStoreForKeys(Pointer<PROPERTYKEY> rgKeys, int cKeys, int flags,
           Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_GetPropertyStoreForKeys_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(10)
+              .cast<Pointer<NativeFunction<_GetPropertyStoreForKeys_Native>>>()
+              .value
               .asFunction<_GetPropertyStoreForKeys_Dart>()(
           ptr.ref.lpVtbl, rgKeys, cKeys, flags, riid, ppv);
 
   int GetPropertyDescriptionList(Pointer<PROPERTYKEY> keyType,
           Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_GetPropertyDescriptionList_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(11)
+              .cast<Pointer<NativeFunction<_GetPropertyDescriptionList_Native>>>()
+              .value
               .asFunction<_GetPropertyDescriptionList_Dart>()(
           ptr.ref.lpVtbl, keyType, riid, ppv);
 
-  int Update(Pointer pbc) =>
-      Pointer<NativeFunction<_Update_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_Update_Dart>()(ptr.ref.lpVtbl, pbc);
+  int Update(Pointer pbc) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_Update_Native>>>()
+      .value
+      .asFunction<_Update_Dart>()(ptr.ref.lpVtbl, pbc);
 
   int GetProperty(Pointer<PROPERTYKEY> key, Pointer<PROPVARIANT> ppropvar) =>
-      Pointer<NativeFunction<_GetProperty_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(13)
+          .cast<Pointer<NativeFunction<_GetProperty_Native>>>()
+          .value
           .asFunction<_GetProperty_Dart>()(ptr.ref.lpVtbl, key, ppropvar);
 
   int GetCLSID(Pointer<PROPERTYKEY> key, Pointer<GUID> pclsid) =>
-      Pointer<NativeFunction<_GetCLSID_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(14).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(14)
+          .cast<Pointer<NativeFunction<_GetCLSID_Native>>>()
+          .value
           .asFunction<_GetCLSID_Dart>()(ptr.ref.lpVtbl, key, pclsid);
 
   int GetFileTime(Pointer<PROPERTYKEY> key, Pointer<FILETIME> pft) =>
-      Pointer<NativeFunction<_GetFileTime_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(15).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(15)
+          .cast<Pointer<NativeFunction<_GetFileTime_Native>>>()
+          .value
           .asFunction<_GetFileTime_Dart>()(ptr.ref.lpVtbl, key, pft);
 
   int GetInt32(Pointer<PROPERTYKEY> key, Pointer<Int32> pi) =>
-      Pointer<NativeFunction<_GetInt32_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(16).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(16)
+          .cast<Pointer<NativeFunction<_GetInt32_Native>>>()
+          .value
           .asFunction<_GetInt32_Dart>()(ptr.ref.lpVtbl, key, pi);
 
   int GetString(Pointer<PROPERTYKEY> key, Pointer<Pointer<Utf16>> ppsz) =>
-      Pointer<NativeFunction<_GetString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(17).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(17)
+          .cast<Pointer<NativeFunction<_GetString_Native>>>()
+          .value
           .asFunction<_GetString_Dart>()(ptr.ref.lpVtbl, key, ppsz);
 
   int GetUInt32(Pointer<PROPERTYKEY> key, Pointer<Uint32> pui) =>
-      Pointer<NativeFunction<_GetUInt32_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(18).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(18)
+          .cast<Pointer<NativeFunction<_GetUInt32_Native>>>()
+          .value
           .asFunction<_GetUInt32_Dart>()(ptr.ref.lpVtbl, key, pui);
 
   int GetUInt64(Pointer<PROPERTYKEY> key, Pointer<Uint64> pull) =>
-      Pointer<NativeFunction<_GetUInt64_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(19).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(19)
+          .cast<Pointer<NativeFunction<_GetUInt64_Native>>>()
+          .value
           .asFunction<_GetUInt64_Dart>()(ptr.ref.lpVtbl, key, pull);
 
   int GetBool(Pointer<PROPERTYKEY> key, Pointer<Int32> pf) =>
-      Pointer<NativeFunction<_GetBool_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(20).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(20)
+          .cast<Pointer<NativeFunction<_GetBool_Native>>>()
+          .value
           .asFunction<_GetBool_Dart>()(ptr.ref.lpVtbl, key, pf);
 }

--- a/lib/src/com/IShellItemArray.dart
+++ b/lib/src/com/IShellItemArray.dart
@@ -65,43 +65,54 @@ class IShellItemArray extends IUnknown {
 
   int BindToHandler(Pointer pbc, Pointer<GUID> bhid, Pointer<GUID> riid,
           Pointer<Pointer> ppvOut) =>
-      Pointer<NativeFunction<_BindToHandler_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_BindToHandler_Native>>>()
+              .value
               .asFunction<_BindToHandler_Dart>()(
           ptr.ref.lpVtbl, pbc, bhid, riid, ppvOut);
 
   int GetPropertyStore(int flags, Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_GetPropertyStore_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_GetPropertyStore_Native>>>()
+              .value
               .asFunction<_GetPropertyStore_Dart>()(
           ptr.ref.lpVtbl, flags, riid, ppv);
 
   int GetPropertyDescriptionList(Pointer<PROPERTYKEY> keyType,
           Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_GetPropertyDescriptionList_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_GetPropertyDescriptionList_Native>>>()
+              .value
               .asFunction<_GetPropertyDescriptionList_Dart>()(
           ptr.ref.lpVtbl, keyType, riid, ppv);
 
   int GetAttributes(
           int AttribFlags, int sfgaoMask, Pointer<Uint32> psfgaoAttribs) =>
-      Pointer<NativeFunction<_GetAttributes_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(6)
+              .cast<Pointer<NativeFunction<_GetAttributes_Native>>>()
+              .value
               .asFunction<_GetAttributes_Dart>()(
           ptr.ref.lpVtbl, AttribFlags, sfgaoMask, psfgaoAttribs);
 
-  int GetCount(Pointer<Uint32> pdwNumItems) =>
-      Pointer<NativeFunction<_GetCount_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetCount_Dart>()(ptr.ref.lpVtbl, pdwNumItems);
+  int GetCount(Pointer<Uint32> pdwNumItems) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetCount_Native>>>()
+      .value
+      .asFunction<_GetCount_Dart>()(ptr.ref.lpVtbl, pdwNumItems);
 
-  int GetItemAt(int dwIndex, Pointer<Pointer> ppsi) =>
-      Pointer<NativeFunction<_GetItemAt_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
-          .asFunction<_GetItemAt_Dart>()(ptr.ref.lpVtbl, dwIndex, ppsi);
+  int GetItemAt(int dwIndex, Pointer<Pointer> ppsi) => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_GetItemAt_Native>>>()
+      .value
+      .asFunction<_GetItemAt_Dart>()(ptr.ref.lpVtbl, dwIndex, ppsi);
 
-  int EnumItems(Pointer<Pointer> ppenumShellItems) =>
-      Pointer<NativeFunction<_EnumItems_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_EnumItems_Dart>()(ptr.ref.lpVtbl, ppenumShellItems);
+  int EnumItems(Pointer<Pointer> ppenumShellItems) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_EnumItems_Native>>>()
+      .value
+      .asFunction<_EnumItems_Dart>()(ptr.ref.lpVtbl, ppenumShellItems);
 }

--- a/lib/src/com/IShellItemFilter.dart
+++ b/lib/src/com/IShellItemFilter.dart
@@ -37,14 +37,16 @@ class IShellItemFilter extends IUnknown {
 
   IShellItemFilter(Pointer<COMObject> ptr) : super(ptr);
 
-  int IncludeItem(Pointer psi) =>
-      Pointer<NativeFunction<_IncludeItem_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_IncludeItem_Dart>()(ptr.ref.lpVtbl, psi);
+  int IncludeItem(Pointer psi) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_IncludeItem_Native>>>()
+      .value
+      .asFunction<_IncludeItem_Dart>()(ptr.ref.lpVtbl, psi);
 
-  int GetEnumFlagsForItem(Pointer psi, Pointer<Uint32> pgrfFlags) =>
-      Pointer<NativeFunction<_GetEnumFlagsForItem_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
-              .asFunction<_GetEnumFlagsForItem_Dart>()(
-          ptr.ref.lpVtbl, psi, pgrfFlags);
+  int GetEnumFlagsForItem(Pointer psi, Pointer<Uint32> pgrfFlags) => ptr
+      .ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetEnumFlagsForItem_Native>>>()
+      .value
+      .asFunction<_GetEnumFlagsForItem_Dart>()(ptr.ref.lpVtbl, psi, pgrfFlags);
 }

--- a/lib/src/com/IShellItemResources.dart
+++ b/lib/src/com/IShellItemResources.dart
@@ -103,61 +103,77 @@ class IShellItemResources extends IUnknown {
 
   IShellItemResources(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetAttributes(Pointer<Uint32> pdwAttributes) =>
-      Pointer<NativeFunction<_GetAttributes_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetAttributes_Dart>()(ptr.ref.lpVtbl, pdwAttributes);
+  int GetAttributes(Pointer<Uint32> pdwAttributes) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetAttributes_Native>>>()
+      .value
+      .asFunction<_GetAttributes_Dart>()(ptr.ref.lpVtbl, pdwAttributes);
 
-  int GetSize(Pointer<Uint64> pullSize) =>
-      Pointer<NativeFunction<_GetSize_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetSize_Dart>()(ptr.ref.lpVtbl, pullSize);
+  int GetSize(Pointer<Uint64> pullSize) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetSize_Native>>>()
+      .value
+      .asFunction<_GetSize_Dart>()(ptr.ref.lpVtbl, pullSize);
 
   int GetTimes(Pointer<FILETIME> pftCreation, Pointer<FILETIME> pftWrite,
           Pointer<FILETIME> pftAccess) =>
-      Pointer<NativeFunction<_GetTimes_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_GetTimes_Native>>>()
+              .value
               .asFunction<_GetTimes_Dart>()(
           ptr.ref.lpVtbl, pftCreation, pftWrite, pftAccess);
 
   int SetTimes(Pointer<FILETIME> pftCreation, Pointer<FILETIME> pftWrite,
           Pointer<FILETIME> pftAccess) =>
-      Pointer<NativeFunction<_SetTimes_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(6)
+              .cast<Pointer<NativeFunction<_SetTimes_Native>>>()
+              .value
               .asFunction<_SetTimes_Dart>()(
           ptr.ref.lpVtbl, pftCreation, pftWrite, pftAccess);
 
   int GetResourceDescription(Pointer<SHELL_ITEM_RESOURCE> pcsir,
           Pointer<Pointer<Utf16>> ppszDescription) =>
-      Pointer<NativeFunction<_GetResourceDescription_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(7)
+              .cast<Pointer<NativeFunction<_GetResourceDescription_Native>>>()
+              .value
               .asFunction<_GetResourceDescription_Dart>()(
           ptr.ref.lpVtbl, pcsir, ppszDescription);
 
-  int EnumResources(Pointer<Pointer> ppenumr) =>
-      Pointer<NativeFunction<_EnumResources_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
-          .asFunction<_EnumResources_Dart>()(ptr.ref.lpVtbl, ppenumr);
+  int EnumResources(Pointer<Pointer> ppenumr) => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_EnumResources_Native>>>()
+      .value
+      .asFunction<_EnumResources_Dart>()(ptr.ref.lpVtbl, ppenumr);
 
   int SupportsResource(Pointer<SHELL_ITEM_RESOURCE> pcsir) =>
-      Pointer<NativeFunction<_SupportsResource_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(9)
+          .cast<Pointer<NativeFunction<_SupportsResource_Native>>>()
+          .value
           .asFunction<_SupportsResource_Dart>()(ptr.ref.lpVtbl, pcsir);
 
   int OpenResource(Pointer<SHELL_ITEM_RESOURCE> pcsir, Pointer<GUID> riid,
           Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_OpenResource_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(10)
+          .cast<Pointer<NativeFunction<_OpenResource_Native>>>()
+          .value
           .asFunction<_OpenResource_Dart>()(ptr.ref.lpVtbl, pcsir, riid, ppv);
 
   int CreateResource(Pointer<SHELL_ITEM_RESOURCE> pcsir, Pointer<GUID> riid,
           Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_CreateResource_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(11)
+          .cast<Pointer<NativeFunction<_CreateResource_Native>>>()
+          .value
           .asFunction<_CreateResource_Dart>()(ptr.ref.lpVtbl, pcsir, riid, ppv);
 
-  int MarkForDelete() =>
-      Pointer<NativeFunction<_MarkForDelete_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_MarkForDelete_Dart>()(ptr.ref.lpVtbl);
+  int MarkForDelete() => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_MarkForDelete_Native>>>()
+      .value
+      .asFunction<_MarkForDelete_Dart>()(ptr.ref.lpVtbl);
 }

--- a/lib/src/com/IShellLink.dart
+++ b/lib/src/com/IShellLink.dart
@@ -113,99 +113,121 @@ class IShellLink extends IUnknown {
 
   int GetPath(Pointer<Utf16> pszFile, int cch, Pointer<WIN32_FIND_DATA> pfd,
           int fFlags) =>
-      Pointer<NativeFunction<_GetPath_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_GetPath_Native>>>()
+              .value
               .asFunction<_GetPath_Dart>()(
           ptr.ref.lpVtbl, pszFile, cch, pfd, fFlags);
 
-  int GetIDList(Pointer<Pointer<ITEMIDLIST>> ppidl) =>
-      Pointer<NativeFunction<_GetIDList_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetIDList_Dart>()(ptr.ref.lpVtbl, ppidl);
+  int GetIDList(Pointer<Pointer<ITEMIDLIST>> ppidl) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetIDList_Native>>>()
+      .value
+      .asFunction<_GetIDList_Dart>()(ptr.ref.lpVtbl, ppidl);
 
-  int SetIDList(Pointer<ITEMIDLIST> pidl) =>
-      Pointer<NativeFunction<_SetIDList_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_SetIDList_Dart>()(ptr.ref.lpVtbl, pidl);
+  int SetIDList(Pointer<ITEMIDLIST> pidl) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_SetIDList_Native>>>()
+      .value
+      .asFunction<_SetIDList_Dart>()(ptr.ref.lpVtbl, pidl);
 
-  int GetDescription(Pointer<Utf16> pszName, int cch) =>
-      Pointer<NativeFunction<_GetDescription_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetDescription_Dart>()(ptr.ref.lpVtbl, pszName, cch);
+  int GetDescription(Pointer<Utf16> pszName, int cch) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetDescription_Native>>>()
+      .value
+      .asFunction<_GetDescription_Dart>()(ptr.ref.lpVtbl, pszName, cch);
 
-  int SetDescription(Pointer<Utf16> pszName) =>
-      Pointer<NativeFunction<_SetDescription_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_SetDescription_Dart>()(ptr.ref.lpVtbl, pszName);
+  int SetDescription(Pointer<Utf16> pszName) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_SetDescription_Native>>>()
+      .value
+      .asFunction<_SetDescription_Dart>()(ptr.ref.lpVtbl, pszName);
 
   int GetWorkingDirectory(Pointer<Utf16> pszDir, int cch) =>
-      Pointer<NativeFunction<_GetWorkingDirectory_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_GetWorkingDirectory_Native>>>()
+          .value
           .asFunction<_GetWorkingDirectory_Dart>()(ptr.ref.lpVtbl, pszDir, cch);
 
-  int SetWorkingDirectory(Pointer<Utf16> pszDir) =>
-      Pointer<NativeFunction<_SetWorkingDirectory_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
-          .asFunction<_SetWorkingDirectory_Dart>()(ptr.ref.lpVtbl, pszDir);
+  int SetWorkingDirectory(Pointer<Utf16> pszDir) => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_SetWorkingDirectory_Native>>>()
+      .value
+      .asFunction<_SetWorkingDirectory_Dart>()(ptr.ref.lpVtbl, pszDir);
 
-  int GetArguments(Pointer<Utf16> pszArgs, int cch) =>
-      Pointer<NativeFunction<_GetArguments_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_GetArguments_Dart>()(ptr.ref.lpVtbl, pszArgs, cch);
+  int GetArguments(Pointer<Utf16> pszArgs, int cch) => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_GetArguments_Native>>>()
+      .value
+      .asFunction<_GetArguments_Dart>()(ptr.ref.lpVtbl, pszArgs, cch);
 
-  int SetArguments(Pointer<Utf16> pszArgs) =>
-      Pointer<NativeFunction<_SetArguments_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
-          .asFunction<_SetArguments_Dart>()(ptr.ref.lpVtbl, pszArgs);
+  int SetArguments(Pointer<Utf16> pszArgs) => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_SetArguments_Native>>>()
+      .value
+      .asFunction<_SetArguments_Dart>()(ptr.ref.lpVtbl, pszArgs);
 
-  int GetHotkey(Pointer<Uint16> pwHotkey) =>
-      Pointer<NativeFunction<_GetHotkey_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_GetHotkey_Dart>()(ptr.ref.lpVtbl, pwHotkey);
+  int GetHotkey(Pointer<Uint16> pwHotkey) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_GetHotkey_Native>>>()
+      .value
+      .asFunction<_GetHotkey_Dart>()(ptr.ref.lpVtbl, pwHotkey);
 
-  int SetHotkey(int wHotkey) =>
-      Pointer<NativeFunction<_SetHotkey_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_SetHotkey_Dart>()(ptr.ref.lpVtbl, wHotkey);
+  int SetHotkey(int wHotkey) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_SetHotkey_Native>>>()
+      .value
+      .asFunction<_SetHotkey_Dart>()(ptr.ref.lpVtbl, wHotkey);
 
-  int GetShowCmd(Pointer<Int32> piShowCmd) =>
-      Pointer<NativeFunction<_GetShowCmd_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(14).value)
-          .asFunction<_GetShowCmd_Dart>()(ptr.ref.lpVtbl, piShowCmd);
+  int GetShowCmd(Pointer<Int32> piShowCmd) => ptr.ref.lpVtbl.value
+      .elementAt(14)
+      .cast<Pointer<NativeFunction<_GetShowCmd_Native>>>()
+      .value
+      .asFunction<_GetShowCmd_Dart>()(ptr.ref.lpVtbl, piShowCmd);
 
-  int SetShowCmd(int iShowCmd) =>
-      Pointer<NativeFunction<_SetShowCmd_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(15).value)
-          .asFunction<_SetShowCmd_Dart>()(ptr.ref.lpVtbl, iShowCmd);
+  int SetShowCmd(int iShowCmd) => ptr.ref.lpVtbl.value
+      .elementAt(15)
+      .cast<Pointer<NativeFunction<_SetShowCmd_Native>>>()
+      .value
+      .asFunction<_SetShowCmd_Dart>()(ptr.ref.lpVtbl, iShowCmd);
 
   int GetIconLocation(
           Pointer<Utf16> pszIconPath, int cch, Pointer<Int32> piIcon) =>
-      Pointer<NativeFunction<_GetIconLocation_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(16).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(16)
+              .cast<Pointer<NativeFunction<_GetIconLocation_Native>>>()
+              .value
               .asFunction<_GetIconLocation_Dart>()(
           ptr.ref.lpVtbl, pszIconPath, cch, piIcon);
 
-  int SetIconLocation(Pointer<Utf16> pszIconPath, int iIcon) =>
-      Pointer<NativeFunction<_SetIconLocation_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(17).value)
-              .asFunction<_SetIconLocation_Dart>()(
-          ptr.ref.lpVtbl, pszIconPath, iIcon);
+  int SetIconLocation(Pointer<Utf16> pszIconPath, int iIcon) => ptr
+      .ref.lpVtbl.value
+      .elementAt(17)
+      .cast<Pointer<NativeFunction<_SetIconLocation_Native>>>()
+      .value
+      .asFunction<_SetIconLocation_Dart>()(ptr.ref.lpVtbl, pszIconPath, iIcon);
 
   int SetRelativePath(Pointer<Utf16> pszPathRel, int dwReserved) =>
-      Pointer<NativeFunction<_SetRelativePath_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(18).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(18)
+              .cast<Pointer<NativeFunction<_SetRelativePath_Native>>>()
+              .value
               .asFunction<_SetRelativePath_Dart>()(
           ptr.ref.lpVtbl, pszPathRel, dwReserved);
 
-  int Resolve(int hwnd, int fFlags) =>
-      Pointer<NativeFunction<_Resolve_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(19).value)
-          .asFunction<_Resolve_Dart>()(ptr.ref.lpVtbl, hwnd, fFlags);
+  int Resolve(int hwnd, int fFlags) => ptr.ref.lpVtbl.value
+      .elementAt(19)
+      .cast<Pointer<NativeFunction<_Resolve_Native>>>()
+      .value
+      .asFunction<_Resolve_Dart>()(ptr.ref.lpVtbl, hwnd, fFlags);
 
-  int SetPath(Pointer<Utf16> pszFile) =>
-      Pointer<NativeFunction<_SetPath_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(20).value)
-          .asFunction<_SetPath_Dart>()(ptr.ref.lpVtbl, pszFile);
+  int SetPath(Pointer<Utf16> pszFile) => ptr.ref.lpVtbl.value
+      .elementAt(20)
+      .cast<Pointer<NativeFunction<_SetPath_Native>>>()
+      .value
+      .asFunction<_SetPath_Dart>()(ptr.ref.lpVtbl, pszFile);
 }
 
 /// {@category com}

--- a/lib/src/com/IShellLinkDataList.dart
+++ b/lib/src/com/IShellLinkDataList.dart
@@ -47,29 +47,34 @@ class IShellLinkDataList extends IUnknown {
 
   IShellLinkDataList(Pointer<COMObject> ptr) : super(ptr);
 
-  int AddDataBlock(Pointer pDataBlock) =>
-      Pointer<NativeFunction<_AddDataBlock_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_AddDataBlock_Dart>()(ptr.ref.lpVtbl, pDataBlock);
+  int AddDataBlock(Pointer pDataBlock) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_AddDataBlock_Native>>>()
+      .value
+      .asFunction<_AddDataBlock_Dart>()(ptr.ref.lpVtbl, pDataBlock);
 
-  int CopyDataBlock(int dwSig, Pointer<Pointer> ppDataBlock) =>
-      Pointer<NativeFunction<_CopyDataBlock_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
-              .asFunction<_CopyDataBlock_Dart>()(
-          ptr.ref.lpVtbl, dwSig, ppDataBlock);
+  int CopyDataBlock(int dwSig, Pointer<Pointer> ppDataBlock) => ptr
+      .ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_CopyDataBlock_Native>>>()
+      .value
+      .asFunction<_CopyDataBlock_Dart>()(ptr.ref.lpVtbl, dwSig, ppDataBlock);
 
-  int RemoveDataBlock(int dwSig) =>
-      Pointer<NativeFunction<_RemoveDataBlock_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_RemoveDataBlock_Dart>()(ptr.ref.lpVtbl, dwSig);
+  int RemoveDataBlock(int dwSig) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_RemoveDataBlock_Native>>>()
+      .value
+      .asFunction<_RemoveDataBlock_Dart>()(ptr.ref.lpVtbl, dwSig);
 
-  int GetFlags(Pointer<Uint32> pdwFlags) =>
-      Pointer<NativeFunction<_GetFlags_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetFlags_Dart>()(ptr.ref.lpVtbl, pdwFlags);
+  int GetFlags(Pointer<Uint32> pdwFlags) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetFlags_Native>>>()
+      .value
+      .asFunction<_GetFlags_Dart>()(ptr.ref.lpVtbl, pdwFlags);
 
-  int SetFlags(int dwFlags) =>
-      Pointer<NativeFunction<_SetFlags_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_SetFlags_Dart>()(ptr.ref.lpVtbl, dwFlags);
+  int SetFlags(int dwFlags) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_SetFlags_Native>>>()
+      .value
+      .asFunction<_SetFlags_Dart>()(ptr.ref.lpVtbl, dwFlags);
 }

--- a/lib/src/com/IShellLinkDual.dart
+++ b/lib/src/com/IShellLinkDual.dart
@@ -241,22 +241,28 @@ class IShellLinkDual extends IDispatch {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int Resolve(int fFlags) =>
-      Pointer<NativeFunction<_Resolve_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(19).value)
-          .asFunction<_Resolve_Dart>()(ptr.ref.lpVtbl, fFlags);
+  int Resolve(int fFlags) => ptr.ref.lpVtbl.value
+      .elementAt(19)
+      .cast<Pointer<NativeFunction<_Resolve_Native>>>()
+      .value
+      .asFunction<_Resolve_Dart>()(ptr.ref.lpVtbl, fFlags);
 
   int GetIconLocation(Pointer<Pointer<Utf16>> pbs, Pointer<Int32> piIcon) =>
-      Pointer<NativeFunction<_GetIconLocation_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(20).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(20)
+          .cast<Pointer<NativeFunction<_GetIconLocation_Native>>>()
+          .value
           .asFunction<_GetIconLocation_Dart>()(ptr.ref.lpVtbl, pbs, piIcon);
 
-  int SetIconLocation(Pointer<Utf16> bs, int iIcon) =>
-      Pointer<NativeFunction<_SetIconLocation_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(21).value)
-          .asFunction<_SetIconLocation_Dart>()(ptr.ref.lpVtbl, bs, iIcon);
+  int SetIconLocation(Pointer<Utf16> bs, int iIcon) => ptr.ref.lpVtbl.value
+      .elementAt(21)
+      .cast<Pointer<NativeFunction<_SetIconLocation_Native>>>()
+      .value
+      .asFunction<_SetIconLocation_Dart>()(ptr.ref.lpVtbl, bs, iIcon);
 
-  int Save(VARIANT vWhere) => Pointer<NativeFunction<_Save_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(22).value)
+  int Save(VARIANT vWhere) => ptr.ref.lpVtbl.value
+      .elementAt(22)
+      .cast<Pointer<NativeFunction<_Save_Native>>>()
+      .value
       .asFunction<_Save_Dart>()(ptr.ref.lpVtbl, vWhere);
 }

--- a/lib/src/com/IShellLinkDual.dart
+++ b/lib/src/com/IShellLinkDual.dart
@@ -114,8 +114,10 @@ class IShellLinkDual extends IDispatch {
   }
 
   set Path(Pointer<Utf16> value) {
-    final hr = Pointer<NativeFunction<_put_Path_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(8).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(8)
+        .cast<Pointer<NativeFunction<_put_Path_Native>>>()
+        .value
         .asFunction<_put_Path_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -141,8 +143,10 @@ class IShellLinkDual extends IDispatch {
   }
 
   set Description(Pointer<Utf16> value) {
-    final hr = Pointer<NativeFunction<_put_Description_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(10).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(10)
+        .cast<Pointer<NativeFunction<_put_Description_Native>>>()
+        .value
         .asFunction<_put_Description_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -169,10 +173,11 @@ class IShellLinkDual extends IDispatch {
   }
 
   set WorkingDirectory(Pointer<Utf16> value) {
-    final hr =
-        Pointer<NativeFunction<_put_WorkingDirectory_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(12).value)
-            .asFunction<_put_WorkingDirectory_Dart>()(ptr.ref.lpVtbl, value);
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(12)
+        .cast<Pointer<NativeFunction<_put_WorkingDirectory_Native>>>()
+        .value
+        .asFunction<_put_WorkingDirectory_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -197,8 +202,10 @@ class IShellLinkDual extends IDispatch {
   }
 
   set Arguments(Pointer<Utf16> value) {
-    final hr = Pointer<NativeFunction<_put_Arguments_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(14).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(14)
+        .cast<Pointer<NativeFunction<_put_Arguments_Native>>>()
+        .value
         .asFunction<_put_Arguments_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -224,8 +231,10 @@ class IShellLinkDual extends IDispatch {
   }
 
   set Hotkey(int value) {
-    final hr = Pointer<NativeFunction<_put_Hotkey_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(16).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(16)
+        .cast<Pointer<NativeFunction<_put_Hotkey_Native>>>()
+        .value
         .asFunction<_put_Hotkey_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -251,8 +260,10 @@ class IShellLinkDual extends IDispatch {
   }
 
   set ShowCommand(int value) {
-    final hr = Pointer<NativeFunction<_put_ShowCommand_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt(18).value)
+    final hr = ptr.ref.lpVtbl.value
+        .elementAt(18)
+        .cast<Pointer<NativeFunction<_put_ShowCommand_Native>>>()
+        .value
         .asFunction<_put_ShowCommand_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);

--- a/lib/src/com/IShellLinkDual.dart
+++ b/lib/src/com/IShellLinkDual.dart
@@ -98,9 +98,12 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Path_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(7)
+          .cast<Pointer<NativeFunction<_get_Path_Native>>>()
+          .value
           .asFunction<_get_Path_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -122,9 +125,12 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Description_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(9)
+          .cast<Pointer<NativeFunction<_get_Description_Native>>>()
+          .value
           .asFunction<_get_Description_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -146,11 +152,13 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_WorkingDirectory_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(11).value)
-                  .asFunction<_get_WorkingDirectory_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(11)
+              .cast<Pointer<NativeFunction<_get_WorkingDirectory_Native>>>()
+              .value
+              .asFunction<_get_WorkingDirectory_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -173,9 +181,12 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Arguments_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(13)
+          .cast<Pointer<NativeFunction<_get_Arguments_Native>>>()
+          .value
           .asFunction<_get_Arguments_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -197,9 +208,12 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Hotkey_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(15).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(15)
+          .cast<Pointer<NativeFunction<_get_Hotkey_Native>>>()
+          .value
           .asFunction<_get_Hotkey_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -221,9 +235,12 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_ShowCommand_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(17).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(17)
+          .cast<Pointer<NativeFunction<_get_ShowCommand_Native>>>()
+          .value
           .asFunction<_get_ShowCommand_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IShellService.dart
+++ b/lib/src/com/IShellService.dart
@@ -32,8 +32,9 @@ class IShellService extends IUnknown {
 
   IShellService(Pointer<COMObject> ptr) : super(ptr);
 
-  int SetOwner(Pointer punkOwner) =>
-      Pointer<NativeFunction<_SetOwner_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_SetOwner_Dart>()(ptr.ref.lpVtbl, punkOwner);
+  int SetOwner(Pointer punkOwner) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_SetOwner_Native>>>()
+      .value
+      .asFunction<_SetOwner_Dart>()(ptr.ref.lpVtbl, punkOwner);
 }

--- a/lib/src/com/ISpellChecker.dart
+++ b/lib/src/com/ISpellChecker.dart
@@ -97,9 +97,12 @@ class ISpellChecker extends IUnknown {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_LanguageTag_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_get_LanguageTag_Native>>>()
+          .value
           .asFunction<_get_LanguageTag_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -152,9 +155,12 @@ class ISpellChecker extends IUnknown {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_OptionIds_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(10)
+          .cast<Pointer<NativeFunction<_get_OptionIds_Native>>>()
+          .value
           .asFunction<_get_OptionIds_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -168,9 +174,12 @@ class ISpellChecker extends IUnknown {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Id_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(11)
+          .cast<Pointer<NativeFunction<_get_Id_Native>>>()
+          .value
           .asFunction<_get_Id_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -184,9 +193,12 @@ class ISpellChecker extends IUnknown {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_LocalizedName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(12)
+          .cast<Pointer<NativeFunction<_get_LocalizedName_Native>>>()
+          .value
           .asFunction<_get_LocalizedName_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/ISpellChecker.dart
+++ b/lib/src/com/ISpellChecker.dart
@@ -109,34 +109,43 @@ class ISpellChecker extends IUnknown {
     }
   }
 
-  int Check(Pointer<Utf16> text, Pointer<Pointer> value) =>
-      Pointer<NativeFunction<_Check_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_Check_Dart>()(ptr.ref.lpVtbl, text, value);
+  int Check(Pointer<Utf16> text, Pointer<Pointer> value) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_Check_Native>>>()
+      .value
+      .asFunction<_Check_Dart>()(ptr.ref.lpVtbl, text, value);
 
   int Suggest(Pointer<Utf16> word, Pointer<Pointer> value) =>
-      Pointer<NativeFunction<_Suggest_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(5)
+          .cast<Pointer<NativeFunction<_Suggest_Native>>>()
+          .value
           .asFunction<_Suggest_Dart>()(ptr.ref.lpVtbl, word, value);
 
-  int Add(Pointer<Utf16> word) =>
-      Pointer<NativeFunction<_Add_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Add_Dart>()(ptr.ref.lpVtbl, word);
+  int Add(Pointer<Utf16> word) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Add_Native>>>()
+      .value
+      .asFunction<_Add_Dart>()(ptr.ref.lpVtbl, word);
 
-  int Ignore(Pointer<Utf16> word) =>
-      Pointer<NativeFunction<_Ignore_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_Ignore_Dart>()(ptr.ref.lpVtbl, word);
+  int Ignore(Pointer<Utf16> word) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_Ignore_Native>>>()
+      .value
+      .asFunction<_Ignore_Dart>()(ptr.ref.lpVtbl, word);
 
   int AutoCorrect(Pointer<Utf16> from, Pointer<Utf16> to) =>
-      Pointer<NativeFunction<_AutoCorrect_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_AutoCorrect_Native>>>()
+          .value
           .asFunction<_AutoCorrect_Dart>()(ptr.ref.lpVtbl, from, to);
 
   int GetOptionValue(Pointer<Utf16> optionId, Pointer<Uint8> value) =>
-      Pointer<NativeFunction<_GetOptionValue_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(9).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(9)
+          .cast<Pointer<NativeFunction<_GetOptionValue_Native>>>()
+          .value
           .asFunction<_GetOptionValue_Dart>()(ptr.ref.lpVtbl, optionId, value);
 
   Pointer get OptionIds {
@@ -188,25 +197,32 @@ class ISpellChecker extends IUnknown {
   }
 
   int add_SpellCheckerChanged(Pointer handler, Pointer<Uint32> eventCookie) =>
-      Pointer<NativeFunction<_add_SpellCheckerChanged_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(13).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(13)
+              .cast<Pointer<NativeFunction<_add_SpellCheckerChanged_Native>>>()
+              .value
               .asFunction<_add_SpellCheckerChanged_Dart>()(
           ptr.ref.lpVtbl, handler, eventCookie);
 
-  int remove_SpellCheckerChanged(int eventCookie) =>
-      Pointer<NativeFunction<_remove_SpellCheckerChanged_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(14).value)
-              .asFunction<_remove_SpellCheckerChanged_Dart>()(
-          ptr.ref.lpVtbl, eventCookie);
+  int remove_SpellCheckerChanged(int eventCookie) => ptr.ref.lpVtbl.value
+          .elementAt(14)
+          .cast<Pointer<NativeFunction<_remove_SpellCheckerChanged_Native>>>()
+          .value
+          .asFunction<_remove_SpellCheckerChanged_Dart>()(
+      ptr.ref.lpVtbl, eventCookie);
 
   int GetOptionDescription(Pointer<Utf16> optionId, Pointer<Pointer> value) =>
-      Pointer<NativeFunction<_GetOptionDescription_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(15).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(15)
+              .cast<Pointer<NativeFunction<_GetOptionDescription_Native>>>()
+              .value
               .asFunction<_GetOptionDescription_Dart>()(
           ptr.ref.lpVtbl, optionId, value);
 
   int ComprehensiveCheck(Pointer<Utf16> text, Pointer<Pointer> value) =>
-      Pointer<NativeFunction<_ComprehensiveCheck_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(16).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(16)
+          .cast<Pointer<NativeFunction<_ComprehensiveCheck_Native>>>()
+          .value
           .asFunction<_ComprehensiveCheck_Dart>()(ptr.ref.lpVtbl, text, value);
 }

--- a/lib/src/com/ISpellCheckerChangedEventHandler.dart
+++ b/lib/src/com/ISpellCheckerChangedEventHandler.dart
@@ -33,8 +33,9 @@ class ISpellCheckerChangedEventHandler extends IUnknown {
 
   ISpellCheckerChangedEventHandler(Pointer<COMObject> ptr) : super(ptr);
 
-  int Invoke(Pointer sender) =>
-      Pointer<NativeFunction<_Invoke_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_Invoke_Dart>()(ptr.ref.lpVtbl, sender);
+  int Invoke(Pointer sender) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_Invoke_Native>>>()
+      .value
+      .asFunction<_Invoke_Dart>()(ptr.ref.lpVtbl, sender);
 }

--- a/lib/src/com/ISpellCheckerFactory.dart
+++ b/lib/src/com/ISpellCheckerFactory.dart
@@ -66,13 +66,17 @@ class ISpellCheckerFactory extends IUnknown {
   }
 
   int IsSupported(Pointer<Utf16> languageTag, Pointer<Int32> value) =>
-      Pointer<NativeFunction<_IsSupported_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(4)
+          .cast<Pointer<NativeFunction<_IsSupported_Native>>>()
+          .value
           .asFunction<_IsSupported_Dart>()(ptr.ref.lpVtbl, languageTag, value);
 
   int CreateSpellChecker(Pointer<Utf16> languageTag, Pointer<Pointer> value) =>
-      Pointer<NativeFunction<_CreateSpellChecker_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_CreateSpellChecker_Native>>>()
+              .value
               .asFunction<_CreateSpellChecker_Dart>()(
           ptr.ref.lpVtbl, languageTag, value);
 }

--- a/lib/src/com/ISpellCheckerFactory.dart
+++ b/lib/src/com/ISpellCheckerFactory.dart
@@ -51,11 +51,13 @@ class ISpellCheckerFactory extends IUnknown {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_SupportedLanguages_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(3).value)
-                  .asFunction<_get_SupportedLanguages_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_get_SupportedLanguages_Native>>>()
+              .value
+              .asFunction<_get_SupportedLanguages_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/ISpellingError.dart
+++ b/lib/src/com/ISpellingError.dart
@@ -50,9 +50,12 @@ class ISpellingError extends IUnknown {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_StartIndex_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(3)
+          .cast<Pointer<NativeFunction<_get_StartIndex_Native>>>()
+          .value
           .asFunction<_get_StartIndex_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -66,9 +69,12 @@ class ISpellingError extends IUnknown {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Length_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(4)
+          .cast<Pointer<NativeFunction<_get_Length_Native>>>()
+          .value
           .asFunction<_get_Length_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -82,11 +88,13 @@ class ISpellingError extends IUnknown {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr =
-          Pointer<NativeFunction<_get_CorrectiveAction_Native>>.fromAddress(
-                      ptr.ref.vtable.elementAt(5).value)
-                  .asFunction<_get_CorrectiveAction_Dart>()(
-              ptr.ref.lpVtbl, retValuePtr);
+      final hr = ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_get_CorrectiveAction_Native>>>()
+              .value
+              .asFunction<_get_CorrectiveAction_Dart>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;
@@ -100,9 +108,12 @@ class ISpellingError extends IUnknown {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = Pointer<NativeFunction<_get_Replacement_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<Pointer<NativeFunction<_get_Replacement_Native>>>()
+          .value
           .asFunction<_get_Replacement_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+
       if (FAILED(hr)) throw WindowsException(hr);
 
       final retValue = retValuePtr.value;

--- a/lib/src/com/IStream.dart
+++ b/lib/src/com/IStream.dart
@@ -67,51 +67,64 @@ class IStream extends ISequentialStream {
   IStream(Pointer<COMObject> ptr) : super(ptr);
 
   int Seek(int dlibMove, int dwOrigin, Pointer<Uint64> plibNewPosition) =>
-      Pointer<NativeFunction<_Seek_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_Seek_Native>>>()
+              .value
               .asFunction<_Seek_Dart>()(
           ptr.ref.lpVtbl, dlibMove, dwOrigin, plibNewPosition);
 
-  int SetSize(int libNewSize) =>
-      Pointer<NativeFunction<_SetSize_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_SetSize_Dart>()(ptr.ref.lpVtbl, libNewSize);
+  int SetSize(int libNewSize) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_SetSize_Native>>>()
+      .value
+      .asFunction<_SetSize_Dart>()(ptr.ref.lpVtbl, libNewSize);
 
   int CopyTo(Pointer pstm, int cb, Pointer<Uint64> pcbRead,
           Pointer<Uint64> pcbWritten) =>
-      Pointer<NativeFunction<_CopyTo_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(7)
+              .cast<Pointer<NativeFunction<_CopyTo_Native>>>()
+              .value
               .asFunction<_CopyTo_Dart>()(
           ptr.ref.lpVtbl, pstm, cb, pcbRead, pcbWritten);
 
-  int Commit(int grfCommitFlags) =>
-      Pointer<NativeFunction<_Commit_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
-          .asFunction<_Commit_Dart>()(ptr.ref.lpVtbl, grfCommitFlags);
+  int Commit(int grfCommitFlags) => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_Commit_Native>>>()
+      .value
+      .asFunction<_Commit_Dart>()(ptr.ref.lpVtbl, grfCommitFlags);
 
-  int Revert() => Pointer<NativeFunction<_Revert_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(9).value)
+  int Revert() => ptr.ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_Revert_Native>>>()
+      .value
       .asFunction<_Revert_Dart>()(ptr.ref.lpVtbl);
 
-  int LockRegion(int libOffset, int cb, int dwLockType) =>
-      Pointer<NativeFunction<_LockRegion_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
-              .asFunction<_LockRegion_Dart>()(
-          ptr.ref.lpVtbl, libOffset, cb, dwLockType);
+  int LockRegion(int libOffset, int cb, int dwLockType) => ptr.ref.lpVtbl.value
+          .elementAt(10)
+          .cast<Pointer<NativeFunction<_LockRegion_Native>>>()
+          .value
+          .asFunction<_LockRegion_Dart>()(
+      ptr.ref.lpVtbl, libOffset, cb, dwLockType);
 
   int UnlockRegion(int libOffset, int cb, int dwLockType) =>
-      Pointer<NativeFunction<_UnlockRegion_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(11)
+              .cast<Pointer<NativeFunction<_UnlockRegion_Native>>>()
+              .value
               .asFunction<_UnlockRegion_Dart>()(
           ptr.ref.lpVtbl, libOffset, cb, dwLockType);
 
-  int Stat(Pointer<STATSTG> pstatstg, int grfStatFlag) =>
-      Pointer<NativeFunction<_Stat_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_Stat_Dart>()(ptr.ref.lpVtbl, pstatstg, grfStatFlag);
+  int Stat(Pointer<STATSTG> pstatstg, int grfStatFlag) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_Stat_Native>>>()
+      .value
+      .asFunction<_Stat_Dart>()(ptr.ref.lpVtbl, pstatstg, grfStatFlag);
 
-  int Clone(Pointer<Pointer> ppstm) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppstm);
+  int Clone(Pointer<Pointer> ppstm) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppstm);
 }

--- a/lib/src/com/IStringable.dart
+++ b/lib/src/com/IStringable.dart
@@ -34,8 +34,9 @@ class IStringable extends IInspectable {
 
   IStringable(Pointer<COMObject> ptr) : super(ptr);
 
-  int ToString(Pointer<IntPtr> result) =>
-      Pointer<NativeFunction<_ToString_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_ToString_Dart>()(ptr.ref.lpVtbl, result);
+  int ToString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_ToString_Native>>>()
+      .value
+      .asFunction<_ToString_Dart>()(ptr.ref.lpVtbl, result);
 }

--- a/lib/src/com/ISupportErrorInfo.dart
+++ b/lib/src/com/ISupportErrorInfo.dart
@@ -34,8 +34,9 @@ class ISupportErrorInfo extends IUnknown {
 
   ISupportErrorInfo(Pointer<COMObject> ptr) : super(ptr);
 
-  int InterfaceSupportsErrorInfo(Pointer<GUID> riid) =>
-      Pointer<NativeFunction<_InterfaceSupportsErrorInfo_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_InterfaceSupportsErrorInfo_Dart>()(ptr.ref.lpVtbl, riid);
+  int InterfaceSupportsErrorInfo(Pointer<GUID> riid) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_InterfaceSupportsErrorInfo_Native>>>()
+      .value
+      .asFunction<_InterfaceSupportsErrorInfo_Dart>()(ptr.ref.lpVtbl, riid);
 }

--- a/lib/src/com/ITypeInfo.dart
+++ b/lib/src/com/ITypeInfo.dart
@@ -165,49 +165,63 @@ class ITypeInfo extends IUnknown {
 
   ITypeInfo(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetTypeAttr(Pointer<Pointer<TYPEATTR>> ppTypeAttr) =>
-      Pointer<NativeFunction<_GetTypeAttr_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetTypeAttr_Dart>()(ptr.ref.lpVtbl, ppTypeAttr);
+  int GetTypeAttr(Pointer<Pointer<TYPEATTR>> ppTypeAttr) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetTypeAttr_Native>>>()
+      .value
+      .asFunction<_GetTypeAttr_Dart>()(ptr.ref.lpVtbl, ppTypeAttr);
 
-  int GetTypeComp(Pointer<Pointer> ppTComp) =>
-      Pointer<NativeFunction<_GetTypeComp_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_GetTypeComp_Dart>()(ptr.ref.lpVtbl, ppTComp);
+  int GetTypeComp(Pointer<Pointer> ppTComp) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_GetTypeComp_Native>>>()
+      .value
+      .asFunction<_GetTypeComp_Dart>()(ptr.ref.lpVtbl, ppTComp);
 
   int GetFuncDesc(int index, Pointer<Pointer<FUNCDESC>> ppFuncDesc) =>
-      Pointer<NativeFunction<_GetFuncDesc_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(5)
+          .cast<Pointer<NativeFunction<_GetFuncDesc_Native>>>()
+          .value
           .asFunction<_GetFuncDesc_Dart>()(ptr.ref.lpVtbl, index, ppFuncDesc);
 
   int GetVarDesc(int index, Pointer<Pointer<VARDESC>> ppVarDesc) =>
-      Pointer<NativeFunction<_GetVarDesc_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<Pointer<NativeFunction<_GetVarDesc_Native>>>()
+          .value
           .asFunction<_GetVarDesc_Dart>()(ptr.ref.lpVtbl, index, ppVarDesc);
 
   int GetNames(int memid, Pointer<Pointer<Utf16>> rgBstrNames, int cMaxNames,
           Pointer<Uint32> pcNames) =>
-      Pointer<NativeFunction<_GetNames_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(7)
+              .cast<Pointer<NativeFunction<_GetNames_Native>>>()
+              .value
               .asFunction<_GetNames_Dart>()(
           ptr.ref.lpVtbl, memid, rgBstrNames, cMaxNames, pcNames);
 
   int GetRefTypeOfImplType(int index, Pointer<Uint32> pRefType) =>
-      Pointer<NativeFunction<_GetRefTypeOfImplType_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(8)
+              .cast<Pointer<NativeFunction<_GetRefTypeOfImplType_Native>>>()
+              .value
               .asFunction<_GetRefTypeOfImplType_Dart>()(
           ptr.ref.lpVtbl, index, pRefType);
 
   int GetImplTypeFlags(int index, Pointer<Int32> pImplTypeFlags) =>
-      Pointer<NativeFunction<_GetImplTypeFlags_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(9).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(9)
+              .cast<Pointer<NativeFunction<_GetImplTypeFlags_Native>>>()
+              .value
               .asFunction<_GetImplTypeFlags_Dart>()(
           ptr.ref.lpVtbl, index, pImplTypeFlags);
 
   int GetIDsOfNames(Pointer<Pointer<Utf16>> rgszNames, int cNames,
           Pointer<Int32> pMemId) =>
-      Pointer<NativeFunction<_GetIDsOfNames_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(10)
+              .cast<Pointer<NativeFunction<_GetIDsOfNames_Native>>>()
+              .value
               .asFunction<_GetIDsOfNames_Dart>()(
           ptr.ref.lpVtbl, rgszNames, cNames, pMemId);
 
@@ -219,8 +233,10 @@ class ITypeInfo extends IUnknown {
           Pointer<VARIANT> pVarResult,
           Pointer<EXCEPINFO> pExcepInfo,
           Pointer<Uint32> puArgErr) =>
-      Pointer<NativeFunction<_Invoke_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(11)
+              .cast<Pointer<NativeFunction<_Invoke_Native>>>()
+              .value
               .asFunction<_Invoke_Dart>()(ptr.ref.lpVtbl, pvInstance, memid,
           wFlags, pDispParams, pVarResult, pExcepInfo, puArgErr);
 
@@ -230,60 +246,75 @@ class ITypeInfo extends IUnknown {
           Pointer<Pointer<Utf16>> pBstrDocString,
           Pointer<Uint32> pdwHelpContext,
           Pointer<Pointer<Utf16>> pBstrHelpFile) =>
-      Pointer<NativeFunction<_GetDocumentation_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(12).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(12)
+              .cast<Pointer<NativeFunction<_GetDocumentation_Native>>>()
+              .value
               .asFunction<_GetDocumentation_Dart>()(ptr.ref.lpVtbl, memid,
           pBstrName, pBstrDocString, pdwHelpContext, pBstrHelpFile);
 
   int GetDllEntry(int memid, int invKind, Pointer<Pointer<Utf16>> pBstrDllName,
           Pointer<Pointer<Utf16>> pBstrName, Pointer<Uint16> pwOrdinal) =>
-      Pointer<NativeFunction<_GetDllEntry_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(13).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(13)
+              .cast<Pointer<NativeFunction<_GetDllEntry_Native>>>()
+              .value
               .asFunction<_GetDllEntry_Dart>()(
           ptr.ref.lpVtbl, memid, invKind, pBstrDllName, pBstrName, pwOrdinal);
 
-  int GetRefTypeInfo(int hRefType, Pointer<Pointer> ppTInfo) =>
-      Pointer<NativeFunction<_GetRefTypeInfo_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(14).value)
-              .asFunction<_GetRefTypeInfo_Dart>()(
-          ptr.ref.lpVtbl, hRefType, ppTInfo);
+  int GetRefTypeInfo(int hRefType, Pointer<Pointer> ppTInfo) => ptr
+      .ref.lpVtbl.value
+      .elementAt(14)
+      .cast<Pointer<NativeFunction<_GetRefTypeInfo_Native>>>()
+      .value
+      .asFunction<_GetRefTypeInfo_Dart>()(ptr.ref.lpVtbl, hRefType, ppTInfo);
 
-  int AddressOfMember(int memid, int invKind, Pointer<Pointer> ppv) =>
-      Pointer<NativeFunction<_AddressOfMember_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(15).value)
-              .asFunction<_AddressOfMember_Dart>()(
-          ptr.ref.lpVtbl, memid, invKind, ppv);
+  int AddressOfMember(int memid, int invKind, Pointer<Pointer> ppv) => ptr
+      .ref.lpVtbl.value
+      .elementAt(15)
+      .cast<Pointer<NativeFunction<_AddressOfMember_Native>>>()
+      .value
+      .asFunction<_AddressOfMember_Dart>()(ptr.ref.lpVtbl, memid, invKind, ppv);
 
   int CreateInstance(
           Pointer pUnkOuter, Pointer<GUID> riid, Pointer<Pointer> ppvObj) =>
-      Pointer<NativeFunction<_CreateInstance_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(16).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(16)
+              .cast<Pointer<NativeFunction<_CreateInstance_Native>>>()
+              .value
               .asFunction<_CreateInstance_Dart>()(
           ptr.ref.lpVtbl, pUnkOuter, riid, ppvObj);
 
   int GetMops(int memid, Pointer<Pointer<Utf16>> pBstrMops) =>
-      Pointer<NativeFunction<_GetMops_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(17).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(17)
+          .cast<Pointer<NativeFunction<_GetMops_Native>>>()
+          .value
           .asFunction<_GetMops_Dart>()(ptr.ref.lpVtbl, memid, pBstrMops);
 
   int GetContainingTypeLib(Pointer<Pointer> ppTLib, Pointer<Uint32> pIndex) =>
-      Pointer<NativeFunction<_GetContainingTypeLib_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(18).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(18)
+              .cast<Pointer<NativeFunction<_GetContainingTypeLib_Native>>>()
+              .value
               .asFunction<_GetContainingTypeLib_Dart>()(
           ptr.ref.lpVtbl, ppTLib, pIndex);
 
-  void ReleaseTypeAttr(Pointer<TYPEATTR> pTypeAttr) =>
-      Pointer<NativeFunction<_ReleaseTypeAttr_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(19).value)
-          .asFunction<_ReleaseTypeAttr_Dart>()(ptr.ref.lpVtbl, pTypeAttr);
+  void ReleaseTypeAttr(Pointer<TYPEATTR> pTypeAttr) => ptr.ref.lpVtbl.value
+      .elementAt(19)
+      .cast<Pointer<NativeFunction<_ReleaseTypeAttr_Native>>>()
+      .value
+      .asFunction<_ReleaseTypeAttr_Dart>()(ptr.ref.lpVtbl, pTypeAttr);
 
-  void ReleaseFuncDesc(Pointer<FUNCDESC> pFuncDesc) =>
-      Pointer<NativeFunction<_ReleaseFuncDesc_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(20).value)
-          .asFunction<_ReleaseFuncDesc_Dart>()(ptr.ref.lpVtbl, pFuncDesc);
+  void ReleaseFuncDesc(Pointer<FUNCDESC> pFuncDesc) => ptr.ref.lpVtbl.value
+      .elementAt(20)
+      .cast<Pointer<NativeFunction<_ReleaseFuncDesc_Native>>>()
+      .value
+      .asFunction<_ReleaseFuncDesc_Dart>()(ptr.ref.lpVtbl, pFuncDesc);
 
-  void ReleaseVarDesc(Pointer<VARDESC> pVarDesc) =>
-      Pointer<NativeFunction<_ReleaseVarDesc_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(21).value)
-          .asFunction<_ReleaseVarDesc_Dart>()(ptr.ref.lpVtbl, pVarDesc);
+  void ReleaseVarDesc(Pointer<VARDESC> pVarDesc) => ptr.ref.lpVtbl.value
+      .elementAt(21)
+      .cast<Pointer<NativeFunction<_ReleaseVarDesc_Native>>>()
+      .value
+      .asFunction<_ReleaseVarDesc_Dart>()(ptr.ref.lpVtbl, pVarDesc);
 }

--- a/lib/src/com/IUri.dart
+++ b/lib/src/com/IUri.dart
@@ -151,134 +151,166 @@ class IUri extends IUnknown {
 
   int GetPropertyBSTR(
           int uriProp, Pointer<Pointer<Utf16>> pbstrProperty, int dwFlags) =>
-      Pointer<NativeFunction<_GetPropertyBSTR_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_GetPropertyBSTR_Native>>>()
+              .value
               .asFunction<_GetPropertyBSTR_Dart>()(
           ptr.ref.lpVtbl, uriProp, pbstrProperty, dwFlags);
 
   int GetPropertyLength(
           int uriProp, Pointer<Uint32> pcchProperty, int dwFlags) =>
-      Pointer<NativeFunction<_GetPropertyLength_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_GetPropertyLength_Native>>>()
+              .value
               .asFunction<_GetPropertyLength_Dart>()(
           ptr.ref.lpVtbl, uriProp, pcchProperty, dwFlags);
 
   int GetPropertyDWORD(int uriProp, Pointer<Uint32> pdwProperty, int dwFlags) =>
-      Pointer<NativeFunction<_GetPropertyDWORD_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_GetPropertyDWORD_Native>>>()
+              .value
               .asFunction<_GetPropertyDWORD_Dart>()(
           ptr.ref.lpVtbl, uriProp, pdwProperty, dwFlags);
 
-  int HasProperty(int uriProp, Pointer<Int32> pfHasProperty) =>
-      Pointer<NativeFunction<_HasProperty_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(6).value)
-              .asFunction<_HasProperty_Dart>()(
-          ptr.ref.lpVtbl, uriProp, pfHasProperty);
+  int HasProperty(int uriProp, Pointer<Int32> pfHasProperty) => ptr
+      .ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_HasProperty_Native>>>()
+      .value
+      .asFunction<_HasProperty_Dart>()(ptr.ref.lpVtbl, uriProp, pfHasProperty);
 
   int GetAbsoluteUri(Pointer<Pointer<Utf16>> pbstrAbsoluteUri) =>
-      Pointer<NativeFunction<_GetAbsoluteUri_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(7)
+          .cast<Pointer<NativeFunction<_GetAbsoluteUri_Native>>>()
+          .value
           .asFunction<_GetAbsoluteUri_Dart>()(ptr.ref.lpVtbl, pbstrAbsoluteUri);
 
   int GetAuthority(Pointer<Pointer<Utf16>> pbstrAuthority) =>
-      Pointer<NativeFunction<_GetAuthority_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_GetAuthority_Native>>>()
+          .value
           .asFunction<_GetAuthority_Dart>()(ptr.ref.lpVtbl, pbstrAuthority);
 
-  int GetDisplayUri(Pointer<Pointer<Utf16>> pbstrDisplayString) =>
-      Pointer<NativeFunction<_GetDisplayUri_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(9).value)
-              .asFunction<_GetDisplayUri_Dart>()(
-          ptr.ref.lpVtbl, pbstrDisplayString);
+  int GetDisplayUri(Pointer<Pointer<Utf16>> pbstrDisplayString) => ptr
+      .ref.lpVtbl.value
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_GetDisplayUri_Native>>>()
+      .value
+      .asFunction<_GetDisplayUri_Dart>()(ptr.ref.lpVtbl, pbstrDisplayString);
 
-  int GetDomain(Pointer<Pointer<Utf16>> pbstrDomain) =>
-      Pointer<NativeFunction<_GetDomain_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_GetDomain_Dart>()(ptr.ref.lpVtbl, pbstrDomain);
+  int GetDomain(Pointer<Pointer<Utf16>> pbstrDomain) => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_GetDomain_Native>>>()
+      .value
+      .asFunction<_GetDomain_Dart>()(ptr.ref.lpVtbl, pbstrDomain);
 
   int GetExtension(Pointer<Pointer<Utf16>> pbstrExtension) =>
-      Pointer<NativeFunction<_GetExtension_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(11)
+          .cast<Pointer<NativeFunction<_GetExtension_Native>>>()
+          .value
           .asFunction<_GetExtension_Dart>()(ptr.ref.lpVtbl, pbstrExtension);
 
-  int GetFragment(Pointer<Pointer<Utf16>> pbstrFragment) =>
-      Pointer<NativeFunction<_GetFragment_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_GetFragment_Dart>()(ptr.ref.lpVtbl, pbstrFragment);
+  int GetFragment(Pointer<Pointer<Utf16>> pbstrFragment) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_GetFragment_Native>>>()
+      .value
+      .asFunction<_GetFragment_Dart>()(ptr.ref.lpVtbl, pbstrFragment);
 
-  int GetHost(Pointer<Pointer<Utf16>> pbstrHost) =>
-      Pointer<NativeFunction<_GetHost_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(13).value)
-          .asFunction<_GetHost_Dart>()(ptr.ref.lpVtbl, pbstrHost);
+  int GetHost(Pointer<Pointer<Utf16>> pbstrHost) => ptr.ref.lpVtbl.value
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_GetHost_Native>>>()
+      .value
+      .asFunction<_GetHost_Dart>()(ptr.ref.lpVtbl, pbstrHost);
 
-  int GetPassword(Pointer<Pointer<Utf16>> pbstrPassword) =>
-      Pointer<NativeFunction<_GetPassword_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(14).value)
-          .asFunction<_GetPassword_Dart>()(ptr.ref.lpVtbl, pbstrPassword);
+  int GetPassword(Pointer<Pointer<Utf16>> pbstrPassword) => ptr.ref.lpVtbl.value
+      .elementAt(14)
+      .cast<Pointer<NativeFunction<_GetPassword_Native>>>()
+      .value
+      .asFunction<_GetPassword_Dart>()(ptr.ref.lpVtbl, pbstrPassword);
 
-  int GetPath(Pointer<Pointer<Utf16>> pbstrPath) =>
-      Pointer<NativeFunction<_GetPath_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(15).value)
-          .asFunction<_GetPath_Dart>()(ptr.ref.lpVtbl, pbstrPath);
+  int GetPath(Pointer<Pointer<Utf16>> pbstrPath) => ptr.ref.lpVtbl.value
+      .elementAt(15)
+      .cast<Pointer<NativeFunction<_GetPath_Native>>>()
+      .value
+      .asFunction<_GetPath_Dart>()(ptr.ref.lpVtbl, pbstrPath);
 
-  int GetPathAndQuery(Pointer<Pointer<Utf16>> pbstrPathAndQuery) =>
-      Pointer<NativeFunction<_GetPathAndQuery_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(16).value)
-              .asFunction<_GetPathAndQuery_Dart>()(
-          ptr.ref.lpVtbl, pbstrPathAndQuery);
+  int GetPathAndQuery(Pointer<Pointer<Utf16>> pbstrPathAndQuery) => ptr
+      .ref.lpVtbl.value
+      .elementAt(16)
+      .cast<Pointer<NativeFunction<_GetPathAndQuery_Native>>>()
+      .value
+      .asFunction<_GetPathAndQuery_Dart>()(ptr.ref.lpVtbl, pbstrPathAndQuery);
 
-  int GetQuery(Pointer<Pointer<Utf16>> pbstrQuery) =>
-      Pointer<NativeFunction<_GetQuery_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(17).value)
-          .asFunction<_GetQuery_Dart>()(ptr.ref.lpVtbl, pbstrQuery);
+  int GetQuery(Pointer<Pointer<Utf16>> pbstrQuery) => ptr.ref.lpVtbl.value
+      .elementAt(17)
+      .cast<Pointer<NativeFunction<_GetQuery_Native>>>()
+      .value
+      .asFunction<_GetQuery_Dart>()(ptr.ref.lpVtbl, pbstrQuery);
 
-  int GetRawUri(Pointer<Pointer<Utf16>> pbstrRawUri) =>
-      Pointer<NativeFunction<_GetRawUri_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(18).value)
-          .asFunction<_GetRawUri_Dart>()(ptr.ref.lpVtbl, pbstrRawUri);
+  int GetRawUri(Pointer<Pointer<Utf16>> pbstrRawUri) => ptr.ref.lpVtbl.value
+      .elementAt(18)
+      .cast<Pointer<NativeFunction<_GetRawUri_Native>>>()
+      .value
+      .asFunction<_GetRawUri_Dart>()(ptr.ref.lpVtbl, pbstrRawUri);
 
   int GetSchemeName(Pointer<Pointer<Utf16>> pbstrSchemeName) =>
-      Pointer<NativeFunction<_GetSchemeName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(19).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(19)
+          .cast<Pointer<NativeFunction<_GetSchemeName_Native>>>()
+          .value
           .asFunction<_GetSchemeName_Dart>()(ptr.ref.lpVtbl, pbstrSchemeName);
 
-  int GetUserInfo(Pointer<Pointer<Utf16>> pbstrUserInfo) =>
-      Pointer<NativeFunction<_GetUserInfo_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(20).value)
-          .asFunction<_GetUserInfo_Dart>()(ptr.ref.lpVtbl, pbstrUserInfo);
+  int GetUserInfo(Pointer<Pointer<Utf16>> pbstrUserInfo) => ptr.ref.lpVtbl.value
+      .elementAt(20)
+      .cast<Pointer<NativeFunction<_GetUserInfo_Native>>>()
+      .value
+      .asFunction<_GetUserInfo_Dart>()(ptr.ref.lpVtbl, pbstrUserInfo);
 
-  int GetUserName(Pointer<Pointer<Utf16>> pbstrUserName) =>
-      Pointer<NativeFunction<_GetUserName_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(21).value)
-          .asFunction<_GetUserName_Dart>()(ptr.ref.lpVtbl, pbstrUserName);
+  int GetUserName(Pointer<Pointer<Utf16>> pbstrUserName) => ptr.ref.lpVtbl.value
+      .elementAt(21)
+      .cast<Pointer<NativeFunction<_GetUserName_Native>>>()
+      .value
+      .asFunction<_GetUserName_Dart>()(ptr.ref.lpVtbl, pbstrUserName);
 
-  int GetHostType(Pointer<Uint32> pdwHostType) =>
-      Pointer<NativeFunction<_GetHostType_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(22).value)
-          .asFunction<_GetHostType_Dart>()(ptr.ref.lpVtbl, pdwHostType);
+  int GetHostType(Pointer<Uint32> pdwHostType) => ptr.ref.lpVtbl.value
+      .elementAt(22)
+      .cast<Pointer<NativeFunction<_GetHostType_Native>>>()
+      .value
+      .asFunction<_GetHostType_Dart>()(ptr.ref.lpVtbl, pdwHostType);
 
-  int GetPort(Pointer<Uint32> pdwPort) =>
-      Pointer<NativeFunction<_GetPort_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(23).value)
-          .asFunction<_GetPort_Dart>()(ptr.ref.lpVtbl, pdwPort);
+  int GetPort(Pointer<Uint32> pdwPort) => ptr.ref.lpVtbl.value
+      .elementAt(23)
+      .cast<Pointer<NativeFunction<_GetPort_Native>>>()
+      .value
+      .asFunction<_GetPort_Dart>()(ptr.ref.lpVtbl, pdwPort);
 
-  int GetScheme(Pointer<Uint32> pdwScheme) =>
-      Pointer<NativeFunction<_GetScheme_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(24).value)
-          .asFunction<_GetScheme_Dart>()(ptr.ref.lpVtbl, pdwScheme);
+  int GetScheme(Pointer<Uint32> pdwScheme) => ptr.ref.lpVtbl.value
+      .elementAt(24)
+      .cast<Pointer<NativeFunction<_GetScheme_Native>>>()
+      .value
+      .asFunction<_GetScheme_Dart>()(ptr.ref.lpVtbl, pdwScheme);
 
-  int GetZone(Pointer<Uint32> pdwZone) =>
-      Pointer<NativeFunction<_GetZone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(25).value)
-          .asFunction<_GetZone_Dart>()(ptr.ref.lpVtbl, pdwZone);
+  int GetZone(Pointer<Uint32> pdwZone) => ptr.ref.lpVtbl.value
+      .elementAt(25)
+      .cast<Pointer<NativeFunction<_GetZone_Native>>>()
+      .value
+      .asFunction<_GetZone_Dart>()(ptr.ref.lpVtbl, pdwZone);
 
-  int GetProperties(Pointer<Uint32> pdwFlags) =>
-      Pointer<NativeFunction<_GetProperties_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(26).value)
-          .asFunction<_GetProperties_Dart>()(ptr.ref.lpVtbl, pdwFlags);
+  int GetProperties(Pointer<Uint32> pdwFlags) => ptr.ref.lpVtbl.value
+      .elementAt(26)
+      .cast<Pointer<NativeFunction<_GetProperties_Native>>>()
+      .value
+      .asFunction<_GetProperties_Dart>()(ptr.ref.lpVtbl, pdwFlags);
 
-  int IsEqual(Pointer pUri, Pointer<Int32> pfEqual) =>
-      Pointer<NativeFunction<_IsEqual_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(27).value)
-          .asFunction<_IsEqual_Dart>()(ptr.ref.lpVtbl, pUri, pfEqual);
+  int IsEqual(Pointer pUri, Pointer<Int32> pfEqual) => ptr.ref.lpVtbl.value
+      .elementAt(27)
+      .cast<Pointer<NativeFunction<_IsEqual_Native>>>()
+      .value
+      .asFunction<_IsEqual_Dart>()(ptr.ref.lpVtbl, pUri, pfEqual);
 }

--- a/lib/src/com/IUserDataPathsStatics.dart
+++ b/lib/src/com/IUserDataPathsStatics.dart
@@ -40,13 +40,15 @@ class IUserDataPathsStatics extends IInspectable {
 
   IUserDataPathsStatics(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetForUser(Pointer user, Pointer<Pointer> result) =>
-      Pointer<NativeFunction<_GetForUser_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_GetForUser_Dart>()(ptr.ref.lpVtbl, user, result);
+  int GetForUser(Pointer user, Pointer<Pointer> result) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_GetForUser_Native>>>()
+      .value
+      .asFunction<_GetForUser_Dart>()(ptr.ref.lpVtbl, user, result);
 
-  int GetDefault(Pointer<Pointer> result) =>
-      Pointer<NativeFunction<_GetDefault_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_GetDefault_Dart>()(ptr.ref.lpVtbl, result);
+  int GetDefault(Pointer<Pointer> result) => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetDefault_Native>>>()
+      .value
+      .asFunction<_GetDefault_Dart>()(ptr.ref.lpVtbl, result);
 }

--- a/lib/src/com/IVirtualDesktopManager.dart
+++ b/lib/src/com/IVirtualDesktopManager.dart
@@ -47,24 +47,32 @@ class IVirtualDesktopManager extends IUnknown {
 
   IVirtualDesktopManager(Pointer<COMObject> ptr) : super(ptr);
 
-  int IsWindowOnCurrentVirtualDesktop(
-          int topLevelWindow, Pointer<Int32> onCurrentDesktop) =>
-      Pointer<
-                      NativeFunction<
-                          _IsWindowOnCurrentVirtualDesktop_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
-              .asFunction<_IsWindowOnCurrentVirtualDesktop_Dart>()(
-          ptr.ref.lpVtbl, topLevelWindow, onCurrentDesktop);
+  int
+      IsWindowOnCurrentVirtualDesktop(
+              int topLevelWindow, Pointer<Int32> onCurrentDesktop) =>
+          ptr.ref.lpVtbl.value
+                  .elementAt(3)
+                  .cast<
+                      Pointer<
+                          NativeFunction<
+                              _IsWindowOnCurrentVirtualDesktop_Native>>>()
+                  .value
+                  .asFunction<_IsWindowOnCurrentVirtualDesktop_Dart>()(
+              ptr.ref.lpVtbl, topLevelWindow, onCurrentDesktop);
 
   int GetWindowDesktopId(int topLevelWindow, Pointer<GUID> desktopId) =>
-      Pointer<NativeFunction<_GetWindowDesktopId_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_GetWindowDesktopId_Native>>>()
+              .value
               .asFunction<_GetWindowDesktopId_Dart>()(
           ptr.ref.lpVtbl, topLevelWindow, desktopId);
 
   int MoveWindowToDesktop(int topLevelWindow, Pointer<GUID> desktopId) =>
-      Pointer<NativeFunction<_MoveWindowToDesktop_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_MoveWindowToDesktop_Native>>>()
+              .value
               .asFunction<_MoveWindowToDesktop_Dart>()(
           ptr.ref.lpVtbl, topLevelWindow, desktopId);
 }

--- a/lib/src/com/IWbemClassObject.dart
+++ b/lib/src/com/IWbemClassObject.dart
@@ -186,148 +186,184 @@ class IWbemClassObject extends IUnknown {
 
   IWbemClassObject(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetQualifierSet(Pointer<Pointer> ppQualSet) =>
-      Pointer<NativeFunction<_GetQualifierSet_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_GetQualifierSet_Dart>()(ptr.ref.lpVtbl, ppQualSet);
+  int GetQualifierSet(Pointer<Pointer> ppQualSet) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_GetQualifierSet_Native>>>()
+      .value
+      .asFunction<_GetQualifierSet_Dart>()(ptr.ref.lpVtbl, ppQualSet);
 
   int Get(Pointer<Utf16> wszName, int lFlags, Pointer<VARIANT> pVal,
           Pointer<Int32> pType, Pointer<Int32> plFlavor) =>
-      Pointer<NativeFunction<_Get_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(4)
+              .cast<Pointer<NativeFunction<_Get_Native>>>()
+              .value
               .asFunction<_Get_Dart>()(
           ptr.ref.lpVtbl, wszName, lFlags, pVal, pType, plFlavor);
 
   int Put(Pointer<Utf16> wszName, int lFlags, Pointer<VARIANT> pVal,
           int Type) =>
-      Pointer<NativeFunction<_Put_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(5)
+          .cast<Pointer<NativeFunction<_Put_Native>>>()
+          .value
           .asFunction<_Put_Dart>()(ptr.ref.lpVtbl, wszName, lFlags, pVal, Type);
 
-  int Delete(Pointer<Utf16> wszName) =>
-      Pointer<NativeFunction<_Delete_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
-          .asFunction<_Delete_Dart>()(ptr.ref.lpVtbl, wszName);
+  int Delete(Pointer<Utf16> wszName) => ptr.ref.lpVtbl.value
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_Delete_Native>>>()
+      .value
+      .asFunction<_Delete_Dart>()(ptr.ref.lpVtbl, wszName);
 
   int GetNames(Pointer<Utf16> wszQualifierName, int lFlags,
           Pointer<VARIANT> pQualifierVal, Pointer<Pointer<SAFEARRAY>> pNames) =>
-      Pointer<NativeFunction<_GetNames_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(7)
+              .cast<Pointer<NativeFunction<_GetNames_Native>>>()
+              .value
               .asFunction<_GetNames_Dart>()(
           ptr.ref.lpVtbl, wszQualifierName, lFlags, pQualifierVal, pNames);
 
-  int BeginEnumeration(int lEnumFlags) =>
-      Pointer<NativeFunction<_BeginEnumeration_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(8).value)
-          .asFunction<_BeginEnumeration_Dart>()(ptr.ref.lpVtbl, lEnumFlags);
+  int BeginEnumeration(int lEnumFlags) => ptr.ref.lpVtbl.value
+      .elementAt(8)
+      .cast<Pointer<NativeFunction<_BeginEnumeration_Native>>>()
+      .value
+      .asFunction<_BeginEnumeration_Dart>()(ptr.ref.lpVtbl, lEnumFlags);
 
   int Next(int lFlags, Pointer<Pointer<Utf16>> strName, Pointer<VARIANT> pVal,
           Pointer<Int32> pType, Pointer<Int32> plFlavor) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(9).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(9)
+              .cast<Pointer<NativeFunction<_Next_Native>>>()
+              .value
               .asFunction<_Next_Dart>()(
           ptr.ref.lpVtbl, lFlags, strName, pVal, pType, plFlavor);
 
-  int EndEnumeration() =>
-      Pointer<NativeFunction<_EndEnumeration_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_EndEnumeration_Dart>()(ptr.ref.lpVtbl);
+  int EndEnumeration() => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_EndEnumeration_Native>>>()
+      .value
+      .asFunction<_EndEnumeration_Dart>()(ptr.ref.lpVtbl);
 
   int GetPropertyQualifierSet(
           Pointer<Utf16> wszProperty, Pointer<Pointer> ppQualSet) =>
-      Pointer<NativeFunction<_GetPropertyQualifierSet_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(11)
+              .cast<Pointer<NativeFunction<_GetPropertyQualifierSet_Native>>>()
+              .value
               .asFunction<_GetPropertyQualifierSet_Dart>()(
           ptr.ref.lpVtbl, wszProperty, ppQualSet);
 
-  int Clone(Pointer<Pointer> ppCopy) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(12).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppCopy);
+  int Clone(Pointer<Pointer> ppCopy) => ptr.ref.lpVtbl.value
+      .elementAt(12)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppCopy);
 
   int GetObjectText(int lFlags, Pointer<Pointer<Utf16>> pstrObjectText) =>
-      Pointer<NativeFunction<_GetObjectText_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(13).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(13)
+              .cast<Pointer<NativeFunction<_GetObjectText_Native>>>()
+              .value
               .asFunction<_GetObjectText_Dart>()(
           ptr.ref.lpVtbl, lFlags, pstrObjectText);
 
   int SpawnDerivedClass(int lFlags, Pointer<Pointer> ppNewClass) =>
-      Pointer<NativeFunction<_SpawnDerivedClass_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(14).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(14)
+              .cast<Pointer<NativeFunction<_SpawnDerivedClass_Native>>>()
+              .value
               .asFunction<_SpawnDerivedClass_Dart>()(
           ptr.ref.lpVtbl, lFlags, ppNewClass);
 
-  int SpawnInstance(int lFlags, Pointer<Pointer> ppNewInstance) =>
-      Pointer<NativeFunction<_SpawnInstance_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(15).value)
-              .asFunction<_SpawnInstance_Dart>()(
-          ptr.ref.lpVtbl, lFlags, ppNewInstance);
+  int SpawnInstance(int lFlags, Pointer<Pointer> ppNewInstance) => ptr
+      .ref.lpVtbl.value
+      .elementAt(15)
+      .cast<Pointer<NativeFunction<_SpawnInstance_Native>>>()
+      .value
+      .asFunction<_SpawnInstance_Dart>()(ptr.ref.lpVtbl, lFlags, ppNewInstance);
 
-  int CompareTo(int lFlags, Pointer pCompareTo) =>
-      Pointer<NativeFunction<_CompareTo_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(16).value)
-          .asFunction<_CompareTo_Dart>()(ptr.ref.lpVtbl, lFlags, pCompareTo);
+  int CompareTo(int lFlags, Pointer pCompareTo) => ptr.ref.lpVtbl.value
+      .elementAt(16)
+      .cast<Pointer<NativeFunction<_CompareTo_Native>>>()
+      .value
+      .asFunction<_CompareTo_Dart>()(ptr.ref.lpVtbl, lFlags, pCompareTo);
 
   int GetPropertyOrigin(
           Pointer<Utf16> wszName, Pointer<Pointer<Utf16>> pstrClassName) =>
-      Pointer<NativeFunction<_GetPropertyOrigin_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(17).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(17)
+              .cast<Pointer<NativeFunction<_GetPropertyOrigin_Native>>>()
+              .value
               .asFunction<_GetPropertyOrigin_Dart>()(
           ptr.ref.lpVtbl, wszName, pstrClassName);
 
-  int InheritsFrom(Pointer<Utf16> strAncestor) =>
-      Pointer<NativeFunction<_InheritsFrom_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(18).value)
-          .asFunction<_InheritsFrom_Dart>()(ptr.ref.lpVtbl, strAncestor);
+  int InheritsFrom(Pointer<Utf16> strAncestor) => ptr.ref.lpVtbl.value
+      .elementAt(18)
+      .cast<Pointer<NativeFunction<_InheritsFrom_Native>>>()
+      .value
+      .asFunction<_InheritsFrom_Dart>()(ptr.ref.lpVtbl, strAncestor);
 
   int GetMethod(Pointer<Utf16> wszName, int lFlags,
           Pointer<Pointer> ppInSignature, Pointer<Pointer> ppOutSignature) =>
-      Pointer<NativeFunction<_GetMethod_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(19).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(19)
+              .cast<Pointer<NativeFunction<_GetMethod_Native>>>()
+              .value
               .asFunction<_GetMethod_Dart>()(
           ptr.ref.lpVtbl, wszName, lFlags, ppInSignature, ppOutSignature);
 
   int PutMethod(Pointer<Utf16> wszName, int lFlags, Pointer pInSignature,
           Pointer pOutSignature) =>
-      Pointer<NativeFunction<_PutMethod_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(20).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(20)
+              .cast<Pointer<NativeFunction<_PutMethod_Native>>>()
+              .value
               .asFunction<_PutMethod_Dart>()(
           ptr.ref.lpVtbl, wszName, lFlags, pInSignature, pOutSignature);
 
-  int DeleteMethod(Pointer<Utf16> wszName) =>
-      Pointer<NativeFunction<_DeleteMethod_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(21).value)
-          .asFunction<_DeleteMethod_Dart>()(ptr.ref.lpVtbl, wszName);
+  int DeleteMethod(Pointer<Utf16> wszName) => ptr.ref.lpVtbl.value
+      .elementAt(21)
+      .cast<Pointer<NativeFunction<_DeleteMethod_Native>>>()
+      .value
+      .asFunction<_DeleteMethod_Dart>()(ptr.ref.lpVtbl, wszName);
 
-  int BeginMethodEnumeration(int lEnumFlags) =>
-      Pointer<NativeFunction<_BeginMethodEnumeration_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(22).value)
-              .asFunction<_BeginMethodEnumeration_Dart>()(
-          ptr.ref.lpVtbl, lEnumFlags);
+  int BeginMethodEnumeration(int lEnumFlags) => ptr.ref.lpVtbl.value
+      .elementAt(22)
+      .cast<Pointer<NativeFunction<_BeginMethodEnumeration_Native>>>()
+      .value
+      .asFunction<_BeginMethodEnumeration_Dart>()(ptr.ref.lpVtbl, lEnumFlags);
 
   int NextMethod(int lFlags, Pointer<Pointer<Utf16>> pstrName,
           Pointer<Pointer> ppInSignature, Pointer<Pointer> ppOutSignature) =>
-      Pointer<NativeFunction<_NextMethod_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(23).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(23)
+              .cast<Pointer<NativeFunction<_NextMethod_Native>>>()
+              .value
               .asFunction<_NextMethod_Dart>()(
           ptr.ref.lpVtbl, lFlags, pstrName, ppInSignature, ppOutSignature);
 
-  int EndMethodEnumeration() =>
-      Pointer<NativeFunction<_EndMethodEnumeration_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(24).value)
-          .asFunction<_EndMethodEnumeration_Dart>()(ptr.ref.lpVtbl);
+  int EndMethodEnumeration() => ptr.ref.lpVtbl.value
+      .elementAt(24)
+      .cast<Pointer<NativeFunction<_EndMethodEnumeration_Native>>>()
+      .value
+      .asFunction<_EndMethodEnumeration_Dart>()(ptr.ref.lpVtbl);
 
   int GetMethodQualifierSet(
           Pointer<Utf16> wszMethod, Pointer<Pointer> ppQualSet) =>
-      Pointer<NativeFunction<_GetMethodQualifierSet_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(25).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(25)
+              .cast<Pointer<NativeFunction<_GetMethodQualifierSet_Native>>>()
+              .value
               .asFunction<_GetMethodQualifierSet_Dart>()(
           ptr.ref.lpVtbl, wszMethod, ppQualSet);
 
   int GetMethodOrigin(Pointer<Utf16> wszMethodName,
           Pointer<Pointer<Utf16>> pstrClassName) =>
-      Pointer<NativeFunction<_GetMethodOrigin_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(26).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(26)
+              .cast<Pointer<NativeFunction<_GetMethodOrigin_Native>>>()
+              .value
               .asFunction<_GetMethodOrigin_Dart>()(
           ptr.ref.lpVtbl, wszMethodName, pstrClassName);
 }

--- a/lib/src/com/IWbemContext.dart
+++ b/lib/src/com/IWbemContext.dart
@@ -69,51 +69,65 @@ class IWbemContext extends IUnknown {
 
   IWbemContext(Pointer<COMObject> ptr) : super(ptr);
 
-  int Clone(Pointer<Pointer> ppNewCopy) =>
-      Pointer<NativeFunction<_Clone_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(3).value)
-          .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppNewCopy);
+  int Clone(Pointer<Pointer> ppNewCopy) => ptr.ref.lpVtbl.value
+      .elementAt(3)
+      .cast<Pointer<NativeFunction<_Clone_Native>>>()
+      .value
+      .asFunction<_Clone_Dart>()(ptr.ref.lpVtbl, ppNewCopy);
 
   int GetNames(int lFlags, Pointer<Pointer<SAFEARRAY>> pNames) =>
-      Pointer<NativeFunction<_GetNames_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(4)
+          .cast<Pointer<NativeFunction<_GetNames_Native>>>()
+          .value
           .asFunction<_GetNames_Dart>()(ptr.ref.lpVtbl, lFlags, pNames);
 
-  int BeginEnumeration(int lFlags) =>
-      Pointer<NativeFunction<_BeginEnumeration_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(5).value)
-          .asFunction<_BeginEnumeration_Dart>()(ptr.ref.lpVtbl, lFlags);
+  int BeginEnumeration(int lFlags) => ptr.ref.lpVtbl.value
+      .elementAt(5)
+      .cast<Pointer<NativeFunction<_BeginEnumeration_Native>>>()
+      .value
+      .asFunction<_BeginEnumeration_Dart>()(ptr.ref.lpVtbl, lFlags);
 
   int Next(int lFlags, Pointer<Pointer<Utf16>> pstrName,
           Pointer<VARIANT> pValue) =>
-      Pointer<NativeFunction<_Next_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<Pointer<NativeFunction<_Next_Native>>>()
+          .value
           .asFunction<_Next_Dart>()(ptr.ref.lpVtbl, lFlags, pstrName, pValue);
 
-  int EndEnumeration() =>
-      Pointer<NativeFunction<_EndEnumeration_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(7).value)
-          .asFunction<_EndEnumeration_Dart>()(ptr.ref.lpVtbl);
+  int EndEnumeration() => ptr.ref.lpVtbl.value
+      .elementAt(7)
+      .cast<Pointer<NativeFunction<_EndEnumeration_Native>>>()
+      .value
+      .asFunction<_EndEnumeration_Dart>()(ptr.ref.lpVtbl);
 
   int SetValue(Pointer<Utf16> wszName, int lFlags, Pointer<VARIANT> pValue) =>
-      Pointer<NativeFunction<_SetValue_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(8)
+              .cast<Pointer<NativeFunction<_SetValue_Native>>>()
+              .value
               .asFunction<_SetValue_Dart>()(
           ptr.ref.lpVtbl, wszName, lFlags, pValue);
 
   int GetValue(Pointer<Utf16> wszName, int lFlags, Pointer<VARIANT> pValue) =>
-      Pointer<NativeFunction<_GetValue_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(9).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(9)
+              .cast<Pointer<NativeFunction<_GetValue_Native>>>()
+              .value
               .asFunction<_GetValue_Dart>()(
           ptr.ref.lpVtbl, wszName, lFlags, pValue);
 
-  int DeleteValue(Pointer<Utf16> wszName, int lFlags) =>
-      Pointer<NativeFunction<_DeleteValue_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(10).value)
-          .asFunction<_DeleteValue_Dart>()(ptr.ref.lpVtbl, wszName, lFlags);
+  int DeleteValue(Pointer<Utf16> wszName, int lFlags) => ptr.ref.lpVtbl.value
+      .elementAt(10)
+      .cast<Pointer<NativeFunction<_DeleteValue_Native>>>()
+      .value
+      .asFunction<_DeleteValue_Dart>()(ptr.ref.lpVtbl, wszName, lFlags);
 
-  int DeleteAll() => Pointer<NativeFunction<_DeleteAll_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(11).value)
+  int DeleteAll() => ptr.ref.lpVtbl.value
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_DeleteAll_Native>>>()
+      .value
       .asFunction<_DeleteAll_Dart>()(ptr.ref.lpVtbl);
 }
 

--- a/lib/src/com/IWbemLocator.dart
+++ b/lib/src/com/IWbemLocator.dart
@@ -62,8 +62,10 @@ class IWbemLocator extends IUnknown {
           Pointer<Utf16> strAuthority,
           Pointer pCtx,
           Pointer<Pointer> ppNamespace) =>
-      Pointer<NativeFunction<_ConnectServer_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_ConnectServer_Native>>>()
+              .value
               .asFunction<_ConnectServer_Dart>()(
           ptr.ref.lpVtbl,
           strNetworkResource,

--- a/lib/src/com/IWbemServices.dart
+++ b/lib/src/com/IWbemServices.dart
@@ -298,131 +298,168 @@ class IWbemServices extends IUnknown {
 
   int OpenNamespace(Pointer<Utf16> strNamespace, int lFlags, Pointer pCtx,
           Pointer<Pointer> ppWorkingNamespace, Pointer<Pointer> ppResult) =>
-      Pointer<NativeFunction<_OpenNamespace_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(3).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(3)
+              .cast<Pointer<NativeFunction<_OpenNamespace_Native>>>()
+              .value
               .asFunction<_OpenNamespace_Dart>()(ptr.ref.lpVtbl, strNamespace,
           lFlags, pCtx, ppWorkingNamespace, ppResult);
 
-  int CancelAsyncCall(Pointer pSink) =>
-      Pointer<NativeFunction<_CancelAsyncCall_Native>>.fromAddress(
-              ptr.ref.vtable.elementAt(4).value)
-          .asFunction<_CancelAsyncCall_Dart>()(ptr.ref.lpVtbl, pSink);
+  int CancelAsyncCall(Pointer pSink) => ptr.ref.lpVtbl.value
+      .elementAt(4)
+      .cast<Pointer<NativeFunction<_CancelAsyncCall_Native>>>()
+      .value
+      .asFunction<_CancelAsyncCall_Dart>()(ptr.ref.lpVtbl, pSink);
 
   int QueryObjectSink(int lFlags, Pointer<Pointer> ppResponseHandler) =>
-      Pointer<NativeFunction<_QueryObjectSink_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(5).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(5)
+              .cast<Pointer<NativeFunction<_QueryObjectSink_Native>>>()
+              .value
               .asFunction<_QueryObjectSink_Dart>()(
           ptr.ref.lpVtbl, lFlags, ppResponseHandler);
 
   int GetObject(Pointer<Utf16> strObjectPath, int lFlags, Pointer pCtx,
           Pointer<Pointer> ppObject, Pointer<Pointer> ppCallResult) =>
-      Pointer<NativeFunction<_GetObject_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(6).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(6)
+              .cast<Pointer<NativeFunction<_GetObject_Native>>>()
+              .value
               .asFunction<_GetObject_Dart>()(
           ptr.ref.lpVtbl, strObjectPath, lFlags, pCtx, ppObject, ppCallResult);
 
   int GetObjectAsync(Pointer<Utf16> strObjectPath, int lFlags, Pointer pCtx,
           Pointer pResponseHandler) =>
-      Pointer<NativeFunction<_GetObjectAsync_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(7).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(7)
+              .cast<Pointer<NativeFunction<_GetObjectAsync_Native>>>()
+              .value
               .asFunction<_GetObjectAsync_Dart>()(
           ptr.ref.lpVtbl, strObjectPath, lFlags, pCtx, pResponseHandler);
 
   int PutClass(Pointer pObject, int lFlags, Pointer pCtx,
           Pointer<Pointer> ppCallResult) =>
-      Pointer<NativeFunction<_PutClass_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(8).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(8)
+              .cast<Pointer<NativeFunction<_PutClass_Native>>>()
+              .value
               .asFunction<_PutClass_Dart>()(
           ptr.ref.lpVtbl, pObject, lFlags, pCtx, ppCallResult);
 
   int PutClassAsync(Pointer pObject, int lFlags, Pointer pCtx,
           Pointer pResponseHandler) =>
-      Pointer<NativeFunction<_PutClassAsync_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(9).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(9)
+              .cast<Pointer<NativeFunction<_PutClassAsync_Native>>>()
+              .value
               .asFunction<_PutClassAsync_Dart>()(
           ptr.ref.lpVtbl, pObject, lFlags, pCtx, pResponseHandler);
 
   int DeleteClass(Pointer<Utf16> strClass, int lFlags, Pointer pCtx,
           Pointer<Pointer> ppCallResult) =>
-      Pointer<NativeFunction<_DeleteClass_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(10).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(10)
+              .cast<Pointer<NativeFunction<_DeleteClass_Native>>>()
+              .value
               .asFunction<_DeleteClass_Dart>()(
           ptr.ref.lpVtbl, strClass, lFlags, pCtx, ppCallResult);
 
   int DeleteClassAsync(Pointer<Utf16> strClass, int lFlags, Pointer pCtx,
           Pointer pResponseHandler) =>
-      Pointer<NativeFunction<_DeleteClassAsync_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(11).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(11)
+              .cast<Pointer<NativeFunction<_DeleteClassAsync_Native>>>()
+              .value
               .asFunction<_DeleteClassAsync_Dart>()(
           ptr.ref.lpVtbl, strClass, lFlags, pCtx, pResponseHandler);
 
   int CreateClassEnum(Pointer<Utf16> strSuperclass, int lFlags, Pointer pCtx,
           Pointer<Pointer> ppEnum) =>
-      Pointer<NativeFunction<_CreateClassEnum_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(12).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(12)
+              .cast<Pointer<NativeFunction<_CreateClassEnum_Native>>>()
+              .value
               .asFunction<_CreateClassEnum_Dart>()(
           ptr.ref.lpVtbl, strSuperclass, lFlags, pCtx, ppEnum);
 
   int CreateClassEnumAsync(Pointer<Utf16> strSuperclass, int lFlags,
           Pointer pCtx, Pointer pResponseHandler) =>
-      Pointer<NativeFunction<_CreateClassEnumAsync_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(13).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(13)
+              .cast<Pointer<NativeFunction<_CreateClassEnumAsync_Native>>>()
+              .value
               .asFunction<_CreateClassEnumAsync_Dart>()(
           ptr.ref.lpVtbl, strSuperclass, lFlags, pCtx, pResponseHandler);
 
   int PutInstance(Pointer pInst, int lFlags, Pointer pCtx,
           Pointer<Pointer> ppCallResult) =>
-      Pointer<NativeFunction<_PutInstance_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(14).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(14)
+              .cast<Pointer<NativeFunction<_PutInstance_Native>>>()
+              .value
               .asFunction<_PutInstance_Dart>()(
           ptr.ref.lpVtbl, pInst, lFlags, pCtx, ppCallResult);
 
   int PutInstanceAsync(
           Pointer pInst, int lFlags, Pointer pCtx, Pointer pResponseHandler) =>
-      Pointer<NativeFunction<_PutInstanceAsync_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(15).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(15)
+              .cast<Pointer<NativeFunction<_PutInstanceAsync_Native>>>()
+              .value
               .asFunction<_PutInstanceAsync_Dart>()(
           ptr.ref.lpVtbl, pInst, lFlags, pCtx, pResponseHandler);
 
   int DeleteInstance(Pointer<Utf16> strObjectPath, int lFlags, Pointer pCtx,
           Pointer<Pointer> ppCallResult) =>
-      Pointer<NativeFunction<_DeleteInstance_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(16).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(16)
+              .cast<Pointer<NativeFunction<_DeleteInstance_Native>>>()
+              .value
               .asFunction<_DeleteInstance_Dart>()(
           ptr.ref.lpVtbl, strObjectPath, lFlags, pCtx, ppCallResult);
 
   int DeleteInstanceAsync(Pointer<Utf16> strObjectPath, int lFlags,
           Pointer pCtx, Pointer pResponseHandler) =>
-      Pointer<NativeFunction<_DeleteInstanceAsync_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(17).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(17)
+              .cast<Pointer<NativeFunction<_DeleteInstanceAsync_Native>>>()
+              .value
               .asFunction<_DeleteInstanceAsync_Dart>()(
           ptr.ref.lpVtbl, strObjectPath, lFlags, pCtx, pResponseHandler);
 
   int CreateInstanceEnum(Pointer<Utf16> strFilter, int lFlags, Pointer pCtx,
           Pointer<Pointer> ppEnum) =>
-      Pointer<NativeFunction<_CreateInstanceEnum_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(18).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(18)
+              .cast<Pointer<NativeFunction<_CreateInstanceEnum_Native>>>()
+              .value
               .asFunction<_CreateInstanceEnum_Dart>()(
           ptr.ref.lpVtbl, strFilter, lFlags, pCtx, ppEnum);
 
   int CreateInstanceEnumAsync(Pointer<Utf16> strFilter, int lFlags,
           Pointer pCtx, Pointer pResponseHandler) =>
-      Pointer<NativeFunction<_CreateInstanceEnumAsync_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(19).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(19)
+              .cast<Pointer<NativeFunction<_CreateInstanceEnumAsync_Native>>>()
+              .value
               .asFunction<_CreateInstanceEnumAsync_Dart>()(
           ptr.ref.lpVtbl, strFilter, lFlags, pCtx, pResponseHandler);
 
   int ExecQuery(Pointer<Utf16> strQueryLanguage, Pointer<Utf16> strQuery,
           int lFlags, Pointer pCtx, Pointer<Pointer> ppEnum) =>
-      Pointer<NativeFunction<_ExecQuery_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(20).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(20)
+              .cast<Pointer<NativeFunction<_ExecQuery_Native>>>()
+              .value
               .asFunction<_ExecQuery_Dart>()(
           ptr.ref.lpVtbl, strQueryLanguage, strQuery, lFlags, pCtx, ppEnum);
 
   int ExecQueryAsync(Pointer<Utf16> strQueryLanguage, Pointer<Utf16> strQuery,
           int lFlags, Pointer pCtx, Pointer pResponseHandler) =>
-      Pointer<NativeFunction<_ExecQueryAsync_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(21).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(21)
+              .cast<Pointer<NativeFunction<_ExecQueryAsync_Native>>>()
+              .value
               .asFunction<_ExecQueryAsync_Dart>()(ptr.ref.lpVtbl,
           strQueryLanguage, strQuery, lFlags, pCtx, pResponseHandler);
 
@@ -432,8 +469,10 @@ class IWbemServices extends IUnknown {
           int lFlags,
           Pointer pCtx,
           Pointer<Pointer> ppEnum) =>
-      Pointer<NativeFunction<_ExecNotificationQuery_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(22).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(22)
+              .cast<Pointer<NativeFunction<_ExecNotificationQuery_Native>>>()
+              .value
               .asFunction<_ExecNotificationQuery_Dart>()(
           ptr.ref.lpVtbl, strQueryLanguage, strQuery, lFlags, pCtx, ppEnum);
 
@@ -443,8 +482,10 @@ class IWbemServices extends IUnknown {
           int lFlags,
           Pointer pCtx,
           Pointer pResponseHandler) =>
-      Pointer<NativeFunction<_ExecNotificationQueryAsync_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(23).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(23)
+              .cast<Pointer<NativeFunction<_ExecNotificationQueryAsync_Native>>>()
+              .value
               .asFunction<_ExecNotificationQueryAsync_Dart>()(ptr.ref.lpVtbl,
           strQueryLanguage, strQuery, lFlags, pCtx, pResponseHandler);
 
@@ -456,8 +497,10 @@ class IWbemServices extends IUnknown {
           Pointer pInParams,
           Pointer<Pointer> ppOutParams,
           Pointer<Pointer> ppCallResult) =>
-      Pointer<NativeFunction<_ExecMethod_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(24).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(24)
+              .cast<Pointer<NativeFunction<_ExecMethod_Native>>>()
+              .value
               .asFunction<_ExecMethod_Dart>()(ptr.ref.lpVtbl, strObjectPath,
           strMethodName, lFlags, pCtx, pInParams, ppOutParams, ppCallResult);
 
@@ -468,8 +511,10 @@ class IWbemServices extends IUnknown {
           Pointer pCtx,
           Pointer pInParams,
           Pointer pResponseHandler) =>
-      Pointer<NativeFunction<_ExecMethodAsync_Native>>.fromAddress(
-                  ptr.ref.vtable.elementAt(25).value)
+      ptr.ref.lpVtbl.value
+              .elementAt(25)
+              .cast<Pointer<NativeFunction<_ExecMethodAsync_Native>>>()
+              .value
               .asFunction<_ExecMethodAsync_Dart>()(
           ptr.ref.lpVtbl,
           strObjectPath,

--- a/test/tool/goldens/IAsyncInfo.golden
+++ b/test/tool/goldens/IAsyncInfo.golden
@@ -65,9 +65,12 @@ class IAsyncInfo extends IInspectable {
       final retValuePtr = calloc<Uint32>();
       
       try {
-        final hr = Pointer<NativeFunction<_get_Id_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(6).value)
-           .asFunction<_get_Id_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+        final hr = ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<Pointer<NativeFunction<_get_Id_Native>>>()
+          .value
+          .asFunction<_get_Id_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+          
         if (FAILED(hr)) throw WindowsException(hr);
 
         final retValue = retValuePtr.value;
@@ -81,9 +84,12 @@ class IAsyncInfo extends IInspectable {
       final retValuePtr = calloc<Uint32>();
       
       try {
-        final hr = Pointer<NativeFunction<_get_Status_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(7).value)
-           .asFunction<_get_Status_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+        final hr = ptr.ref.lpVtbl.value
+          .elementAt(7)
+          .cast<Pointer<NativeFunction<_get_Status_Native>>>()
+          .value
+          .asFunction<_get_Status_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+          
         if (FAILED(hr)) throw WindowsException(hr);
 
         final retValue = retValuePtr.value;
@@ -97,9 +103,12 @@ class IAsyncInfo extends IInspectable {
       final retValuePtr = calloc<Uint32>();
       
       try {
-        final hr = Pointer<NativeFunction<_get_ErrorCode_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(8).value)
-           .asFunction<_get_ErrorCode_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+        final hr = ptr.ref.lpVtbl.value
+          .elementAt(8)
+          .cast<Pointer<NativeFunction<_get_ErrorCode_Native>>>()
+          .value
+          .asFunction<_get_ErrorCode_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+          
         if (FAILED(hr)) throw WindowsException(hr);
 
         final retValue = retValuePtr.value;
@@ -109,17 +118,15 @@ class IAsyncInfo extends IInspectable {
       }
     }
 
-  int Cancel() =>
-    Pointer<NativeFunction<_Cancel_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(9).value)
-            .asFunction<_Cancel_Dart>()(
-         ptr.ref.lpVtbl);
+  int Cancel() => ptr.ref.lpVtbl.value      .elementAt(9)
+      .cast<Pointer<NativeFunction<_Cancel_Native>>>()
+      .value
+      .asFunction<_Cancel_Dart>()(ptr.ref.lpVtbl);
 
-  int Close() =>
-    Pointer<NativeFunction<_Close_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(10).value)
-            .asFunction<_Close_Dart>()(
-         ptr.ref.lpVtbl);
+  int Close() => ptr.ref.lpVtbl.value      .elementAt(10)
+      .cast<Pointer<NativeFunction<_Close_Native>>>()
+      .value
+      .asFunction<_Close_Dart>()(ptr.ref.lpVtbl);
 
 }
 

--- a/test/tool/goldens/INetwork.golden
+++ b/test/tool/goldens/INetwork.golden
@@ -147,61 +147,56 @@ class INetwork extends IDispatch {
 
    INetwork(Pointer<COMObject> ptr) : super(ptr);
 
-  int GetName(Pointer<Pointer<Utf16>> pszNetworkName) =>
-    Pointer<NativeFunction<_GetName_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(7).value)
-            .asFunction<_GetName_Dart>()(
-         ptr.ref.lpVtbl, pszNetworkName);
+  int GetName(Pointer<Pointer<Utf16>> pszNetworkName) => ptr.ref.lpVtbl.value      .elementAt(7)
+      .cast<Pointer<NativeFunction<_GetName_Native>>>()
+      .value
+      .asFunction<_GetName_Dart>()(ptr.ref.lpVtbl, pszNetworkName);
 
-  int SetName(Pointer<Utf16> szNetworkNewName) =>
-    Pointer<NativeFunction<_SetName_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(8).value)
-            .asFunction<_SetName_Dart>()(
-         ptr.ref.lpVtbl, szNetworkNewName);
+  int SetName(Pointer<Utf16> szNetworkNewName) => ptr.ref.lpVtbl.value      .elementAt(8)
+      .cast<Pointer<NativeFunction<_SetName_Native>>>()
+      .value
+      .asFunction<_SetName_Dart>()(ptr.ref.lpVtbl, szNetworkNewName);
 
-  int GetDescription(Pointer<Pointer<Utf16>> pszDescription) =>
-    Pointer<NativeFunction<_GetDescription_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(9).value)
-            .asFunction<_GetDescription_Dart>()(
-         ptr.ref.lpVtbl, pszDescription);
+  int GetDescription(Pointer<Pointer<Utf16>> pszDescription) => ptr.ref.lpVtbl.value      .elementAt(9)
+      .cast<Pointer<NativeFunction<_GetDescription_Native>>>()
+      .value
+      .asFunction<_GetDescription_Dart>()(ptr.ref.lpVtbl, pszDescription);
 
-  int SetDescription(Pointer<Utf16> szDescription) =>
-    Pointer<NativeFunction<_SetDescription_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(10).value)
-            .asFunction<_SetDescription_Dart>()(
-         ptr.ref.lpVtbl, szDescription);
+  int SetDescription(Pointer<Utf16> szDescription) => ptr.ref.lpVtbl.value      .elementAt(10)
+      .cast<Pointer<NativeFunction<_SetDescription_Native>>>()
+      .value
+      .asFunction<_SetDescription_Dart>()(ptr.ref.lpVtbl, szDescription);
 
-  int GetNetworkId(Pointer<GUID> pgdGuidNetworkId) =>
-    Pointer<NativeFunction<_GetNetworkId_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(11).value)
-            .asFunction<_GetNetworkId_Dart>()(
-         ptr.ref.lpVtbl, pgdGuidNetworkId);
+  int GetNetworkId(Pointer<GUID> pgdGuidNetworkId) => ptr.ref.lpVtbl.value      .elementAt(11)
+      .cast<Pointer<NativeFunction<_GetNetworkId_Native>>>()
+      .value
+      .asFunction<_GetNetworkId_Dart>()(ptr.ref.lpVtbl, pgdGuidNetworkId);
 
-  int GetDomainType(Pointer<Uint32> pNetworkType) =>
-    Pointer<NativeFunction<_GetDomainType_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(12).value)
-            .asFunction<_GetDomainType_Dart>()(
-         ptr.ref.lpVtbl, pNetworkType);
+  int GetDomainType(Pointer<Uint32> pNetworkType) => ptr.ref.lpVtbl.value      .elementAt(12)
+      .cast<Pointer<NativeFunction<_GetDomainType_Native>>>()
+      .value
+      .asFunction<_GetDomainType_Dart>()(ptr.ref.lpVtbl, pNetworkType);
 
-  int GetNetworkConnections(Pointer<Pointer> ppEnumNetworkConnection) =>
-    Pointer<NativeFunction<_GetNetworkConnections_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(13).value)
-            .asFunction<_GetNetworkConnections_Dart>()(
-         ptr.ref.lpVtbl, ppEnumNetworkConnection);
+  int GetNetworkConnections(Pointer<Pointer> ppEnumNetworkConnection) => ptr.ref.lpVtbl.value      .elementAt(13)
+      .cast<Pointer<NativeFunction<_GetNetworkConnections_Native>>>()
+      .value
+      .asFunction<_GetNetworkConnections_Dart>()(ptr.ref.lpVtbl, ppEnumNetworkConnection);
 
-  int GetTimeCreatedAndConnected(Pointer<Uint32> pdwLowDateTimeCreated, Pointer<Uint32> pdwHighDateTimeCreated, Pointer<Uint32> pdwLowDateTimeConnected, Pointer<Uint32> pdwHighDateTimeConnected) =>
-    Pointer<NativeFunction<_GetTimeCreatedAndConnected_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(14).value)
-            .asFunction<_GetTimeCreatedAndConnected_Dart>()(
-         ptr.ref.lpVtbl, pdwLowDateTimeCreated, pdwHighDateTimeCreated, pdwLowDateTimeConnected, pdwHighDateTimeConnected);
+  int GetTimeCreatedAndConnected(Pointer<Uint32> pdwLowDateTimeCreated, Pointer<Uint32> pdwHighDateTimeCreated, Pointer<Uint32> pdwLowDateTimeConnected, Pointer<Uint32> pdwHighDateTimeConnected) => ptr.ref.lpVtbl.value      .elementAt(14)
+      .cast<Pointer<NativeFunction<_GetTimeCreatedAndConnected_Native>>>()
+      .value
+      .asFunction<_GetTimeCreatedAndConnected_Dart>()(ptr.ref.lpVtbl, pdwLowDateTimeCreated, pdwHighDateTimeCreated, pdwLowDateTimeConnected, pdwHighDateTimeConnected);
 
     int get IsConnectedToInternet {
       final retValuePtr = calloc<Int16>();
       
       try {
-        final hr = Pointer<NativeFunction<_get_IsConnectedToInternet_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(15).value)
-           .asFunction<_get_IsConnectedToInternet_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+        final hr = ptr.ref.lpVtbl.value
+          .elementAt(15)
+          .cast<Pointer<NativeFunction<_get_IsConnectedToInternet_Native>>>()
+          .value
+          .asFunction<_get_IsConnectedToInternet_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+          
         if (FAILED(hr)) throw WindowsException(hr);
 
         final retValue = retValuePtr.value;
@@ -215,9 +210,12 @@ class INetwork extends IDispatch {
       final retValuePtr = calloc<Int16>();
       
       try {
-        final hr = Pointer<NativeFunction<_get_IsConnected_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt(16).value)
-           .asFunction<_get_IsConnected_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+        final hr = ptr.ref.lpVtbl.value
+          .elementAt(16)
+          .cast<Pointer<NativeFunction<_get_IsConnected_Native>>>()
+          .value
+          .asFunction<_get_IsConnected_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+          
         if (FAILED(hr)) throw WindowsException(hr);
 
         final retValue = retValuePtr.value;
@@ -227,23 +225,20 @@ class INetwork extends IDispatch {
       }
     }
 
-  int GetConnectivity(Pointer<Uint32> pConnectivity) =>
-    Pointer<NativeFunction<_GetConnectivity_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(17).value)
-            .asFunction<_GetConnectivity_Dart>()(
-         ptr.ref.lpVtbl, pConnectivity);
+  int GetConnectivity(Pointer<Uint32> pConnectivity) => ptr.ref.lpVtbl.value      .elementAt(17)
+      .cast<Pointer<NativeFunction<_GetConnectivity_Native>>>()
+      .value
+      .asFunction<_GetConnectivity_Dart>()(ptr.ref.lpVtbl, pConnectivity);
 
-  int GetCategory(Pointer<Uint32> pCategory) =>
-    Pointer<NativeFunction<_GetCategory_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(18).value)
-            .asFunction<_GetCategory_Dart>()(
-         ptr.ref.lpVtbl, pCategory);
+  int GetCategory(Pointer<Uint32> pCategory) => ptr.ref.lpVtbl.value      .elementAt(18)
+      .cast<Pointer<NativeFunction<_GetCategory_Native>>>()
+      .value
+      .asFunction<_GetCategory_Dart>()(ptr.ref.lpVtbl, pCategory);
 
-  int SetCategory(int NewCategory) =>
-    Pointer<NativeFunction<_SetCategory_Native>>.fromAddress(
-                ptr.ref.vtable.elementAt(19).value)
-            .asFunction<_SetCategory_Dart>()(
-         ptr.ref.lpVtbl, NewCategory);
+  int SetCategory(int NewCategory) => ptr.ref.lpVtbl.value      .elementAt(19)
+      .cast<Pointer<NativeFunction<_SetCategory_Native>>>()
+      .value
+      .asFunction<_SetCategory_Dart>()(ptr.ref.lpVtbl, NewCategory);
 
 }
 

--- a/tool/metadata/projection/typeprinter.dart
+++ b/tool/metadata/projection/typeprinter.dart
@@ -208,7 +208,7 @@ import '../winrt/winrt_constants.dart';
           .cast<Pointer<NativeFunction<_${method.name}_Native>>>()
           .value
           .asFunction<_${method.name}_Dart>()(ptr.ref.lpVtbl, retValuePtr);
-          
+
         if (FAILED(hr)) throw WindowsException(hr);
 
         final retValue = retValuePtr.value;
@@ -226,9 +226,11 @@ import '../winrt/winrt_constants.dart';
 
     buffer.writeln('''
   set ${method.name.substring(4)}(${method.parameters.first.dartType} value) {
-    final hr = Pointer<NativeFunction<_${method.name}_Native>>.fromAddress(
-            ptr.ref.vtable.elementAt($vtableIndex).value)
-        .asFunction<_${method.name}_Dart>()(ptr.ref.lpVtbl, value);
+    final hr = ptr.ref.lpVtbl.value
+          .elementAt($vtableIndex)
+          .cast<Pointer<NativeFunction<_${method.name}_Native>>>()
+          .value
+          .asFunction<_${method.name}_Dart>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/tool/metadata/projection/typeprinter.dart
+++ b/tool/metadata/projection/typeprinter.dart
@@ -168,13 +168,12 @@ import '../winrt/winrt_constants.dart';
         buffer.write(', ');
       }
     }
-    buffer.writeln(') =>');
-    buffer.write(
-        '    Pointer<NativeFunction<_${method.name}_Native>>.fromAddress(\n');
-    buffer.write(
-        '                ptr.ref.vtable.elementAt($vtableIndex).value)\n');
-    buffer.write('            .asFunction<_${method.name}_Dart>()(\n');
-    buffer.write('         ptr.ref.lpVtbl');
+    buffer.write(') => ptr.ref.lpVtbl.value');
+    buffer.write('''
+      .elementAt($vtableIndex)
+      .cast<Pointer<NativeFunction<_${method.name}_Native>>>()
+      .value
+      .asFunction<_${method.name}_Dart>()(ptr.ref.lpVtbl''');
     if (method.parameters.isNotEmpty) {
       buffer.write(', ');
     }

--- a/tool/metadata/projection/typeprinter.dart
+++ b/tool/metadata/projection/typeprinter.dart
@@ -203,9 +203,12 @@ import '../winrt/winrt_constants.dart';
       final retValuePtr = calloc<${method.parameters.first.nativeType}>();
       
       try {
-        final hr = Pointer<NativeFunction<_${method.name}_Native>>.fromAddress(
-          ptr.ref.vtable.elementAt($vtableIndex).value)
-           .asFunction<_${method.name}_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+        final hr = ptr.ref.lpVtbl.value
+          .elementAt($vtableIndex)
+          .cast<Pointer<NativeFunction<_${method.name}_Native>>>()
+          .value
+          .asFunction<_${method.name}_Dart>()(ptr.ref.lpVtbl, retValuePtr);
+          
         if (FAILED(hr)) throw WindowsException(hr);
 
         final retValue = retValuePtr.value;


### PR DESCRIPTION
Replaces an unnecessary `.fromAddress(.value)` pattern with a cast.