### PR TITLE
Add trailing commas to generated files to improve formatting performance

### DIFF
--- a/tool/projection/function.dart
+++ b/tool/projection/function.dart
@@ -30,17 +30,17 @@ class FunctionProjection {
       '${returnType.nativeType} Function($nativeParams)';
 
   String get nativeParams =>
-      parameters.map((param) => param.ffiProjection).join(', ');
+      parameters.map((param) => '${param.ffiProjection}, ').join();
 
   String get dartPrototype => '${returnType.dartType} Function($dartParams)';
 
   String get dartParams =>
-      parameters.map((param) => param.dartProjection).join(', ');
+      parameters.map((param) => '${param.dartProjection}, ').join();
 
   @override
   String toString() => '''
     ${safeTypenameForString(returnType.dartType)} $k32StrippedName($dartParams) =>
-      _$nameWithoutEncoding(${parameters.map((param) => param.identifier).join(', ')});
+      _$nameWithoutEncoding(${parameters.map((param) => '${param.identifier}, ').join()});
 
     late final _$nameWithoutEncoding = 
       _$lib.lookupFunction<$nativePrototype, $dartPrototype>('${method.name}');

--- a/tool/projection/method.dart
+++ b/tool/projection/method.dart
@@ -71,12 +71,12 @@ class MethodProjection {
   }
 
   String get methodParams =>
-      parameters.map((param) => param.dartProjection).join(', ');
+      parameters.map((param) => '${param.dartProjection}, ').join();
 
   String get nativeParams => [
         'Pointer',
         ...parameters.map((param) => param.ffiProjection),
-      ].join(', ');
+      ].map((p) => '$p, ').join();
 
   String get nativePrototype =>
       '${returnType.nativeType} Function($nativeParams)';
@@ -84,14 +84,14 @@ class MethodProjection {
   String get dartParams => [
         'Pointer',
         ...parameters.map((param) => param.dartProjection),
-      ].join(', ');
+      ].map((p) => '$p, ').join();
 
   String get dartPrototype => '${returnType.dartType} Function($dartParams)';
 
   String get identifiers => [
         'ptr.ref.lpVtbl',
         ...parameters.map((param) => param.identifier)
-      ].join(', ');
+      ].map((p) => '$p, ').join();
 
   // TODO: Check whether there's a better way to detect how methods like
   // put_AutoDemodulate are declared (should this be a property?) Detect whether

--- a/tool/projection/winrt_interface.dart
+++ b/tool/projection/winrt_interface.dart
@@ -40,7 +40,7 @@ class WinRTInterfaceProjection extends InterfaceProjection {
 
     // if (typeDef.genericParams.isNotEmpty) {
     //   final genericParams =
-    //       typeDef.genericParams.map<String>((p) => p.name).join(', ');
+    //       typeDef.genericParams.map<String>((p) => '${p.name}, ').join();
     //   interface.shortNameWithGenericSpecifier =
     //       '${interface.shortName}<$genericParams>';
     // } else {


### PR DESCRIPTION
I don't know how important the formatting of these files are, but adding trailing commas avoids the formatter having to figure out where to wrap long argument/parameter lists, and decreases the time spend formatting while generating code dramatically.

On my PC:

Before: 4:30
After: 0:33

I believe the results are semantically the same (though with additional commas/wrapping, ofc), though I have errors after running the scripts both with and without this change so I'm not certain (the errors do seem the same to me), so it's worth double-checking my work!