### PR TITLE
Project `Pointer<COMObject>` types correctly

### DIFF
--- a/example/calendar.dart
+++ b/example/calendar.dart
@@ -23,8 +23,11 @@ void main() {
     final comObject =
         CreateObject('Windows.Globalization.Calendar', IID_ICalendar);
     final calendar = ICalendar(comObject);
-
     print(calendarData(calendar));
+
+    final clonedCalendar = ICalendar(calendar.Clone());
+    print(
+        'Comparison result of calendar and its clone: ${clonedCalendar.Compare(calendar.ptr)}');
 
     calendar.ChangeCalendarSystem(japaneseCalendar);
     print(calendarData(calendar));
@@ -36,6 +39,7 @@ void main() {
     print(dateTime);
 
     free(comObject);
+    free(clonedCalendar.ptr);
   } finally {
     WindowsDeleteString(japaneseCalendar);
     WindowsDeleteString(hebrewCalendar);

--- a/lib/src/com/ICalendar.dart
+++ b/lib/src/com/ICalendar.dart
@@ -37,35 +37,30 @@ class ICalendar extends IInspectable {
   ICalendar(Pointer<COMObject> ptr) : super(ptr);
 
   Pointer<COMObject> Clone() {
-    final retValuePtr = calloc<Pointer<COMObject>>();
+    final retValuePtr = calloc<COMObject>();
 
-    try {
-      final hr = ptr.ref.lpVtbl.value
-          .elementAt(6)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      HRESULT Function(
-            Pointer,
-            Pointer<Pointer<COMObject>>,
-          )>>>()
-          .value
-          .asFunction<
-              int Function(
-            Pointer,
-            Pointer<Pointer<COMObject>>,
-          )>()(
-        ptr.ref.lpVtbl,
-        retValuePtr,
-      );
+    final hr = ptr.ref.vtable
+        .elementAt(6)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(
+          Pointer,
+          Pointer<COMObject>,
+        )>>>()
+        .value
+        .asFunction<
+            int Function(
+          Pointer,
+          Pointer<COMObject>,
+        )>()(
+      ptr.ref.lpVtbl,
+      retValuePtr,
+    );
 
-      if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) throw WindowsException(hr);
 
-      final retValue = retValuePtr.value;
-      return retValue;
-    } finally {
-      free(retValuePtr);
-    }
+    return retValuePtr;
   }
 
   void SetToMin() => ptr.ref.lpVtbl.value
@@ -99,6 +94,24 @@ class ICalendar extends IInspectable {
           )>()(
         ptr.ref.lpVtbl,
       );
+
+  Pointer<COMObject> get Languages {
+    final retValuePtr = calloc<COMObject>();
+
+    final hr = ptr.ref.vtable
+            .elementAt(9)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
+            .value
+            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl, retValuePtr);
+
+    if (FAILED(hr)) throw WindowsException(hr);
+
+    return retValuePtr;
+  }
 
   String get NumeralSystem {
     final retValuePtr = calloc<HSTRING>();
@@ -2533,7 +2546,7 @@ class ICalendar extends IInspectable {
             Pointer<Int32>,
           )>()(
         ptr.ref.lpVtbl,
-        other,
+        Pointer<Pointer<COMObject>>.fromAddress(other.address).value,
         retValuePtr,
       );
 
@@ -2602,7 +2615,7 @@ class ICalendar extends IInspectable {
             Pointer<COMObject> other,
           )>()(
         ptr.ref.lpVtbl,
-        other,
+        Pointer<Pointer<COMObject>>.fromAddress(other.address).value,
       );
 
   int get FirstMinuteInThisHour {

--- a/lib/src/com/ICalendar.dart
+++ b/lib/src/com/ICalendar.dart
@@ -10,7 +10,6 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 
-import '../api-ms-win-core-winrt-string-l1-1-0.dart';
 import '../callbacks.dart';
 import '../combase.dart';
 import '../constants.dart';
@@ -20,9 +19,12 @@ import '../macros.dart';
 import '../ole32.dart';
 import '../structs.dart';
 import '../structs.g.dart';
-import '../types.dart';
 import '../utils.dart';
+
+import '../api-ms-win-core-winrt-string-l1-1-0.dart';
 import '../winrt/winrt_helpers.dart';
+import '../types.dart';
+
 import 'IInspectable.dart';
 
 /// @nodoc

--- a/lib/src/com/ICalendar.dart
+++ b/lib/src/com/ICalendar.dart
@@ -2552,7 +2552,7 @@ class ICalendar extends IInspectable {
             Pointer<Int32>,
           )>()(
         ptr.ref.lpVtbl,
-        Pointer<Pointer<COMObject>>.fromAddress(other.address).value,
+        other.cast<Pointer<COMObject>>().value,
         retValuePtr,
       );
 
@@ -2621,7 +2621,7 @@ class ICalendar extends IInspectable {
             Pointer<COMObject> other,
           )>()(
         ptr.ref.lpVtbl,
-        Pointer<Pointer<COMObject>>.fromAddress(other.address).value,
+        other.cast<Pointer<COMObject>>().value,
       );
 
   int get FirstMinuteInThisHour {

--- a/lib/src/com/ICalendar.dart
+++ b/lib/src/com/ICalendar.dart
@@ -39,7 +39,7 @@ class ICalendar extends IInspectable {
   Pointer<COMObject> Clone() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
+    final hr = ptr.ref.lpVtbl.value
         .elementAt(6)
         .cast<
             Pointer<
@@ -98,7 +98,7 @@ class ICalendar extends IInspectable {
   Pointer<COMObject> get Languages {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
+    final hr = ptr.ref.lpVtbl.value
         .elementAt(9)
         .cast<
             Pointer<

--- a/lib/src/com/ICalendar.dart
+++ b/lib/src/com/ICalendar.dart
@@ -10,6 +10,7 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 
+import '../api-ms-win-core-winrt-string-l1-1-0.dart';
 import '../callbacks.dart';
 import '../combase.dart';
 import '../constants.dart';
@@ -19,12 +20,9 @@ import '../macros.dart';
 import '../ole32.dart';
 import '../structs.dart';
 import '../structs.g.dart';
-import '../utils.dart';
-
-import '../api-ms-win-core-winrt-string-l1-1-0.dart';
-import '../winrt/winrt_helpers.dart';
 import '../types.dart';
-
+import '../utils.dart';
+import '../winrt/winrt_helpers.dart';
 import 'IInspectable.dart';
 
 /// @nodoc
@@ -99,14 +97,20 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
-            .elementAt(9)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
-            .value
-            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, retValuePtr);
+        .elementAt(9)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(
+          Pointer,
+          Pointer<COMObject>,
+        )>>>()
+        .value
+        .asFunction<
+            int Function(
+          Pointer,
+          Pointer<COMObject>,
+        )>()(ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/test/tool/goldens/ICalendar.golden
+++ b/test/tool/goldens/ICalendar.golden
@@ -37,35 +37,30 @@ class ICalendar extends IInspectable {
   ICalendar(Pointer<COMObject> ptr) : super(ptr);
 
   Pointer<COMObject> Clone() {
-    final retValuePtr = calloc<Pointer<COMObject>>();
+    final retValuePtr = calloc<COMObject>();
 
-    try {
-      final hr = ptr.ref.lpVtbl.value
-          .elementAt(6)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      HRESULT Function(
-            Pointer,
-            Pointer<Pointer<COMObject>>,
-          )>>>()
-          .value
-          .asFunction<
-              int Function(
-            Pointer,
-            Pointer<Pointer<COMObject>>,
-          )>()(
-        ptr.ref.lpVtbl,
-        retValuePtr,
-      );
+    final hr = ptr.ref.vtable
+        .elementAt(6)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(
+          Pointer,
+          Pointer<COMObject>,
+        )>>>()
+        .value
+        .asFunction<
+            int Function(
+          Pointer,
+          Pointer<COMObject>,
+        )>()(
+      ptr.ref.lpVtbl,
+      retValuePtr,
+    );
 
-      if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) throw WindowsException(hr);
 
-      final retValue = retValuePtr.value;
-      return retValue;
-    } finally {
-      free(retValuePtr);
-    }
+    return retValuePtr;
   }
 
   void SetToMin() => ptr.ref.lpVtbl.value
@@ -99,6 +94,24 @@ class ICalendar extends IInspectable {
           )>()(
         ptr.ref.lpVtbl,
       );
+
+  Pointer<COMObject> get Languages {
+    final retValuePtr = calloc<COMObject>();
+
+    final hr = ptr.ref.vtable
+            .elementAt(9)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
+            .value
+            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl, retValuePtr);
+
+    if (FAILED(hr)) throw WindowsException(hr);
+
+    return retValuePtr;
+  }
 
   String get NumeralSystem {
     final retValuePtr = calloc<HSTRING>();
@@ -2533,7 +2546,7 @@ class ICalendar extends IInspectable {
             Pointer<Int32>,
           )>()(
         ptr.ref.lpVtbl,
-        other,
+        Pointer<Pointer<COMObject>>.fromAddress(other.address).value,
         retValuePtr,
       );
 
@@ -2602,7 +2615,7 @@ class ICalendar extends IInspectable {
             Pointer<COMObject> other,
           )>()(
         ptr.ref.lpVtbl,
-        other,
+        Pointer<Pointer<COMObject>>.fromAddress(other.address).value,
       );
 
   int get FirstMinuteInThisHour {

--- a/test/tool/goldens/ICalendar.golden
+++ b/test/tool/goldens/ICalendar.golden
@@ -99,14 +99,20 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
-            .elementAt(9)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
-            .value
-            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, retValuePtr);
+        .elementAt(9)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(
+          Pointer,
+          Pointer<COMObject>,
+        )>>>()
+        .value
+        .asFunction<
+            int Function(
+          Pointer,
+          Pointer<COMObject>,
+        )>()(ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/test/tool/goldens/ICalendar.golden
+++ b/test/tool/goldens/ICalendar.golden
@@ -2552,7 +2552,7 @@ class ICalendar extends IInspectable {
             Pointer<Int32>,
           )>()(
         ptr.ref.lpVtbl,
-        Pointer<Pointer<COMObject>>.fromAddress(other.address).value,
+        other.cast<Pointer<COMObject>>().value,
         retValuePtr,
       );
 
@@ -2621,7 +2621,7 @@ class ICalendar extends IInspectable {
             Pointer<COMObject> other,
           )>()(
         ptr.ref.lpVtbl,
-        Pointer<Pointer<COMObject>>.fromAddress(other.address).value,
+        other.cast<Pointer<COMObject>>().value,
       );
 
   int get FirstMinuteInThisHour {

--- a/test/tool/goldens/ICalendar.golden
+++ b/test/tool/goldens/ICalendar.golden
@@ -39,7 +39,7 @@ class ICalendar extends IInspectable {
   Pointer<COMObject> Clone() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
+    final hr = ptr.ref.lpVtbl.value
         .elementAt(6)
         .cast<
             Pointer<
@@ -98,7 +98,7 @@ class ICalendar extends IInspectable {
   Pointer<COMObject> get Languages {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
+    final hr = ptr.ref.lpVtbl.value
         .elementAt(9)
         .cast<
             Pointer<

--- a/test/tool/winrt_projection_test.dart
+++ b/test/tool/winrt_projection_test.dart
@@ -203,6 +203,24 @@ void main() {
         equalsIgnoringWhitespace('int Function(Pointer, Pointer<Int32>,)'));
   });
 
+  test('WinRT Clone method successfully projects Pointer<COMObject>', () {
+    final winTypeDef =
+        MetadataStore.getMetadataForType('Windows.Globalization.ICalendar');
+
+    final projection = WinRTInterfaceProjection(winTypeDef!);
+    final numDaysProjection =
+        projection.methodProjections.firstWhere((m) => m.name == 'Clone');
+
+    expect(
+        numDaysProjection.nativePrototype,
+        equalsIgnoringWhitespace(
+            'HRESULT Function(Pointer, Pointer<COMObject>, )'));
+    expect(
+        numDaysProjection.dartPrototype,
+        equalsIgnoringWhitespace(
+            'int Function(Pointer, Pointer<COMObject>, )'));
+  });
+
   test('WinRT set property successfully projects something', () {
     final winTypeDef = MetadataStore.getMetadataForType(
         'Windows.Storage.Pickers.IFileOpenPicker');

--- a/tool/projection/type.dart
+++ b/tool/projection/type.dart
@@ -40,6 +40,8 @@ const Map<String, TypeTuple> specialTypes = {
   'Windows.Win32.Foundation.ULARGE_INTEGER':
       TypeTuple('Uint64', 'int', attribute: '@Uint64()'),
   'System.Guid': TypeTuple('GUID', 'GUID'),
+  'Windows.Foundation.Collections.IVectorView`1':
+      TypeTuple('Pointer<COMObject>', 'Pointer<COMObject>'),
   'Windows.Foundation.DateTime':
       TypeTuple('Uint64', 'int', attribute: '@Uint64()'),
   'Windows.Foundation.HResult':

--- a/tool/projection/winrt_method.dart
+++ b/tool/projection/winrt_method.dart
@@ -44,7 +44,7 @@ class WinRTMethodProjection extends MethodProjection {
         'ptr.ref.lpVtbl',
         ...parameters.map(
           (param) => param.type.dartType == 'Pointer<COMObject>'
-              ? 'Pointer<Pointer<COMObject>>.fromAddress(${param.identifier}.address).value'
+              ? '${param.identifier}.cast<Pointer<COMObject>>().value'
               : param.identifier,
         ),
         if (!isVoidReturn) 'retValuePtr',

--- a/tool/projection/winrt_method.dart
+++ b/tool/projection/winrt_method.dart
@@ -54,7 +54,7 @@ class WinRTMethodProjection extends MethodProjection {
     Pointer<COMObject> $name($methodParams) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
+    final hr = ptr.ref.lpVtbl.value
       .elementAt($vtableOffset)
       .cast<Pointer<NativeFunction<$nativePrototype>>>()
       .value
@@ -77,7 +77,7 @@ class WinRTMethodProjection extends MethodProjection {
   String stringMethodDeclaration() => '''
       String $name($methodParams) {
       final retValuePtr = calloc<HSTRING>();
-
+  
         try {
           final hr = ptr.ref.lpVtbl.value
             .elementAt($vtableOffset)
@@ -105,7 +105,7 @@ class WinRTMethodProjection extends MethodProjection {
   String dateTimeMethodDeclaration() => '''
       DateTime $name($methodParams) {
         final retValuePtr = calloc<Uint64>();
-
+  
         try {
           final hr = ptr.ref.lpVtbl.value
             .elementAt($vtableOffset)
@@ -144,7 +144,7 @@ class WinRTMethodProjection extends MethodProjection {
       return '''
       ${returnType.dartType} $name($methodParams) {
         final retValuePtr = calloc<${returnType.nativeType}>();
-
+  
         try {
           final hr = ptr.ref.lpVtbl.value
             .elementAt($vtableOffset)

--- a/tool/projection/winrt_property.dart
+++ b/tool/projection/winrt_property.dart
@@ -39,7 +39,7 @@ class WinRTGetPropertyProjection extends ComGetPropertyProjection {
     Pointer<COMObject> get $exposedMethodName {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
+    final hr = ptr.ref.lpVtbl.value
       .elementAt($vtableOffset)
       .cast<Pointer<NativeFunction<$nativePrototype>>>()
       .value

--- a/tool/projection/winrt_property.dart
+++ b/tool/projection/winrt_property.dart
@@ -25,7 +25,7 @@ class WinRTGetPropertyProjection extends ComGetPropertyProjection {
 
   @override
   String get nativeParams => isPointerCOMObjectReturn
-      ? 'Pointer, Pointer<COMObject>'
+      ? 'Pointer, Pointer<COMObject>,'
       : 'Pointer, Pointer<${returnType.nativeType}>,';
 
   // WinRT properties always return an HRESULT


### PR DESCRIPTION
I've been working on this for a few days and I think I figured it out (even though I don't fully understand how it works 😄). 

Before this PR, `ICalendar`'s `Clone()` would be projected as:
 ```dart
Pointer<COMObject> Clone() {
    final retValuePtr = calloc<Pointer<COMObject>>();

    try {
      final hr = ptr.ref.lpVtbl.value
          .elementAt(6)
          .cast<
              Pointer<
                  NativeFunction<
                      HRESULT Function(
            Pointer,
            Pointer<Pointer<COMObject>>,
          )>>>()
          .value
          .asFunction<
              int Function(
            Pointer,
            Pointer<Pointer<COMObject>>,
          )>()(
        ptr.ref.lpVtbl,
        retValuePtr,
      );

      if (FAILED(hr)) throw WindowsException(hr);

      final retValue = retValuePtr.value;
      return retValue;
    } finally {
      free(retValuePtr);
    }
  }
```
With this projection, `Clone()` successfully clones the `Calendar` object and `ICalendar.Compare()` compares the calendar objects correctly, _but_ you couldn't use the `Pointer<COMObject>` returned from `Clone()` in the `ICalendar` class.
When you tried to use it, the process would crash every time. e.g.:
```dart
    ...
    final calendar = ICalendar(comObject);
    final clonedCalendar = ICalendar(calendar.Clone());
    print(clonedCalendar.GetDateTime()); // Crashes here
    ...
```

With this PR, `Clone()` will be generated as:
 ```dart
  Pointer<COMObject> Clone() {
    final retValuePtr = calloc<COMObject>();

    final hr = ptr.ref.vtable
        .elementAt(6)
        .cast<
            Pointer<
                NativeFunction<
                    HRESULT Function(
          Pointer,
          Pointer<COMObject>,
        )>>>()
        .value
        .asFunction<
            int Function(
          Pointer,
          Pointer<COMObject>,
        )>()(
      ptr.ref.lpVtbl,
      retValuePtr,
    );

    if (FAILED(hr)) throw WindowsException(hr);

    return retValuePtr;
  }
```
With this projection, you will be able to successfully use the `Pointer<COMObject>` returned from `Clone()` in the `ICalendar` class.

Also, I had to modify the projection of the methods that take `Pointer<COMObject>` as parameters because the process would crash every time when I try to use these.

For example, `ICalendar`'s `Compare()`:
```diff
int Compare(
    Pointer<COMObject> other,
  ) {
    final retValuePtr = calloc<Int32>();

    try {
      final hr = ptr.ref.lpVtbl.value
          .elementAt(93)
          .cast<
              Pointer<
                  NativeFunction<
                      HRESULT Function(
            Pointer,
            Pointer<COMObject> other,
            Pointer<Int32>,
          )>>>()
          .value
          .asFunction<
              int Function(
            Pointer,
            Pointer<COMObject> other,
            Pointer<Int32>,
          )>()(
        ptr.ref.lpVtbl,
-       other,
+       Pointer<Pointer<COMObject>>.fromAddress(other.address).value,
        retValuePtr,
      );

      if (FAILED(hr)) throw WindowsException(hr);

      final retValue = retValuePtr.value;
      return retValue;
    } finally {
      free(retValuePtr);
    }
  }
```

As I said, I don't fully understand how it works and I'm not sure this is the best way to project these but I hope this will give you an idea.

This PR will also allow us to project types like `IVector` and `IVectorView` and much more in the future. I actually manually projected these two types and will send a PR later today.