### PR TITLE
Use `vtable` getter instead of `lpVtbl.value`

### DIFF
--- a/lib/src/com/iapplicationactivationmanager.dart
+++ b/lib/src/com/iapplicationactivationmanager.dart
@@ -35,7 +35,7 @@ class IApplicationActivationManager extends IUnknown {
 
   int ActivateApplication(Pointer<Utf16> appUserModelId,
           Pointer<Utf16> arguments, int options, Pointer<Uint32> processId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -61,7 +61,7 @@ class IApplicationActivationManager extends IUnknown {
           Pointer<COMObject> itemArray,
           Pointer<Utf16> verb,
           Pointer<Uint32> processId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -84,7 +84,7 @@ class IApplicationActivationManager extends IUnknown {
 
   int ActivateForProtocol(Pointer<Utf16> appUserModelId,
           Pointer<COMObject> itemArray, Pointer<Uint32> processId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<

--- a/lib/src/com/iappxfactory.dart
+++ b/lib/src/com/iappxfactory.dart
@@ -36,7 +36,7 @@ class IAppxFactory extends IUnknown {
           Pointer<COMObject> outputStream,
           Pointer<APPX_PACKAGE_SETTINGS> settings,
           Pointer<Pointer<COMObject>> packageWriter) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -57,7 +57,7 @@ class IAppxFactory extends IUnknown {
 
   int CreatePackageReader(Pointer<COMObject> inputStream,
           Pointer<Pointer<COMObject>> packageReader) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -72,7 +72,7 @@ class IAppxFactory extends IUnknown {
 
   int CreateManifestReader(Pointer<COMObject> inputStream,
           Pointer<Pointer<COMObject>> manifestReader) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -87,7 +87,7 @@ class IAppxFactory extends IUnknown {
 
   int CreateBlockMapReader(Pointer<COMObject> inputStream,
           Pointer<Pointer<COMObject>> blockMapReader) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<
@@ -104,7 +104,7 @@ class IAppxFactory extends IUnknown {
           Pointer<COMObject> blockMapStream,
           Pointer<Utf16> signatureFileName,
           Pointer<Pointer<COMObject>> blockMapReader) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<

--- a/lib/src/com/iappxfile.dart
+++ b/lib/src/com/iappxfile.dart
@@ -33,7 +33,7 @@ class IAppxFile extends IUnknown {
   IAppxFile(super.ptr);
 
   int GetCompressionOption(Pointer<Int32> compressionOption) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -45,20 +45,19 @@ class IAppxFile extends IUnknown {
                   int Function(Pointer, Pointer<Int32> compressionOption)>()(
           ptr.ref.lpVtbl, compressionOption);
 
-  int GetContentType(Pointer<Pointer<Utf16>> contentType) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(4)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(
-                              Pointer, Pointer<Pointer<Utf16>> contentType)>>>()
-              .value
-              .asFunction<
-                  int Function(Pointer, Pointer<Pointer<Utf16>> contentType)>()(
-          ptr.ref.lpVtbl, contentType);
+  int GetContentType(Pointer<Pointer<Utf16>> contentType) => ptr.ref.vtable
+          .elementAt(4)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(
+                          Pointer, Pointer<Pointer<Utf16>> contentType)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Pointer<Utf16>> contentType)>()(
+      ptr.ref.lpVtbl, contentType);
 
-  int GetName(Pointer<Pointer<Utf16>> fileName) => ptr.ref.lpVtbl.value
+  int GetName(Pointer<Pointer<Utf16>> fileName) => ptr.ref.vtable
       .elementAt(5)
       .cast<
           Pointer<
@@ -69,7 +68,7 @@ class IAppxFile extends IUnknown {
           int Function(Pointer,
               Pointer<Pointer<Utf16>> fileName)>()(ptr.ref.lpVtbl, fileName);
 
-  int GetSize(Pointer<Uint64> size) => ptr.ref.lpVtbl.value
+  int GetSize(Pointer<Uint64> size) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<
@@ -78,7 +77,7 @@ class IAppxFile extends IUnknown {
       .asFunction<
           int Function(Pointer, Pointer<Uint64> size)>()(ptr.ref.lpVtbl, size);
 
-  int GetStream(Pointer<Pointer<COMObject>> stream) => ptr.ref.lpVtbl.value
+  int GetStream(Pointer<Pointer<COMObject>> stream) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<

--- a/lib/src/com/iappxfilesenumerator.dart
+++ b/lib/src/com/iappxfilesenumerator.dart
@@ -32,7 +32,7 @@ class IAppxFilesEnumerator extends IUnknown {
   // vtable begins at 3, is 3 entries long.
   IAppxFilesEnumerator(super.ptr);
 
-  int GetCurrent(Pointer<Pointer<COMObject>> file) => ptr.ref.lpVtbl.value
+  int GetCurrent(Pointer<Pointer<COMObject>> file) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -43,7 +43,7 @@ class IAppxFilesEnumerator extends IUnknown {
           int Function(Pointer,
               Pointer<Pointer<COMObject>> file)>()(ptr.ref.lpVtbl, file);
 
-  int GetHasCurrent(Pointer<Int32> hasCurrent) => ptr.ref.lpVtbl.value
+  int GetHasCurrent(Pointer<Int32> hasCurrent) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -53,7 +53,7 @@ class IAppxFilesEnumerator extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Int32> hasCurrent)>()(
       ptr.ref.lpVtbl, hasCurrent);
 
-  int MoveNext(Pointer<Int32> hasNext) => ptr.ref.lpVtbl.value
+  int MoveNext(Pointer<Int32> hasNext) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<

--- a/lib/src/com/iappxmanifestapplication.dart
+++ b/lib/src/com/iappxmanifestapplication.dart
@@ -33,7 +33,7 @@ class IAppxManifestApplication extends IUnknown {
   IAppxManifestApplication(super.ptr);
 
   int GetStringValue(Pointer<Utf16> name, Pointer<Pointer<Utf16>> value) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -46,7 +46,7 @@ class IAppxManifestApplication extends IUnknown {
               Pointer<Pointer<Utf16>> value)>()(ptr.ref.lpVtbl, name, value);
 
   int GetAppUserModelId(Pointer<Pointer<Utf16>> appUserModelId) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(4)
           .cast<
               Pointer<

--- a/lib/src/com/iappxmanifestapplicationsenumerator.dart
+++ b/lib/src/com/iappxmanifestapplicationsenumerator.dart
@@ -33,8 +33,7 @@ class IAppxManifestApplicationsEnumerator extends IUnknown {
   // vtable begins at 3, is 3 entries long.
   IAppxManifestApplicationsEnumerator(super.ptr);
 
-  int GetCurrent(Pointer<Pointer<COMObject>> application) => ptr
-          .ref.lpVtbl.value
+  int GetCurrent(Pointer<Pointer<COMObject>> application) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -46,7 +45,7 @@ class IAppxManifestApplicationsEnumerator extends IUnknown {
               int Function(Pointer, Pointer<Pointer<COMObject>> application)>()(
       ptr.ref.lpVtbl, application);
 
-  int GetHasCurrent(Pointer<Int32> hasCurrent) => ptr.ref.lpVtbl.value
+  int GetHasCurrent(Pointer<Int32> hasCurrent) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -56,7 +55,7 @@ class IAppxManifestApplicationsEnumerator extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Int32> hasCurrent)>()(
       ptr.ref.lpVtbl, hasCurrent);
 
-  int MoveNext(Pointer<Int32> hasNext) => ptr.ref.lpVtbl.value
+  int MoveNext(Pointer<Int32> hasNext) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<

--- a/lib/src/com/iappxmanifestospackagedependency.dart
+++ b/lib/src/com/iappxmanifestospackagedependency.dart
@@ -33,7 +33,7 @@ class IAppxManifestOSPackageDependency extends IUnknown {
   // vtable begins at 3, is 2 entries long.
   IAppxManifestOSPackageDependency(super.ptr);
 
-  int GetName(Pointer<Pointer<Utf16>> name) => ptr.ref.lpVtbl.value
+  int GetName(Pointer<Pointer<Utf16>> name) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -43,7 +43,7 @@ class IAppxManifestOSPackageDependency extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Pointer<Utf16>> name)>()(
       ptr.ref.lpVtbl, name);
 
-  int GetVersion(Pointer<Uint64> version) => ptr.ref.lpVtbl.value
+  int GetVersion(Pointer<Uint64> version) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<

--- a/lib/src/com/iappxmanifestpackagedependenciesenumerator.dart
+++ b/lib/src/com/iappxmanifestpackagedependenciesenumerator.dart
@@ -33,7 +33,7 @@ class IAppxManifestPackageDependenciesEnumerator extends IUnknown {
   // vtable begins at 3, is 3 entries long.
   IAppxManifestPackageDependenciesEnumerator(super.ptr);
 
-  int GetCurrent(Pointer<Pointer<COMObject>> dependency) => ptr.ref.lpVtbl.value
+  int GetCurrent(Pointer<Pointer<COMObject>> dependency) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -45,7 +45,7 @@ class IAppxManifestPackageDependenciesEnumerator extends IUnknown {
               int Function(Pointer, Pointer<Pointer<COMObject>> dependency)>()(
       ptr.ref.lpVtbl, dependency);
 
-  int GetHasCurrent(Pointer<Int32> hasCurrent) => ptr.ref.lpVtbl.value
+  int GetHasCurrent(Pointer<Int32> hasCurrent) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -55,7 +55,7 @@ class IAppxManifestPackageDependenciesEnumerator extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Int32> hasCurrent)>()(
       ptr.ref.lpVtbl, hasCurrent);
 
-  int MoveNext(Pointer<Int32> hasNext) => ptr.ref.lpVtbl.value
+  int MoveNext(Pointer<Int32> hasNext) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<

--- a/lib/src/com/iappxmanifestpackagedependency.dart
+++ b/lib/src/com/iappxmanifestpackagedependency.dart
@@ -33,7 +33,7 @@ class IAppxManifestPackageDependency extends IUnknown {
   // vtable begins at 3, is 3 entries long.
   IAppxManifestPackageDependency(super.ptr);
 
-  int GetName(Pointer<Pointer<Utf16>> name) => ptr.ref.lpVtbl.value
+  int GetName(Pointer<Pointer<Utf16>> name) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -43,7 +43,7 @@ class IAppxManifestPackageDependency extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Pointer<Utf16>> name)>()(
       ptr.ref.lpVtbl, name);
 
-  int GetPublisher(Pointer<Pointer<Utf16>> publisher) => ptr.ref.lpVtbl.value
+  int GetPublisher(Pointer<Pointer<Utf16>> publisher) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -55,7 +55,7 @@ class IAppxManifestPackageDependency extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> publisher)>()(
       ptr.ref.lpVtbl, publisher);
 
-  int GetMinVersion(Pointer<Uint64> minVersion) => ptr.ref.lpVtbl.value
+  int GetMinVersion(Pointer<Uint64> minVersion) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<

--- a/lib/src/com/iappxmanifestpackageid.dart
+++ b/lib/src/com/iappxmanifestpackageid.dart
@@ -32,7 +32,7 @@ class IAppxManifestPackageId extends IUnknown {
   // vtable begins at 3, is 8 entries long.
   IAppxManifestPackageId(super.ptr);
 
-  int GetName(Pointer<Pointer<Utf16>> name) => ptr.ref.lpVtbl.value
+  int GetName(Pointer<Pointer<Utf16>> name) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -42,7 +42,7 @@ class IAppxManifestPackageId extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Pointer<Utf16>> name)>()(
       ptr.ref.lpVtbl, name);
 
-  int GetArchitecture(Pointer<Int32> architecture) => ptr.ref.lpVtbl.value
+  int GetArchitecture(Pointer<Int32> architecture) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -52,7 +52,7 @@ class IAppxManifestPackageId extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Int32> architecture)>()(
       ptr.ref.lpVtbl, architecture);
 
-  int GetPublisher(Pointer<Pointer<Utf16>> publisher) => ptr.ref.lpVtbl.value
+  int GetPublisher(Pointer<Pointer<Utf16>> publisher) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -65,7 +65,7 @@ class IAppxManifestPackageId extends IUnknown {
       ptr.ref.lpVtbl, publisher);
 
   int GetVersion(Pointer<Uint64> packageVersion) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<
@@ -77,7 +77,7 @@ class IAppxManifestPackageId extends IUnknown {
                   int Function(Pointer, Pointer<Uint64> packageVersion)>()(
           ptr.ref.lpVtbl, packageVersion);
 
-  int GetResourceId(Pointer<Pointer<Utf16>> resourceId) => ptr.ref.lpVtbl.value
+  int GetResourceId(Pointer<Pointer<Utf16>> resourceId) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -90,7 +90,7 @@ class IAppxManifestPackageId extends IUnknown {
       ptr.ref.lpVtbl, resourceId);
 
   int ComparePublisher(Pointer<Utf16> other, Pointer<Int32> isSame) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(8)
       .cast<
           Pointer<
@@ -103,7 +103,7 @@ class IAppxManifestPackageId extends IUnknown {
               Pointer<Int32> isSame)>()(ptr.ref.lpVtbl, other, isSame);
 
   int GetPackageFullName(Pointer<Pointer<Utf16>> packageFullName) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
@@ -116,7 +116,7 @@ class IAppxManifestPackageId extends IUnknown {
       ptr.ref.lpVtbl, packageFullName);
 
   int GetPackageFamilyName(Pointer<Pointer<Utf16>> packageFamilyName) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<

--- a/lib/src/com/iappxmanifestproperties.dart
+++ b/lib/src/com/iappxmanifestproperties.dart
@@ -32,8 +32,7 @@ class IAppxManifestProperties extends IUnknown {
   // vtable begins at 3, is 2 entries long.
   IAppxManifestProperties(super.ptr);
 
-  int GetBoolValue(Pointer<Utf16> name, Pointer<Int32> value) => ptr
-      .ref.lpVtbl.value
+  int GetBoolValue(Pointer<Utf16> name, Pointer<Int32> value) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -46,7 +45,7 @@ class IAppxManifestProperties extends IUnknown {
               Pointer<Int32> value)>()(ptr.ref.lpVtbl, name, value);
 
   int GetStringValue(Pointer<Utf16> name, Pointer<Pointer<Utf16>> value) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(4)
       .cast<
           Pointer<

--- a/lib/src/com/iappxmanifestreader.dart
+++ b/lib/src/com/iappxmanifestreader.dart
@@ -32,8 +32,7 @@ class IAppxManifestReader extends IUnknown {
   // vtable begins at 3, is 9 entries long.
   IAppxManifestReader(super.ptr);
 
-  int GetPackageId(Pointer<Pointer<COMObject>> packageId) => ptr
-          .ref.lpVtbl.value
+  int GetPackageId(Pointer<Pointer<COMObject>> packageId) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -46,7 +45,7 @@ class IAppxManifestReader extends IUnknown {
       ptr.ref.lpVtbl, packageId);
 
   int GetProperties(Pointer<Pointer<COMObject>> packageProperties) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -59,21 +58,21 @@ class IAppxManifestReader extends IUnknown {
                   Pointer, Pointer<Pointer<COMObject>> packageProperties)>()(
       ptr.ref.lpVtbl, packageProperties);
 
-  int GetPackageDependencies(Pointer<Pointer<COMObject>> dependencies) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(5)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer,
-                              Pointer<Pointer<COMObject>> dependencies)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, Pointer<Pointer<COMObject>> dependencies)>()(
-          ptr.ref.lpVtbl, dependencies);
+  int GetPackageDependencies(Pointer<Pointer<COMObject>> dependencies) => ptr
+          .ref.vtable
+          .elementAt(5)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer,
+                          Pointer<Pointer<COMObject>> dependencies)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, Pointer<Pointer<COMObject>> dependencies)>()(
+      ptr.ref.lpVtbl, dependencies);
 
-  int GetCapabilities(Pointer<Uint32> capabilities) => ptr.ref.lpVtbl.value
+  int GetCapabilities(Pointer<Uint32> capabilities) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -83,8 +82,7 @@ class IAppxManifestReader extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint32> capabilities)>()(
       ptr.ref.lpVtbl, capabilities);
 
-  int GetResources(Pointer<Pointer<COMObject>> resources) => ptr
-          .ref.lpVtbl.value
+  int GetResources(Pointer<Pointer<COMObject>> resources) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -98,7 +96,7 @@ class IAppxManifestReader extends IUnknown {
 
   int
       GetDeviceCapabilities(Pointer<Pointer<COMObject>> deviceCapabilities) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(8)
                   .cast<
                       Pointer<
@@ -114,7 +112,7 @@ class IAppxManifestReader extends IUnknown {
               ptr.ref.lpVtbl, deviceCapabilities);
 
   int GetPrerequisite(Pointer<Utf16> name, Pointer<Uint64> value) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(9)
       .cast<
           Pointer<
@@ -127,7 +125,7 @@ class IAppxManifestReader extends IUnknown {
               Pointer<Uint64> value)>()(ptr.ref.lpVtbl, name, value);
 
   int GetApplications(Pointer<Pointer<COMObject>> applications) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<
@@ -140,17 +138,16 @@ class IAppxManifestReader extends IUnknown {
                       Pointer, Pointer<Pointer<COMObject>> applications)>()(
           ptr.ref.lpVtbl, applications);
 
-  int GetStream(Pointer<Pointer<COMObject>> manifestStream) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(11)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer,
-                              Pointer<Pointer<COMObject>> manifestStream)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, Pointer<Pointer<COMObject>> manifestStream)>()(
-          ptr.ref.lpVtbl, manifestStream);
+  int GetStream(Pointer<Pointer<COMObject>> manifestStream) => ptr.ref.vtable
+          .elementAt(11)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer,
+                          Pointer<Pointer<COMObject>> manifestStream)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, Pointer<Pointer<COMObject>> manifestStream)>()(
+      ptr.ref.lpVtbl, manifestStream);
 }

--- a/lib/src/com/iappxmanifestreader2.dart
+++ b/lib/src/com/iappxmanifestreader2.dart
@@ -33,7 +33,7 @@ class IAppxManifestReader2 extends IAppxManifestReader {
   IAppxManifestReader2(super.ptr);
 
   int GetQualifiedResources(Pointer<Pointer<COMObject>> resources) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(12)
           .cast<
               Pointer<

--- a/lib/src/com/iappxmanifestreader3.dart
+++ b/lib/src/com/iappxmanifestreader3.dart
@@ -34,7 +34,7 @@ class IAppxManifestReader3 extends IAppxManifestReader2 {
 
   int GetCapabilitiesByCapabilityClass(
           int capabilityClass, Pointer<Pointer<COMObject>> capabilities) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(13)
               .cast<
                   Pointer<
@@ -50,7 +50,7 @@ class IAppxManifestReader3 extends IAppxManifestReader2 {
   int
       GetTargetDeviceFamilies(
               Pointer<Pointer<COMObject>> targetDeviceFamilies) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(14)
                   .cast<
                       Pointer<

--- a/lib/src/com/iappxmanifestreader4.dart
+++ b/lib/src/com/iappxmanifestreader4.dart
@@ -34,7 +34,7 @@ class IAppxManifestReader4 extends IAppxManifestReader3 {
 
   int
       GetOptionalPackageInfo(Pointer<Pointer<COMObject>> optionalPackageInfo) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(15)
                   .cast<
                       Pointer<

--- a/lib/src/com/iappxmanifestreader5.dart
+++ b/lib/src/com/iappxmanifestreader5.dart
@@ -34,7 +34,7 @@ class IAppxManifestReader5 extends IUnknown {
 
   int GetMainPackageDependencies(
           Pointer<Pointer<COMObject>> mainPackageDependencies) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<

--- a/lib/src/com/iappxmanifestreader6.dart
+++ b/lib/src/com/iappxmanifestreader6.dart
@@ -34,7 +34,7 @@ class IAppxManifestReader6 extends IUnknown {
 
   int GetIsNonQualifiedResourcePackage(
           Pointer<Int32> isNonQualifiedResourcePackage) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<

--- a/lib/src/com/iappxmanifestreader7.dart
+++ b/lib/src/com/iappxmanifestreader7.dart
@@ -34,7 +34,7 @@ class IAppxManifestReader7 extends IUnknown {
 
   int
       GetDriverDependencies(Pointer<Pointer<COMObject>> driverDependencies) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(3)
                   .cast<
                       Pointer<
@@ -52,7 +52,7 @@ class IAppxManifestReader7 extends IUnknown {
   int GetOSPackageDependencies(
           Pointer<Pointer<COMObject>> osPackageDependencies) =>
       ptr
-              .ref.lpVtbl.value
+              .ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -69,7 +69,7 @@ class IAppxManifestReader7 extends IUnknown {
 
   int GetHostRuntimeDependencies(
           Pointer<Pointer<COMObject>> hostRuntimeDependencies) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<

--- a/lib/src/com/iappxpackagereader.dart
+++ b/lib/src/com/iappxpackagereader.dart
@@ -32,22 +32,21 @@ class IAppxPackageReader extends IUnknown {
   // vtable begins at 3, is 5 entries long.
   IAppxPackageReader(super.ptr);
 
-  int GetBlockMap(Pointer<Pointer<COMObject>> blockMapReader) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(3)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer,
-                              Pointer<Pointer<COMObject>> blockMapReader)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, Pointer<Pointer<COMObject>> blockMapReader)>()(
-          ptr.ref.lpVtbl, blockMapReader);
+  int GetBlockMap(Pointer<Pointer<COMObject>> blockMapReader) => ptr.ref.vtable
+          .elementAt(3)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer,
+                          Pointer<Pointer<COMObject>> blockMapReader)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, Pointer<Pointer<COMObject>> blockMapReader)>()(
+      ptr.ref.lpVtbl, blockMapReader);
 
   int GetFootprintFile(int type, Pointer<Pointer<COMObject>> file) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(4)
       .cast<
           Pointer<
@@ -61,7 +60,7 @@ class IAppxPackageReader extends IUnknown {
 
   int GetPayloadFile(
           Pointer<Utf16> fileName, Pointer<Pointer<COMObject>> file) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -75,7 +74,7 @@ class IAppxPackageReader extends IUnknown {
           ptr.ref.lpVtbl, fileName, file);
 
   int GetPayloadFiles(Pointer<Pointer<COMObject>> filesEnumerator) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -88,17 +87,16 @@ class IAppxPackageReader extends IUnknown {
                   Pointer, Pointer<Pointer<COMObject>> filesEnumerator)>()(
       ptr.ref.lpVtbl, filesEnumerator);
 
-  int GetManifest(Pointer<Pointer<COMObject>> manifestReader) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(7)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer,
-                              Pointer<Pointer<COMObject>> manifestReader)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, Pointer<Pointer<COMObject>> manifestReader)>()(
-          ptr.ref.lpVtbl, manifestReader);
+  int GetManifest(Pointer<Pointer<COMObject>> manifestReader) => ptr.ref.vtable
+          .elementAt(7)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer,
+                          Pointer<Pointer<COMObject>> manifestReader)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, Pointer<Pointer<COMObject>> manifestReader)>()(
+      ptr.ref.lpVtbl, manifestReader);
 }

--- a/lib/src/com/iaudiocaptureclient.dart
+++ b/lib/src/com/iaudiocaptureclient.dart
@@ -38,7 +38,7 @@ class IAudioCaptureClient extends IUnknown {
           Pointer<Uint32> pdwFlags,
           Pointer<Uint64> pu64DevicePosition,
           Pointer<Uint64> pu64QPCPosition) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -66,7 +66,7 @@ class IAudioCaptureClient extends IUnknown {
           pu64DevicePosition,
           pu64QPCPosition);
 
-  int ReleaseBuffer(int NumFramesRead) => ptr.ref.lpVtbl.value
+  int ReleaseBuffer(int NumFramesRead) => ptr.ref.vtable
       .elementAt(4)
       .cast<
           Pointer<
@@ -77,7 +77,7 @@ class IAudioCaptureClient extends IUnknown {
               Pointer, int NumFramesRead)>()(ptr.ref.lpVtbl, NumFramesRead);
 
   int GetNextPacketSize(Pointer<Uint32> pNumFramesInNextPacket) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(5)
           .cast<
               Pointer<

--- a/lib/src/com/iaudioclient.dart
+++ b/lib/src/com/iaudioclient.dart
@@ -39,7 +39,7 @@ class IAudioClient extends IUnknown {
           int hnsPeriodicity,
           Pointer<WAVEFORMATEX> pFormat,
           Pointer<GUID> AudioSessionGuid) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -71,7 +71,7 @@ class IAudioClient extends IUnknown {
           AudioSessionGuid);
 
   int GetBufferSize(Pointer<Uint32> pNumBufferFrames) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -83,7 +83,7 @@ class IAudioClient extends IUnknown {
                   int Function(Pointer, Pointer<Uint32> pNumBufferFrames)>()(
           ptr.ref.lpVtbl, pNumBufferFrames);
 
-  int GetStreamLatency(Pointer<Int64> phnsLatency) => ptr.ref.lpVtbl.value
+  int GetStreamLatency(Pointer<Int64> phnsLatency) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -93,23 +93,22 @@ class IAudioClient extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Int64> phnsLatency)>()(
       ptr.ref.lpVtbl, phnsLatency);
 
-  int GetCurrentPadding(Pointer<Uint32> pNumPaddingFrames) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(6)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(
-                              Pointer, Pointer<Uint32> pNumPaddingFrames)>>>()
-              .value
-              .asFunction<
-                  int Function(Pointer, Pointer<Uint32> pNumPaddingFrames)>()(
-          ptr.ref.lpVtbl, pNumPaddingFrames);
+  int GetCurrentPadding(Pointer<Uint32> pNumPaddingFrames) => ptr.ref.vtable
+          .elementAt(6)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(
+                          Pointer, Pointer<Uint32> pNumPaddingFrames)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Uint32> pNumPaddingFrames)>()(
+      ptr.ref.lpVtbl, pNumPaddingFrames);
 
   int
       IsFormatSupported(int ShareMode, Pointer<WAVEFORMATEX> pFormat,
               Pointer<Pointer<WAVEFORMATEX>> ppClosestMatch) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(7)
                   .cast<
                       Pointer<
@@ -130,7 +129,7 @@ class IAudioClient extends IUnknown {
               ptr.ref.lpVtbl, ShareMode, pFormat, ppClosestMatch);
 
   int GetMixFormat(Pointer<Pointer<WAVEFORMATEX>> ppDeviceFormat) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -145,7 +144,7 @@ class IAudioClient extends IUnknown {
 
   int GetDevicePeriod(Pointer<Int64> phnsDefaultDevicePeriod,
           Pointer<Int64> phnsMinimumDevicePeriod) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -160,25 +159,25 @@ class IAudioClient extends IUnknown {
                       Pointer<Int64> phnsMinimumDevicePeriod)>()(
           ptr.ref.lpVtbl, phnsDefaultDevicePeriod, phnsMinimumDevicePeriod);
 
-  int Start() => ptr.ref.lpVtbl.value
+  int Start() => ptr.ref.vtable
       .elementAt(10)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Stop() => ptr.ref.lpVtbl.value
+  int Stop() => ptr.ref.vtable
       .elementAt(11)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Reset() => ptr.ref.lpVtbl.value
+  int Reset() => ptr.ref.vtable
       .elementAt(12)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int SetEventHandle(int eventHandle) => ptr.ref.lpVtbl.value
+  int SetEventHandle(int eventHandle) => ptr.ref.vtable
       .elementAt(13)
       .cast<
           Pointer<
@@ -188,8 +187,7 @@ class IAudioClient extends IUnknown {
           int Function(
               Pointer, int eventHandle)>()(ptr.ref.lpVtbl, eventHandle);
 
-  int GetService(Pointer<GUID> riid, Pointer<Pointer> ppv) => ptr
-      .ref.lpVtbl.value
+  int GetService(Pointer<GUID> riid, Pointer<Pointer> ppv) => ptr.ref.vtable
       .elementAt(14)
       .cast<
           Pointer<

--- a/lib/src/com/iaudioclock.dart
+++ b/lib/src/com/iaudioclock.dart
@@ -32,7 +32,7 @@ class IAudioClock extends IUnknown {
   // vtable begins at 3, is 3 entries long.
   IAudioClock(super.ptr);
 
-  int GetFrequency(Pointer<Uint64> pu64Frequency) => ptr.ref.lpVtbl.value
+  int GetFrequency(Pointer<Uint64> pu64Frequency) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -45,7 +45,7 @@ class IAudioClock extends IUnknown {
 
   int GetPosition(
           Pointer<Uint64> pu64Position, Pointer<Uint64> pu64QPCPosition) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -58,8 +58,7 @@ class IAudioClock extends IUnknown {
                       Pointer<Uint64> pu64QPCPosition)>()(
           ptr.ref.lpVtbl, pu64Position, pu64QPCPosition);
 
-  int GetCharacteristics(Pointer<Uint32> pdwCharacteristics) => ptr
-          .ref.lpVtbl.value
+  int GetCharacteristics(Pointer<Uint32> pdwCharacteristics) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<

--- a/lib/src/com/iaudiorenderclient.dart
+++ b/lib/src/com/iaudiorenderclient.dart
@@ -33,7 +33,7 @@ class IAudioRenderClient extends IUnknown {
   IAudioRenderClient(super.ptr);
 
   int GetBuffer(int NumFramesRequested, Pointer<Pointer<Uint8>> ppData) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -46,7 +46,7 @@ class IAudioRenderClient extends IUnknown {
                       Pointer<Pointer<Uint8>> ppData)>()(
           ptr.ref.lpVtbl, NumFramesRequested, ppData);
 
-  int ReleaseBuffer(int NumFramesWritten, int dwFlags) => ptr.ref.lpVtbl.value
+  int ReleaseBuffer(int NumFramesWritten, int dwFlags) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<

--- a/lib/src/com/iaudiosessioncontrol.dart
+++ b/lib/src/com/iaudiosessioncontrol.dart
@@ -32,7 +32,7 @@ class IAudioSessionControl extends IUnknown {
   // vtable begins at 3, is 9 entries long.
   IAudioSessionControl(super.ptr);
 
-  int GetState(Pointer<Int32> pRetVal) => ptr.ref.lpVtbl.value
+  int GetState(Pointer<Int32> pRetVal) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -42,7 +42,7 @@ class IAudioSessionControl extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Int32> pRetVal)>()(
       ptr.ref.lpVtbl, pRetVal);
 
-  int GetDisplayName(Pointer<Pointer<Utf16>> pRetVal) => ptr.ref.lpVtbl.value
+  int GetDisplayName(Pointer<Pointer<Utf16>> pRetVal) => ptr.ref.vtable
       .elementAt(4)
       .cast<
           Pointer<
@@ -54,7 +54,7 @@ class IAudioSessionControl extends IUnknown {
               Pointer<Pointer<Utf16>> pRetVal)>()(ptr.ref.lpVtbl, pRetVal);
 
   int SetDisplayName(Pointer<Utf16> Value, Pointer<GUID> EventContext) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -67,7 +67,7 @@ class IAudioSessionControl extends IUnknown {
                   Pointer, Pointer<Utf16> Value, Pointer<GUID> EventContext)>()(
       ptr.ref.lpVtbl, Value, EventContext);
 
-  int GetIconPath(Pointer<Pointer<Utf16>> pRetVal) => ptr.ref.lpVtbl.value
+  int GetIconPath(Pointer<Pointer<Utf16>> pRetVal) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<
@@ -79,7 +79,7 @@ class IAudioSessionControl extends IUnknown {
               Pointer<Pointer<Utf16>> pRetVal)>()(ptr.ref.lpVtbl, pRetVal);
 
   int SetIconPath(Pointer<Utf16> Value, Pointer<GUID> EventContext) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -92,7 +92,7 @@ class IAudioSessionControl extends IUnknown {
                   Pointer, Pointer<Utf16> Value, Pointer<GUID> EventContext)>()(
       ptr.ref.lpVtbl, Value, EventContext);
 
-  int GetGroupingParam(Pointer<GUID> pRetVal) => ptr.ref.lpVtbl.value
+  int GetGroupingParam(Pointer<GUID> pRetVal) => ptr.ref.vtable
       .elementAt(8)
       .cast<
           Pointer<
@@ -103,7 +103,7 @@ class IAudioSessionControl extends IUnknown {
               Pointer, Pointer<GUID> pRetVal)>()(ptr.ref.lpVtbl, pRetVal);
 
   int SetGroupingParam(Pointer<GUID> Override, Pointer<GUID> EventContext) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -117,7 +117,7 @@ class IAudioSessionControl extends IUnknown {
           ptr.ref.lpVtbl, Override, EventContext);
 
   int RegisterAudioSessionNotification(Pointer<COMObject> NewNotifications) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<
@@ -130,7 +130,7 @@ class IAudioSessionControl extends IUnknown {
           ptr.ref.lpVtbl, NewNotifications);
 
   int UnregisterAudioSessionNotification(Pointer<COMObject> NewNotifications) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<

--- a/lib/src/com/iaudiosessionmanager.dart
+++ b/lib/src/com/iaudiosessionmanager.dart
@@ -34,7 +34,7 @@ class IAudioSessionManager extends IUnknown {
 
   int GetAudioSessionControl(Pointer<GUID> AudioSessionGuid, int StreamFlags,
           Pointer<Pointer<COMObject>> SessionControl) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -55,7 +55,7 @@ class IAudioSessionManager extends IUnknown {
 
   int GetSimpleAudioVolume(Pointer<GUID> AudioSessionGuid, int StreamFlags,
           Pointer<Pointer<COMObject>> AudioVolume) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<

--- a/lib/src/com/iaudiostreamvolume.dart
+++ b/lib/src/com/iaudiostreamvolume.dart
@@ -32,7 +32,7 @@ class IAudioStreamVolume extends IUnknown {
   // vtable begins at 3, is 5 entries long.
   IAudioStreamVolume(super.ptr);
 
-  int GetChannelCount(Pointer<Uint32> pdwCount) => ptr.ref.lpVtbl.value
+  int GetChannelCount(Pointer<Uint32> pdwCount) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -42,7 +42,7 @@ class IAudioStreamVolume extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint32> pdwCount)>()(
       ptr.ref.lpVtbl, pdwCount);
 
-  int SetChannelVolume(int dwIndex, double fLevel) => ptr.ref.lpVtbl.value
+  int SetChannelVolume(int dwIndex, double fLevel) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -52,8 +52,7 @@ class IAudioStreamVolume extends IUnknown {
           .asFunction<int Function(Pointer, int dwIndex, double fLevel)>()(
       ptr.ref.lpVtbl, dwIndex, fLevel);
 
-  int GetChannelVolume(int dwIndex, Pointer<Float> pfLevel) =>
-      ptr.ref.lpVtbl.value
+  int GetChannelVolume(int dwIndex, Pointer<Float> pfLevel) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -62,11 +61,10 @@ class IAudioStreamVolume extends IUnknown {
                           Pointer, Uint32 dwIndex, Pointer<Float> pfLevel)>>>()
           .value
           .asFunction<
-              int Function(Pointer, int dwIndex,
-                  Pointer<Float> pfLevel)>()(ptr.ref.lpVtbl, dwIndex, pfLevel);
+              int Function(Pointer, int dwIndex, Pointer<Float> pfLevel)>()(
+      ptr.ref.lpVtbl, dwIndex, pfLevel);
 
-  int SetAllVolumes(int dwCount, Pointer<Float> pfVolumes) => ptr
-      .ref.lpVtbl.value
+  int SetAllVolumes(int dwCount, Pointer<Float> pfVolumes) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<
@@ -78,8 +76,7 @@ class IAudioStreamVolume extends IUnknown {
           int Function(Pointer, int dwCount,
               Pointer<Float> pfVolumes)>()(ptr.ref.lpVtbl, dwCount, pfVolumes);
 
-  int GetAllVolumes(int dwCount, Pointer<Float> pfVolumes) => ptr
-      .ref.lpVtbl.value
+  int GetAllVolumes(int dwCount, Pointer<Float> pfVolumes) => ptr.ref.vtable
       .elementAt(7)
       .cast<
           Pointer<

--- a/lib/src/com/ibindctx.dart
+++ b/lib/src/com/ibindctx.dart
@@ -32,7 +32,7 @@ class IBindCtx extends IUnknown {
   // vtable begins at 3, is 10 entries long.
   IBindCtx(super.ptr);
 
-  int RegisterObjectBound(Pointer<COMObject> punk) => ptr.ref.lpVtbl.value
+  int RegisterObjectBound(Pointer<COMObject> punk) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -42,7 +42,7 @@ class IBindCtx extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<COMObject> punk)>()(
       ptr.ref.lpVtbl, punk);
 
-  int RevokeObjectBound(Pointer<COMObject> punk) => ptr.ref.lpVtbl.value
+  int RevokeObjectBound(Pointer<COMObject> punk) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -52,13 +52,13 @@ class IBindCtx extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<COMObject> punk)>()(
       ptr.ref.lpVtbl, punk);
 
-  int ReleaseBoundObjects() => ptr.ref.lpVtbl.value
+  int ReleaseBoundObjects() => ptr.ref.vtable
       .elementAt(5)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int SetBindOptions(Pointer<BIND_OPTS> pbindopts) => ptr.ref.lpVtbl.value
+  int SetBindOptions(Pointer<BIND_OPTS> pbindopts) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -68,7 +68,7 @@ class IBindCtx extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<BIND_OPTS> pbindopts)>()(
       ptr.ref.lpVtbl, pbindopts);
 
-  int GetBindOptions(Pointer<BIND_OPTS> pbindopts) => ptr.ref.lpVtbl.value
+  int GetBindOptions(Pointer<BIND_OPTS> pbindopts) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -78,21 +78,20 @@ class IBindCtx extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<BIND_OPTS> pbindopts)>()(
       ptr.ref.lpVtbl, pbindopts);
 
-  int GetRunningObjectTable(Pointer<Pointer<COMObject>> pprot) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(8)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(
-                              Pointer, Pointer<Pointer<COMObject>> pprot)>>>()
-              .value
-              .asFunction<
-                  int Function(Pointer, Pointer<Pointer<COMObject>> pprot)>()(
-          ptr.ref.lpVtbl, pprot);
+  int GetRunningObjectTable(Pointer<Pointer<COMObject>> pprot) => ptr.ref.vtable
+          .elementAt(8)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(
+                          Pointer, Pointer<Pointer<COMObject>> pprot)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Pointer<COMObject>> pprot)>()(
+      ptr.ref.lpVtbl, pprot);
 
   int RegisterObjectParam(Pointer<Utf16> pszKey, Pointer<COMObject> punk) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
@@ -106,7 +105,7 @@ class IBindCtx extends IUnknown {
 
   int GetObjectParam(
           Pointer<Utf16> pszKey, Pointer<Pointer<COMObject>> ppunk) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<
@@ -119,20 +118,19 @@ class IBindCtx extends IUnknown {
                       Pointer<Pointer<COMObject>> ppunk)>()(
           ptr.ref.lpVtbl, pszKey, ppunk);
 
-  int EnumObjectParam(Pointer<Pointer<COMObject>> ppenum) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(11)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(
-                              Pointer, Pointer<Pointer<COMObject>> ppenum)>>>()
-              .value
-              .asFunction<
-                  int Function(Pointer, Pointer<Pointer<COMObject>> ppenum)>()(
-          ptr.ref.lpVtbl, ppenum);
+  int EnumObjectParam(Pointer<Pointer<COMObject>> ppenum) => ptr.ref.vtable
+          .elementAt(11)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(
+                          Pointer, Pointer<Pointer<COMObject>> ppenum)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Pointer<COMObject>> ppenum)>()(
+      ptr.ref.lpVtbl, ppenum);
 
-  int RevokeObjectParam(Pointer<Utf16> pszKey) => ptr.ref.lpVtbl.value
+  int RevokeObjectParam(Pointer<Utf16> pszKey) => ptr.ref.vtable
       .elementAt(12)
       .cast<
           Pointer<

--- a/lib/src/com/ichannelaudiovolume.dart
+++ b/lib/src/com/ichannelaudiovolume.dart
@@ -32,7 +32,7 @@ class IChannelAudioVolume extends IUnknown {
   // vtable begins at 3, is 5 entries long.
   IChannelAudioVolume(super.ptr);
 
-  int GetChannelCount(Pointer<Uint32> pdwCount) => ptr.ref.lpVtbl.value
+  int GetChannelCount(Pointer<Uint32> pdwCount) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -44,7 +44,7 @@ class IChannelAudioVolume extends IUnknown {
 
   int SetChannelVolume(
           int dwIndex, double fLevel, Pointer<GUID> EventContext) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -57,8 +57,7 @@ class IChannelAudioVolume extends IUnknown {
                       Pointer<GUID> EventContext)>()(
           ptr.ref.lpVtbl, dwIndex, fLevel, EventContext);
 
-  int GetChannelVolume(int dwIndex, Pointer<Float> pfLevel) =>
-      ptr.ref.lpVtbl.value
+  int GetChannelVolume(int dwIndex, Pointer<Float> pfLevel) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -67,12 +66,12 @@ class IChannelAudioVolume extends IUnknown {
                           Pointer, Uint32 dwIndex, Pointer<Float> pfLevel)>>>()
           .value
           .asFunction<
-              int Function(Pointer, int dwIndex,
-                  Pointer<Float> pfLevel)>()(ptr.ref.lpVtbl, dwIndex, pfLevel);
+              int Function(Pointer, int dwIndex, Pointer<Float> pfLevel)>()(
+      ptr.ref.lpVtbl, dwIndex, pfLevel);
 
   int SetAllVolumes(
           int dwCount, Pointer<Float> pfVolumes, Pointer<GUID> EventContext) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<
@@ -88,8 +87,7 @@ class IChannelAudioVolume extends IUnknown {
                       Pointer<GUID> EventContext)>()(
           ptr.ref.lpVtbl, dwCount, pfVolumes, EventContext);
 
-  int GetAllVolumes(int dwCount, Pointer<Float> pfVolumes) => ptr
-      .ref.lpVtbl.value
+  int GetAllVolumes(int dwCount, Pointer<Float> pfVolumes) => ptr.ref.vtable
       .elementAt(7)
       .cast<
           Pointer<

--- a/lib/src/com/iclassfactory.dart
+++ b/lib/src/com/iclassfactory.dart
@@ -34,7 +34,7 @@ class IClassFactory extends IUnknown {
 
   int CreateInstance(Pointer<COMObject> pUnkOuter, Pointer<GUID> riid,
           Pointer<Pointer> ppvObject) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -50,7 +50,7 @@ class IClassFactory extends IUnknown {
                   Pointer<Pointer>
                       ppvObject)>()(ptr.ref.lpVtbl, pUnkOuter, riid, ppvObject);
 
-  int LockServer(int fLock) => ptr.ref.lpVtbl.value
+  int LockServer(int fLock) => ptr.ref.vtable
       .elementAt(4)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 fLock)>>>()
       .value

--- a/lib/src/com/iconnectionpoint.dart
+++ b/lib/src/com/iconnectionpoint.dart
@@ -32,7 +32,7 @@ class IConnectionPoint extends IUnknown {
   // vtable begins at 3, is 5 entries long.
   IConnectionPoint(super.ptr);
 
-  int GetConnectionInterface(Pointer<GUID> pIID) => ptr.ref.lpVtbl.value
+  int GetConnectionInterface(Pointer<GUID> pIID) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -42,7 +42,7 @@ class IConnectionPoint extends IUnknown {
           int Function(Pointer, Pointer<GUID> pIID)>()(ptr.ref.lpVtbl, pIID);
 
   int GetConnectionPointContainer(Pointer<Pointer<COMObject>> ppCPC) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -55,7 +55,7 @@ class IConnectionPoint extends IUnknown {
           ptr.ref.lpVtbl, ppCPC);
 
   int Advise(Pointer<COMObject> pUnkSink, Pointer<Uint32> pdwCookie) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -68,23 +68,22 @@ class IConnectionPoint extends IUnknown {
                       Pointer<Uint32> pdwCookie)>()(
           ptr.ref.lpVtbl, pUnkSink, pdwCookie);
 
-  int Unadvise(int dwCookie) => ptr.ref.lpVtbl.value
+  int Unadvise(int dwCookie) => ptr.ref.vtable
       .elementAt(6)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwCookie)>>>()
       .value
       .asFunction<
           int Function(Pointer, int dwCookie)>()(ptr.ref.lpVtbl, dwCookie);
 
-  int EnumConnections(Pointer<Pointer<COMObject>> ppEnum) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(7)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(
-                              Pointer, Pointer<Pointer<COMObject>> ppEnum)>>>()
-              .value
-              .asFunction<
-                  int Function(Pointer, Pointer<Pointer<COMObject>> ppEnum)>()(
-          ptr.ref.lpVtbl, ppEnum);
+  int EnumConnections(Pointer<Pointer<COMObject>> ppEnum) => ptr.ref.vtable
+          .elementAt(7)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(
+                          Pointer, Pointer<Pointer<COMObject>> ppEnum)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Pointer<COMObject>> ppEnum)>()(
+      ptr.ref.lpVtbl, ppEnum);
 }

--- a/lib/src/com/iconnectionpointcontainer.dart
+++ b/lib/src/com/iconnectionpointcontainer.dart
@@ -32,22 +32,21 @@ class IConnectionPointContainer extends IUnknown {
   // vtable begins at 3, is 2 entries long.
   IConnectionPointContainer(super.ptr);
 
-  int EnumConnectionPoints(Pointer<Pointer<COMObject>> ppEnum) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(3)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(
-                              Pointer, Pointer<Pointer<COMObject>> ppEnum)>>>()
-              .value
-              .asFunction<
-                  int Function(Pointer, Pointer<Pointer<COMObject>> ppEnum)>()(
-          ptr.ref.lpVtbl, ppEnum);
+  int EnumConnectionPoints(Pointer<Pointer<COMObject>> ppEnum) => ptr.ref.vtable
+          .elementAt(3)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(
+                          Pointer, Pointer<Pointer<COMObject>> ppEnum)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Pointer<COMObject>> ppEnum)>()(
+      ptr.ref.lpVtbl, ppEnum);
 
   int FindConnectionPoint(
           Pointer<GUID> riid, Pointer<Pointer<COMObject>> ppCP) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<

--- a/lib/src/com/idesktopwallpaper.dart
+++ b/lib/src/com/idesktopwallpaper.dart
@@ -32,23 +32,23 @@ class IDesktopWallpaper extends IUnknown {
   // vtable begins at 3, is 16 entries long.
   IDesktopWallpaper(super.ptr);
 
-  int SetWallpaper(Pointer<Utf16> monitorID, Pointer<Utf16> wallpaper) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(3)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer, Pointer<Utf16> monitorID,
-                              Pointer<Utf16> wallpaper)>>>()
-              .value
-              .asFunction<
-                  int Function(Pointer, Pointer<Utf16> monitorID,
-                      Pointer<Utf16> wallpaper)>()(
-          ptr.ref.lpVtbl, monitorID, wallpaper);
+  int SetWallpaper(Pointer<Utf16> monitorID, Pointer<Utf16> wallpaper) => ptr
+          .ref.vtable
+          .elementAt(3)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, Pointer<Utf16> monitorID,
+                          Pointer<Utf16> wallpaper)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Utf16> monitorID,
+                  Pointer<Utf16> wallpaper)>()(
+      ptr.ref.lpVtbl, monitorID, wallpaper);
 
   int GetWallpaper(
           Pointer<Utf16> monitorID, Pointer<Pointer<Utf16>> wallpaper) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -64,7 +64,7 @@ class IDesktopWallpaper extends IUnknown {
   int GetMonitorDevicePathAt(
           int monitorIndex, Pointer<Pointer<Utf16>> monitorID) =>
       ptr
-              .ref.lpVtbl.value
+              .ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -77,7 +77,7 @@ class IDesktopWallpaper extends IUnknown {
                       Pointer<Pointer<Utf16>> monitorID)>()(
           ptr.ref.lpVtbl, monitorIndex, monitorID);
 
-  int GetMonitorDevicePathCount(Pointer<Uint32> count) => ptr.ref.lpVtbl.value
+  int GetMonitorDevicePathCount(Pointer<Uint32> count) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<
@@ -88,7 +88,7 @@ class IDesktopWallpaper extends IUnknown {
               Pointer, Pointer<Uint32> count)>()(ptr.ref.lpVtbl, count);
 
   int GetMonitorRECT(Pointer<Utf16> monitorID, Pointer<RECT> displayRect) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -101,13 +101,13 @@ class IDesktopWallpaper extends IUnknown {
                       Pointer<RECT> displayRect)>()(
           ptr.ref.lpVtbl, monitorID, displayRect);
 
-  int SetBackgroundColor(int color) => ptr.ref.lpVtbl.value
+  int SetBackgroundColor(int color) => ptr.ref.vtable
       .elementAt(8)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 color)>>>()
       .value
       .asFunction<int Function(Pointer, int color)>()(ptr.ref.lpVtbl, color);
 
-  int GetBackgroundColor(Pointer<Uint32> color) => ptr.ref.lpVtbl.value
+  int GetBackgroundColor(Pointer<Uint32> color) => ptr.ref.vtable
       .elementAt(9)
       .cast<
           Pointer<
@@ -117,14 +117,14 @@ class IDesktopWallpaper extends IUnknown {
           int Function(
               Pointer, Pointer<Uint32> color)>()(ptr.ref.lpVtbl, color);
 
-  int SetPosition(int position) => ptr.ref.lpVtbl.value
+  int SetPosition(int position) => ptr.ref.vtable
       .elementAt(10)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 position)>>>()
       .value
       .asFunction<
           int Function(Pointer, int position)>()(ptr.ref.lpVtbl, position);
 
-  int GetPosition(Pointer<Int32> position) => ptr.ref.lpVtbl.value
+  int GetPosition(Pointer<Int32> position) => ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -134,7 +134,7 @@ class IDesktopWallpaper extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Int32> position)>()(
       ptr.ref.lpVtbl, position);
 
-  int SetSlideshow(Pointer<COMObject> items) => ptr.ref.lpVtbl.value
+  int SetSlideshow(Pointer<COMObject> items) => ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -144,7 +144,7 @@ class IDesktopWallpaper extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<COMObject> items)>()(
       ptr.ref.lpVtbl, items);
 
-  int GetSlideshow(Pointer<Pointer<COMObject>> items) => ptr.ref.lpVtbl.value
+  int GetSlideshow(Pointer<Pointer<COMObject>> items) => ptr.ref.vtable
           .elementAt(13)
           .cast<
               Pointer<
@@ -156,8 +156,7 @@ class IDesktopWallpaper extends IUnknown {
               int Function(Pointer, Pointer<Pointer<COMObject>> items)>()(
       ptr.ref.lpVtbl, items);
 
-  int SetSlideshowOptions(int options, int slideshowTick) => ptr
-          .ref.lpVtbl.value
+  int SetSlideshowOptions(int options, int slideshowTick) => ptr.ref.vtable
           .elementAt(14)
           .cast<
               Pointer<
@@ -170,7 +169,7 @@ class IDesktopWallpaper extends IUnknown {
 
   int GetSlideshowOptions(
           Pointer<Int32> options, Pointer<Uint32> slideshowTick) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(15)
               .cast<
                   Pointer<
@@ -184,7 +183,7 @@ class IDesktopWallpaper extends IUnknown {
           ptr.ref.lpVtbl, options, slideshowTick);
 
   int AdvanceSlideshow(Pointer<Utf16> monitorID, int direction) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(16)
       .cast<
           Pointer<
@@ -196,7 +195,7 @@ class IDesktopWallpaper extends IUnknown {
           int Function(Pointer, Pointer<Utf16> monitorID,
               int direction)>()(ptr.ref.lpVtbl, monitorID, direction);
 
-  int GetStatus(Pointer<Int32> state) => ptr.ref.lpVtbl.value
+  int GetStatus(Pointer<Int32> state) => ptr.ref.vtable
       .elementAt(17)
       .cast<
           Pointer<
@@ -205,7 +204,7 @@ class IDesktopWallpaper extends IUnknown {
       .asFunction<
           int Function(Pointer, Pointer<Int32> state)>()(ptr.ref.lpVtbl, state);
 
-  int Enable(int enable) => ptr.ref.lpVtbl.value
+  int Enable(int enable) => ptr.ref.vtable
       .elementAt(18)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 enable)>>>()
       .value

--- a/lib/src/com/idispatch.dart
+++ b/lib/src/com/idispatch.dart
@@ -32,7 +32,7 @@ class IDispatch extends IUnknown {
   // vtable begins at 3, is 4 entries long.
   IDispatch(super.ptr);
 
-  int GetTypeInfoCount(Pointer<Uint32> pctinfo) => ptr.ref.lpVtbl.value
+  int GetTypeInfoCount(Pointer<Uint32> pctinfo) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -43,7 +43,7 @@ class IDispatch extends IUnknown {
       ptr.ref.lpVtbl, pctinfo);
 
   int GetTypeInfo(int iTInfo, int lcid, Pointer<Pointer<COMObject>> ppTInfo) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -58,7 +58,7 @@ class IDispatch extends IUnknown {
 
   int GetIDsOfNames(Pointer<GUID> riid, Pointer<Pointer<Utf16>> rgszNames,
           int cNames, int lcid, Pointer<Int32> rgDispId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -90,7 +90,7 @@ class IDispatch extends IUnknown {
           Pointer<VARIANT> pVarResult,
           Pointer<EXCEPINFO> pExcepInfo,
           Pointer<Uint32> puArgErr) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<

--- a/lib/src/com/ienumidlist.dart
+++ b/lib/src/com/ienumidlist.dart
@@ -34,7 +34,7 @@ class IEnumIDList extends IUnknown {
 
   int Next(int celt, Pointer<Pointer<ITEMIDLIST>> rgelt,
           Pointer<Uint32> pceltFetched) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -53,19 +53,19 @@ class IEnumIDList extends IUnknown {
                       Pointer<Uint32> pceltFetched)>()(
           ptr.ref.lpVtbl, celt, rgelt, pceltFetched);
 
-  int Skip(int celt) => ptr.ref.lpVtbl.value
+  int Skip(int celt) => ptr.ref.vtable
       .elementAt(4)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 celt)>>>()
       .value
       .asFunction<int Function(Pointer, int celt)>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => ptr.ref.lpVtbl.value
+  int Reset() => ptr.ref.vtable
       .elementAt(5)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer<COMObject>> ppenum) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppenum) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<

--- a/lib/src/com/ienummoniker.dart
+++ b/lib/src/com/ienummoniker.dart
@@ -34,7 +34,7 @@ class IEnumMoniker extends IUnknown {
 
   int Next(int celt, Pointer<Pointer<COMObject>> rgelt,
           Pointer<Uint32> pceltFetched) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -53,19 +53,19 @@ class IEnumMoniker extends IUnknown {
                       Pointer<Uint32> pceltFetched)>()(
           ptr.ref.lpVtbl, celt, rgelt, pceltFetched);
 
-  int Skip(int celt) => ptr.ref.lpVtbl.value
+  int Skip(int celt) => ptr.ref.vtable
       .elementAt(4)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 celt)>>>()
       .value
       .asFunction<int Function(Pointer, int celt)>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => ptr.ref.lpVtbl.value
+  int Reset() => ptr.ref.vtable
       .elementAt(5)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer<COMObject>> ppenum) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppenum) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<

--- a/lib/src/com/ienumnetworkconnections.dart
+++ b/lib/src/com/ienumnetworkconnections.dart
@@ -36,7 +36,7 @@ class IEnumNetworkConnections extends IDispatch {
     final retValuePtr = calloc<Pointer<COMObject>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -60,7 +60,7 @@ class IEnumNetworkConnections extends IDispatch {
 
   int Next(int celt, Pointer<Pointer<COMObject>> rgelt,
           Pointer<Uint32> pceltFetched) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -79,19 +79,19 @@ class IEnumNetworkConnections extends IDispatch {
                       Pointer<Uint32> pceltFetched)>()(
           ptr.ref.lpVtbl, celt, rgelt, pceltFetched);
 
-  int Skip(int celt) => ptr.ref.lpVtbl.value
+  int Skip(int celt) => ptr.ref.vtable
       .elementAt(9)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 celt)>>>()
       .value
       .asFunction<int Function(Pointer, int celt)>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => ptr.ref.lpVtbl.value
+  int Reset() => ptr.ref.vtable
       .elementAt(10)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer<COMObject>> ppEnumNetwork) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppEnumNetwork) => ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<

--- a/lib/src/com/ienumnetworks.dart
+++ b/lib/src/com/ienumnetworks.dart
@@ -36,7 +36,7 @@ class IEnumNetworks extends IDispatch {
     final retValuePtr = calloc<Pointer<COMObject>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -60,7 +60,7 @@ class IEnumNetworks extends IDispatch {
 
   int Next(int celt, Pointer<Pointer<COMObject>> rgelt,
           Pointer<Uint32> pceltFetched) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -79,19 +79,19 @@ class IEnumNetworks extends IDispatch {
                       Pointer<Uint32> pceltFetched)>()(
           ptr.ref.lpVtbl, celt, rgelt, pceltFetched);
 
-  int Skip(int celt) => ptr.ref.lpVtbl.value
+  int Skip(int celt) => ptr.ref.vtable
       .elementAt(9)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 celt)>>>()
       .value
       .asFunction<int Function(Pointer, int celt)>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => ptr.ref.lpVtbl.value
+  int Reset() => ptr.ref.vtable
       .elementAt(10)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer<COMObject>> ppEnumNetwork) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppEnumNetwork) => ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<

--- a/lib/src/com/ienumresources.dart
+++ b/lib/src/com/ienumresources.dart
@@ -34,7 +34,7 @@ class IEnumResources extends IUnknown {
 
   int Next(int celt, Pointer<SHELL_ITEM_RESOURCE> psir,
           Pointer<Uint32> pceltFetched) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -53,19 +53,19 @@ class IEnumResources extends IUnknown {
                       Pointer<Uint32> pceltFetched)>()(
           ptr.ref.lpVtbl, celt, psir, pceltFetched);
 
-  int Skip(int celt) => ptr.ref.lpVtbl.value
+  int Skip(int celt) => ptr.ref.vtable
       .elementAt(4)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 celt)>>>()
       .value
       .asFunction<int Function(Pointer, int celt)>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => ptr.ref.lpVtbl.value
+  int Reset() => ptr.ref.vtable
       .elementAt(5)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer<COMObject>> ppenumr) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppenumr) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<

--- a/lib/src/com/ienumspellingerror.dart
+++ b/lib/src/com/ienumspellingerror.dart
@@ -32,7 +32,7 @@ class IEnumSpellingError extends IUnknown {
   // vtable begins at 3, is 1 entries long.
   IEnumSpellingError(super.ptr);
 
-  int Next(Pointer<Pointer<COMObject>> value) => ptr.ref.lpVtbl.value
+  int Next(Pointer<Pointer<COMObject>> value) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<

--- a/lib/src/com/ienumstring.dart
+++ b/lib/src/com/ienumstring.dart
@@ -34,7 +34,7 @@ class IEnumString extends IUnknown {
 
   int Next(int celt, Pointer<Pointer<Utf16>> rgelt,
           Pointer<Uint32> pceltFetched) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -50,19 +50,19 @@ class IEnumString extends IUnknown {
                       Pointer<Uint32> pceltFetched)>()(
           ptr.ref.lpVtbl, celt, rgelt, pceltFetched);
 
-  int Skip(int celt) => ptr.ref.lpVtbl.value
+  int Skip(int celt) => ptr.ref.vtable
       .elementAt(4)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 celt)>>>()
       .value
       .asFunction<int Function(Pointer, int celt)>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => ptr.ref.lpVtbl.value
+  int Reset() => ptr.ref.vtable
       .elementAt(5)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer<COMObject>> ppenum) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppenum) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<

--- a/lib/src/com/ienumvariant.dart
+++ b/lib/src/com/ienumvariant.dart
@@ -33,7 +33,7 @@ class IEnumVARIANT extends IUnknown {
   IEnumVARIANT(super.ptr);
 
   int Next(int celt, Pointer<VARIANT> rgVar, Pointer<Uint32> pCeltFetched) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -49,19 +49,19 @@ class IEnumVARIANT extends IUnknown {
                       Pointer<Uint32> pCeltFetched)>()(
           ptr.ref.lpVtbl, celt, rgVar, pCeltFetched);
 
-  int Skip(int celt) => ptr.ref.lpVtbl.value
+  int Skip(int celt) => ptr.ref.vtable
       .elementAt(4)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 celt)>>>()
       .value
       .asFunction<int Function(Pointer, int celt)>()(ptr.ref.lpVtbl, celt);
 
-  int Reset() => ptr.ref.lpVtbl.value
+  int Reset() => ptr.ref.vtable
       .elementAt(5)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Clone(Pointer<Pointer<COMObject>> ppEnum) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppEnum) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<

--- a/lib/src/com/ienumwbemclassobject.dart
+++ b/lib/src/com/ienumwbemclassobject.dart
@@ -32,7 +32,7 @@ class IEnumWbemClassObject extends IUnknown {
   // vtable begins at 3, is 5 entries long.
   IEnumWbemClassObject(super.ptr);
 
-  int Reset() => ptr.ref.lpVtbl.value
+  int Reset() => ptr.ref.vtable
       .elementAt(3)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
@@ -40,7 +40,7 @@ class IEnumWbemClassObject extends IUnknown {
 
   int Next(int lTimeout, int uCount, Pointer<Pointer<COMObject>> apObjects,
           Pointer<Uint32> puReturned) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -61,7 +61,7 @@ class IEnumWbemClassObject extends IUnknown {
                       Pointer<Uint32> puReturned)>()(
           ptr.ref.lpVtbl, lTimeout, uCount, apObjects, puReturned);
 
-  int NextAsync(int uCount, Pointer<COMObject> pSink) => ptr.ref.lpVtbl.value
+  int NextAsync(int uCount, Pointer<COMObject> pSink) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -73,7 +73,7 @@ class IEnumWbemClassObject extends IUnknown {
               int Function(Pointer, int uCount, Pointer<COMObject> pSink)>()(
       ptr.ref.lpVtbl, uCount, pSink);
 
-  int Clone(Pointer<Pointer<COMObject>> ppEnum) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppEnum) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -86,7 +86,7 @@ class IEnumWbemClassObject extends IUnknown {
       ptr.ref.lpVtbl, ppEnum);
 
   int Skip(int lTimeout, int nCount) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<

--- a/lib/src/com/ierrorinfo.dart
+++ b/lib/src/com/ierrorinfo.dart
@@ -32,7 +32,7 @@ class IErrorInfo extends IUnknown {
   // vtable begins at 3, is 5 entries long.
   IErrorInfo(super.ptr);
 
-  int GetGUID(Pointer<GUID> pGUID) => ptr.ref.lpVtbl.value
+  int GetGUID(Pointer<GUID> pGUID) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -41,7 +41,7 @@ class IErrorInfo extends IUnknown {
       .asFunction<
           int Function(Pointer, Pointer<GUID> pGUID)>()(ptr.ref.lpVtbl, pGUID);
 
-  int GetSource(Pointer<Pointer<Utf16>> pBstrSource) => ptr.ref.lpVtbl.value
+  int GetSource(Pointer<Pointer<Utf16>> pBstrSource) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -53,21 +53,20 @@ class IErrorInfo extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pBstrSource)>()(
       ptr.ref.lpVtbl, pBstrSource);
 
-  int GetDescription(Pointer<Pointer<Utf16>> pBstrDescription) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(5)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer,
-                              Pointer<Pointer<Utf16>> pBstrDescription)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, Pointer<Pointer<Utf16>> pBstrDescription)>()(
-          ptr.ref.lpVtbl, pBstrDescription);
+  int GetDescription(Pointer<Pointer<Utf16>> pBstrDescription) => ptr.ref.vtable
+          .elementAt(5)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer,
+                          Pointer<Pointer<Utf16>> pBstrDescription)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, Pointer<Pointer<Utf16>> pBstrDescription)>()(
+      ptr.ref.lpVtbl, pBstrDescription);
 
-  int GetHelpFile(Pointer<Pointer<Utf16>> pBstrHelpFile) => ptr.ref.lpVtbl.value
+  int GetHelpFile(Pointer<Pointer<Utf16>> pBstrHelpFile) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -80,7 +79,7 @@ class IErrorInfo extends IUnknown {
       ptr.ref.lpVtbl, pBstrHelpFile);
 
   int GetHelpContext(Pointer<Uint32> pdwHelpContext) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<

--- a/lib/src/com/ifiledialog.dart
+++ b/lib/src/com/ifiledialog.dart
@@ -33,7 +33,7 @@ class IFileDialog extends IModalWindow {
   IFileDialog(super.ptr);
 
   int SetFileTypes(int cFileTypes, Pointer<COMDLG_FILTERSPEC> rgFilterSpec) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -46,7 +46,7 @@ class IFileDialog extends IModalWindow {
                       Pointer<COMDLG_FILTERSPEC> rgFilterSpec)>()(
           ptr.ref.lpVtbl, cFileTypes, rgFilterSpec);
 
-  int SetFileTypeIndex(int iFileType) => ptr.ref.lpVtbl.value
+  int SetFileTypeIndex(int iFileType) => ptr.ref.vtable
       .elementAt(5)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, Uint32 iFileType)>>>()
@@ -54,7 +54,7 @@ class IFileDialog extends IModalWindow {
       .asFunction<
           int Function(Pointer, int iFileType)>()(ptr.ref.lpVtbl, iFileType);
 
-  int GetFileTypeIndex(Pointer<Uint32> piFileType) => ptr.ref.lpVtbl.value
+  int GetFileTypeIndex(Pointer<Uint32> piFileType) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -65,7 +65,7 @@ class IFileDialog extends IModalWindow {
       ptr.ref.lpVtbl, piFileType);
 
   int Advise(Pointer<COMObject> pfde, Pointer<Uint32> pdwCookie) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(7)
       .cast<
           Pointer<
@@ -77,20 +77,20 @@ class IFileDialog extends IModalWindow {
           int Function(Pointer, Pointer<COMObject> pfde,
               Pointer<Uint32> pdwCookie)>()(ptr.ref.lpVtbl, pfde, pdwCookie);
 
-  int Unadvise(int dwCookie) => ptr.ref.lpVtbl.value
+  int Unadvise(int dwCookie) => ptr.ref.vtable
       .elementAt(8)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwCookie)>>>()
       .value
       .asFunction<
           int Function(Pointer, int dwCookie)>()(ptr.ref.lpVtbl, dwCookie);
 
-  int SetOptions(int fos) => ptr.ref.lpVtbl.value
+  int SetOptions(int fos) => ptr.ref.vtable
       .elementAt(9)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 fos)>>>()
       .value
       .asFunction<int Function(Pointer, int fos)>()(ptr.ref.lpVtbl, fos);
 
-  int GetOptions(Pointer<Uint32> pfos) => ptr.ref.lpVtbl.value
+  int GetOptions(Pointer<Uint32> pfos) => ptr.ref.vtable
       .elementAt(10)
       .cast<
           Pointer<
@@ -99,7 +99,7 @@ class IFileDialog extends IModalWindow {
       .asFunction<
           int Function(Pointer, Pointer<Uint32> pfos)>()(ptr.ref.lpVtbl, pfos);
 
-  int SetDefaultFolder(Pointer<COMObject> psi) => ptr.ref.lpVtbl.value
+  int SetDefaultFolder(Pointer<COMObject> psi) => ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -109,7 +109,7 @@ class IFileDialog extends IModalWindow {
           .asFunction<int Function(Pointer, Pointer<COMObject> psi)>()(
       ptr.ref.lpVtbl, psi);
 
-  int SetFolder(Pointer<COMObject> psi) => ptr.ref.lpVtbl.value
+  int SetFolder(Pointer<COMObject> psi) => ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -119,7 +119,7 @@ class IFileDialog extends IModalWindow {
           .asFunction<int Function(Pointer, Pointer<COMObject> psi)>()(
       ptr.ref.lpVtbl, psi);
 
-  int GetFolder(Pointer<Pointer<COMObject>> ppsi) => ptr.ref.lpVtbl.value
+  int GetFolder(Pointer<Pointer<COMObject>> ppsi) => ptr.ref.vtable
       .elementAt(13)
       .cast<
           Pointer<
@@ -130,8 +130,7 @@ class IFileDialog extends IModalWindow {
           int Function(Pointer,
               Pointer<Pointer<COMObject>> ppsi)>()(ptr.ref.lpVtbl, ppsi);
 
-  int GetCurrentSelection(Pointer<Pointer<COMObject>> ppsi) => ptr
-      .ref.lpVtbl.value
+  int GetCurrentSelection(Pointer<Pointer<COMObject>> ppsi) => ptr.ref.vtable
       .elementAt(14)
       .cast<
           Pointer<
@@ -142,7 +141,7 @@ class IFileDialog extends IModalWindow {
           int Function(Pointer,
               Pointer<Pointer<COMObject>> ppsi)>()(ptr.ref.lpVtbl, ppsi);
 
-  int SetFileName(Pointer<Utf16> pszName) => ptr.ref.lpVtbl.value
+  int SetFileName(Pointer<Utf16> pszName) => ptr.ref.vtable
           .elementAt(15)
           .cast<
               Pointer<
@@ -152,7 +151,7 @@ class IFileDialog extends IModalWindow {
           .asFunction<int Function(Pointer, Pointer<Utf16> pszName)>()(
       ptr.ref.lpVtbl, pszName);
 
-  int GetFileName(Pointer<Pointer<Utf16>> pszName) => ptr.ref.lpVtbl.value
+  int GetFileName(Pointer<Pointer<Utf16>> pszName) => ptr.ref.vtable
       .elementAt(16)
       .cast<
           Pointer<
@@ -163,7 +162,7 @@ class IFileDialog extends IModalWindow {
           int Function(Pointer,
               Pointer<Pointer<Utf16>> pszName)>()(ptr.ref.lpVtbl, pszName);
 
-  int SetTitle(Pointer<Utf16> pszTitle) => ptr.ref.lpVtbl.value
+  int SetTitle(Pointer<Utf16> pszTitle) => ptr.ref.vtable
           .elementAt(17)
           .cast<
               Pointer<
@@ -173,7 +172,7 @@ class IFileDialog extends IModalWindow {
           .asFunction<int Function(Pointer, Pointer<Utf16> pszTitle)>()(
       ptr.ref.lpVtbl, pszTitle);
 
-  int SetOkButtonLabel(Pointer<Utf16> pszText) => ptr.ref.lpVtbl.value
+  int SetOkButtonLabel(Pointer<Utf16> pszText) => ptr.ref.vtable
           .elementAt(18)
           .cast<
               Pointer<
@@ -183,7 +182,7 @@ class IFileDialog extends IModalWindow {
           .asFunction<int Function(Pointer, Pointer<Utf16> pszText)>()(
       ptr.ref.lpVtbl, pszText);
 
-  int SetFileNameLabel(Pointer<Utf16> pszLabel) => ptr.ref.lpVtbl.value
+  int SetFileNameLabel(Pointer<Utf16> pszLabel) => ptr.ref.vtable
           .elementAt(19)
           .cast<
               Pointer<
@@ -193,7 +192,7 @@ class IFileDialog extends IModalWindow {
           .asFunction<int Function(Pointer, Pointer<Utf16> pszLabel)>()(
       ptr.ref.lpVtbl, pszLabel);
 
-  int GetResult(Pointer<Pointer<COMObject>> ppsi) => ptr.ref.lpVtbl.value
+  int GetResult(Pointer<Pointer<COMObject>> ppsi) => ptr.ref.vtable
       .elementAt(20)
       .cast<
           Pointer<
@@ -204,7 +203,7 @@ class IFileDialog extends IModalWindow {
           int Function(Pointer,
               Pointer<Pointer<COMObject>> ppsi)>()(ptr.ref.lpVtbl, ppsi);
 
-  int AddPlace(Pointer<COMObject> psi, int fdap) => ptr.ref.lpVtbl.value
+  int AddPlace(Pointer<COMObject> psi, int fdap) => ptr.ref.vtable
           .elementAt(21)
           .cast<
               Pointer<
@@ -216,26 +215,25 @@ class IFileDialog extends IModalWindow {
               int Function(Pointer, Pointer<COMObject> psi, int fdap)>()(
       ptr.ref.lpVtbl, psi, fdap);
 
-  int SetDefaultExtension(Pointer<Utf16> pszDefaultExtension) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(22)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(
-                              Pointer, Pointer<Utf16> pszDefaultExtension)>>>()
-              .value
-              .asFunction<
-                  int Function(Pointer, Pointer<Utf16> pszDefaultExtension)>()(
-          ptr.ref.lpVtbl, pszDefaultExtension);
+  int SetDefaultExtension(Pointer<Utf16> pszDefaultExtension) => ptr.ref.vtable
+          .elementAt(22)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(
+                          Pointer, Pointer<Utf16> pszDefaultExtension)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Utf16> pszDefaultExtension)>()(
+      ptr.ref.lpVtbl, pszDefaultExtension);
 
-  int Close(int hr) => ptr.ref.lpVtbl.value
+  int Close(int hr) => ptr.ref.vtable
       .elementAt(23)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 hr)>>>()
       .value
       .asFunction<int Function(Pointer, int hr)>()(ptr.ref.lpVtbl, hr);
 
-  int SetClientGuid(Pointer<GUID> guid) => ptr.ref.lpVtbl.value
+  int SetClientGuid(Pointer<GUID> guid) => ptr.ref.vtable
       .elementAt(24)
       .cast<
           Pointer<
@@ -244,13 +242,13 @@ class IFileDialog extends IModalWindow {
       .asFunction<
           int Function(Pointer, Pointer<GUID> guid)>()(ptr.ref.lpVtbl, guid);
 
-  int ClearClientData() => ptr.ref.lpVtbl.value
+  int ClearClientData() => ptr.ref.vtable
       .elementAt(25)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int SetFilter(Pointer<COMObject> pFilter) => ptr.ref.lpVtbl.value
+  int SetFilter(Pointer<COMObject> pFilter) => ptr.ref.vtable
           .elementAt(26)
           .cast<
               Pointer<

--- a/lib/src/com/ifiledialog2.dart
+++ b/lib/src/com/ifiledialog2.dart
@@ -32,7 +32,7 @@ class IFileDialog2 extends IFileDialog {
   // vtable begins at 27, is 2 entries long.
   IFileDialog2(super.ptr);
 
-  int SetCancelButtonLabel(Pointer<Utf16> pszLabel) => ptr.ref.lpVtbl.value
+  int SetCancelButtonLabel(Pointer<Utf16> pszLabel) => ptr.ref.vtable
           .elementAt(27)
           .cast<
               Pointer<
@@ -42,7 +42,7 @@ class IFileDialog2 extends IFileDialog {
           .asFunction<int Function(Pointer, Pointer<Utf16> pszLabel)>()(
       ptr.ref.lpVtbl, pszLabel);
 
-  int SetNavigationRoot(Pointer<COMObject> psi) => ptr.ref.lpVtbl.value
+  int SetNavigationRoot(Pointer<COMObject> psi) => ptr.ref.vtable
           .elementAt(28)
           .cast<
               Pointer<

--- a/lib/src/com/ifiledialogcustomize.dart
+++ b/lib/src/com/ifiledialogcustomize.dart
@@ -32,14 +32,14 @@ class IFileDialogCustomize extends IUnknown {
   // vtable begins at 3, is 27 entries long.
   IFileDialogCustomize(super.ptr);
 
-  int EnableOpenDropDown(int dwIDCtl) => ptr.ref.lpVtbl.value
+  int EnableOpenDropDown(int dwIDCtl) => ptr.ref.vtable
       .elementAt(3)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwIDCtl)>>>()
       .value
       .asFunction<
           int Function(Pointer, int dwIDCtl)>()(ptr.ref.lpVtbl, dwIDCtl);
 
-  int AddMenu(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr.ref.lpVtbl.value
+  int AddMenu(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -51,8 +51,7 @@ class IFileDialogCustomize extends IUnknown {
               int Function(Pointer, int dwIDCtl, Pointer<Utf16> pszLabel)>()(
       ptr.ref.lpVtbl, dwIDCtl, pszLabel);
 
-  int AddPushButton(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr
-          .ref.lpVtbl.value
+  int AddPushButton(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -64,14 +63,14 @@ class IFileDialogCustomize extends IUnknown {
               int Function(Pointer, int dwIDCtl, Pointer<Utf16> pszLabel)>()(
       ptr.ref.lpVtbl, dwIDCtl, pszLabel);
 
-  int AddComboBox(int dwIDCtl) => ptr.ref.lpVtbl.value
+  int AddComboBox(int dwIDCtl) => ptr.ref.vtable
       .elementAt(6)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwIDCtl)>>>()
       .value
       .asFunction<
           int Function(Pointer, int dwIDCtl)>()(ptr.ref.lpVtbl, dwIDCtl);
 
-  int AddRadioButtonList(int dwIDCtl) => ptr.ref.lpVtbl.value
+  int AddRadioButtonList(int dwIDCtl) => ptr.ref.vtable
       .elementAt(7)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwIDCtl)>>>()
       .value
@@ -79,7 +78,7 @@ class IFileDialogCustomize extends IUnknown {
           int Function(Pointer, int dwIDCtl)>()(ptr.ref.lpVtbl, dwIDCtl);
 
   int AddCheckButton(int dwIDCtl, Pointer<Utf16> pszLabel, int bChecked) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -91,7 +90,7 @@ class IFileDialogCustomize extends IUnknown {
               int Function(Pointer, int dwIDCtl, Pointer<Utf16> pszLabel,
                   int bChecked)>()(ptr.ref.lpVtbl, dwIDCtl, pszLabel, bChecked);
 
-  int AddEditBox(int dwIDCtl, Pointer<Utf16> pszText) => ptr.ref.lpVtbl.value
+  int AddEditBox(int dwIDCtl, Pointer<Utf16> pszText) => ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
@@ -103,14 +102,14 @@ class IFileDialogCustomize extends IUnknown {
               int Function(Pointer, int dwIDCtl, Pointer<Utf16> pszText)>()(
       ptr.ref.lpVtbl, dwIDCtl, pszText);
 
-  int AddSeparator(int dwIDCtl) => ptr.ref.lpVtbl.value
+  int AddSeparator(int dwIDCtl) => ptr.ref.vtable
       .elementAt(10)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwIDCtl)>>>()
       .value
       .asFunction<
           int Function(Pointer, int dwIDCtl)>()(ptr.ref.lpVtbl, dwIDCtl);
 
-  int AddText(int dwIDCtl, Pointer<Utf16> pszText) => ptr.ref.lpVtbl.value
+  int AddText(int dwIDCtl, Pointer<Utf16> pszText) => ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -122,8 +121,7 @@ class IFileDialogCustomize extends IUnknown {
               int Function(Pointer, int dwIDCtl, Pointer<Utf16> pszText)>()(
       ptr.ref.lpVtbl, dwIDCtl, pszText);
 
-  int SetControlLabel(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr
-          .ref.lpVtbl.value
+  int SetControlLabel(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -135,8 +133,7 @@ class IFileDialogCustomize extends IUnknown {
               int Function(Pointer, int dwIDCtl, Pointer<Utf16> pszLabel)>()(
       ptr.ref.lpVtbl, dwIDCtl, pszLabel);
 
-  int GetControlState(int dwIDCtl, Pointer<Int32> pdwState) => ptr
-          .ref.lpVtbl.value
+  int GetControlState(int dwIDCtl, Pointer<Int32> pdwState) => ptr.ref.vtable
           .elementAt(13)
           .cast<
               Pointer<
@@ -149,7 +146,7 @@ class IFileDialogCustomize extends IUnknown {
       ptr.ref.lpVtbl, dwIDCtl, pdwState);
 
   int SetControlState(int dwIDCtl, int dwState) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(14)
               .cast<
                   Pointer<
@@ -161,7 +158,7 @@ class IFileDialogCustomize extends IUnknown {
           ptr.ref.lpVtbl, dwIDCtl, dwState);
 
   int GetEditBoxText(int dwIDCtl, Pointer<Pointer<Uint16>> ppszText) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(15)
           .cast<
               Pointer<
@@ -174,8 +171,7 @@ class IFileDialogCustomize extends IUnknown {
                   Pointer, int dwIDCtl, Pointer<Pointer<Uint16>> ppszText)>()(
       ptr.ref.lpVtbl, dwIDCtl, ppszText);
 
-  int SetEditBoxText(int dwIDCtl, Pointer<Utf16> pszText) =>
-      ptr.ref.lpVtbl.value
+  int SetEditBoxText(int dwIDCtl, Pointer<Utf16> pszText) => ptr.ref.vtable
           .elementAt(16)
           .cast<
               Pointer<
@@ -184,11 +180,11 @@ class IFileDialogCustomize extends IUnknown {
                           Pointer, Uint32 dwIDCtl, Pointer<Utf16> pszText)>>>()
           .value
           .asFunction<
-              int Function(Pointer, int dwIDCtl,
-                  Pointer<Utf16> pszText)>()(ptr.ref.lpVtbl, dwIDCtl, pszText);
+              int Function(Pointer, int dwIDCtl, Pointer<Utf16> pszText)>()(
+      ptr.ref.lpVtbl, dwIDCtl, pszText);
 
   int GetCheckButtonState(int dwIDCtl, Pointer<Int32> pbChecked) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(17)
       .cast<
           Pointer<
@@ -201,7 +197,7 @@ class IFileDialogCustomize extends IUnknown {
               Pointer<Int32> pbChecked)>()(ptr.ref.lpVtbl, dwIDCtl, pbChecked);
 
   int SetCheckButtonState(int dwIDCtl, int bChecked) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(18)
               .cast<
                   Pointer<
@@ -213,7 +209,7 @@ class IFileDialogCustomize extends IUnknown {
           ptr.ref.lpVtbl, dwIDCtl, bChecked);
 
   int AddControlItem(int dwIDCtl, int dwIDItem, Pointer<Utf16> pszLabel) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(19)
           .cast<
               Pointer<
@@ -227,7 +223,7 @@ class IFileDialogCustomize extends IUnknown {
       ptr.ref.lpVtbl, dwIDCtl, dwIDItem, pszLabel);
 
   int RemoveControlItem(int dwIDCtl, int dwIDItem) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(20)
               .cast<
                   Pointer<
@@ -238,7 +234,7 @@ class IFileDialogCustomize extends IUnknown {
               .asFunction<int Function(Pointer, int dwIDCtl, int dwIDItem)>()(
           ptr.ref.lpVtbl, dwIDCtl, dwIDItem);
 
-  int RemoveAllControlItems(int dwIDCtl) => ptr.ref.lpVtbl.value
+  int RemoveAllControlItems(int dwIDCtl) => ptr.ref.vtable
       .elementAt(21)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwIDCtl)>>>()
       .value
@@ -246,7 +242,7 @@ class IFileDialogCustomize extends IUnknown {
           int Function(Pointer, int dwIDCtl)>()(ptr.ref.lpVtbl, dwIDCtl);
 
   int GetControlItemState(int dwIDCtl, int dwIDItem, Pointer<Int32> pdwState) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(22)
           .cast<
               Pointer<
@@ -263,7 +259,7 @@ class IFileDialogCustomize extends IUnknown {
                       pdwState)>()(ptr.ref.lpVtbl, dwIDCtl, dwIDItem, pdwState);
 
   int SetControlItemState(int dwIDCtl, int dwIDItem, int dwState) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(23)
           .cast<
               Pointer<
@@ -276,7 +272,7 @@ class IFileDialogCustomize extends IUnknown {
                   int dwState)>()(ptr.ref.lpVtbl, dwIDCtl, dwIDItem, dwState);
 
   int GetSelectedControlItem(int dwIDCtl, Pointer<Uint32> pdwIDItem) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(24)
       .cast<
           Pointer<
@@ -289,7 +285,7 @@ class IFileDialogCustomize extends IUnknown {
               Pointer<Uint32> pdwIDItem)>()(ptr.ref.lpVtbl, dwIDCtl, pdwIDItem);
 
   int SetSelectedControlItem(int dwIDCtl, int dwIDItem) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(25)
               .cast<
                   Pointer<
@@ -300,8 +296,7 @@ class IFileDialogCustomize extends IUnknown {
               .asFunction<int Function(Pointer, int dwIDCtl, int dwIDItem)>()(
           ptr.ref.lpVtbl, dwIDCtl, dwIDItem);
 
-  int StartVisualGroup(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr
-          .ref.lpVtbl.value
+  int StartVisualGroup(int dwIDCtl, Pointer<Utf16> pszLabel) => ptr.ref.vtable
           .elementAt(26)
           .cast<
               Pointer<
@@ -313,13 +308,13 @@ class IFileDialogCustomize extends IUnknown {
               int Function(Pointer, int dwIDCtl, Pointer<Utf16> pszLabel)>()(
       ptr.ref.lpVtbl, dwIDCtl, pszLabel);
 
-  int EndVisualGroup() => ptr.ref.lpVtbl.value
+  int EndVisualGroup() => ptr.ref.vtable
       .elementAt(27)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int MakeProminent(int dwIDCtl) => ptr.ref.lpVtbl.value
+  int MakeProminent(int dwIDCtl) => ptr.ref.vtable
       .elementAt(28)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwIDCtl)>>>()
       .value
@@ -327,7 +322,7 @@ class IFileDialogCustomize extends IUnknown {
           int Function(Pointer, int dwIDCtl)>()(ptr.ref.lpVtbl, dwIDCtl);
 
   int SetControlItemText(int dwIDCtl, int dwIDItem, Pointer<Utf16> pszLabel) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(29)
           .cast<
               Pointer<

--- a/lib/src/com/ifileisinuse.dart
+++ b/lib/src/com/ifileisinuse.dart
@@ -32,7 +32,7 @@ class IFileIsInUse extends IUnknown {
   // vtable begins at 3, is 5 entries long.
   IFileIsInUse(super.ptr);
 
-  int GetAppName(Pointer<Pointer<Utf16>> ppszName) => ptr.ref.lpVtbl.value
+  int GetAppName(Pointer<Pointer<Utf16>> ppszName) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -43,7 +43,7 @@ class IFileIsInUse extends IUnknown {
           int Function(Pointer,
               Pointer<Pointer<Utf16>> ppszName)>()(ptr.ref.lpVtbl, ppszName);
 
-  int GetUsage(Pointer<Int32> pfut) => ptr.ref.lpVtbl.value
+  int GetUsage(Pointer<Int32> pfut) => ptr.ref.vtable
       .elementAt(4)
       .cast<
           Pointer<
@@ -52,7 +52,7 @@ class IFileIsInUse extends IUnknown {
       .asFunction<
           int Function(Pointer, Pointer<Int32> pfut)>()(ptr.ref.lpVtbl, pfut);
 
-  int GetCapabilities(Pointer<Uint32> pdwCapFlags) => ptr.ref.lpVtbl.value
+  int GetCapabilities(Pointer<Uint32> pdwCapFlags) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -62,7 +62,7 @@ class IFileIsInUse extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint32> pdwCapFlags)>()(
       ptr.ref.lpVtbl, pdwCapFlags);
 
-  int GetSwitchToHWND(Pointer<IntPtr> phwnd) => ptr.ref.lpVtbl.value
+  int GetSwitchToHWND(Pointer<IntPtr> phwnd) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<
@@ -72,7 +72,7 @@ class IFileIsInUse extends IUnknown {
           int Function(
               Pointer, Pointer<IntPtr> phwnd)>()(ptr.ref.lpVtbl, phwnd);
 
-  int CloseFile() => ptr.ref.lpVtbl.value
+  int CloseFile() => ptr.ref.vtable
       .elementAt(7)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value

--- a/lib/src/com/ifileopendialog.dart
+++ b/lib/src/com/ifileopendialog.dart
@@ -32,7 +32,7 @@ class IFileOpenDialog extends IFileDialog {
   // vtable begins at 27, is 2 entries long.
   IFileOpenDialog(super.ptr);
 
-  int GetResults(Pointer<Pointer<COMObject>> ppenum) => ptr.ref.lpVtbl.value
+  int GetResults(Pointer<Pointer<COMObject>> ppenum) => ptr.ref.vtable
           .elementAt(27)
           .cast<
               Pointer<
@@ -44,18 +44,17 @@ class IFileOpenDialog extends IFileDialog {
               int Function(Pointer, Pointer<Pointer<COMObject>> ppenum)>()(
       ptr.ref.lpVtbl, ppenum);
 
-  int GetSelectedItems(Pointer<Pointer<COMObject>> ppsai) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(28)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(
-                              Pointer, Pointer<Pointer<COMObject>> ppsai)>>>()
-              .value
-              .asFunction<
-                  int Function(Pointer, Pointer<Pointer<COMObject>> ppsai)>()(
-          ptr.ref.lpVtbl, ppsai);
+  int GetSelectedItems(Pointer<Pointer<COMObject>> ppsai) => ptr.ref.vtable
+          .elementAt(28)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(
+                          Pointer, Pointer<Pointer<COMObject>> ppsai)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Pointer<COMObject>> ppsai)>()(
+      ptr.ref.lpVtbl, ppsai);
 }
 
 /// @nodoc

--- a/lib/src/com/ifilesavedialog.dart
+++ b/lib/src/com/ifilesavedialog.dart
@@ -32,7 +32,7 @@ class IFileSaveDialog extends IFileDialog {
   // vtable begins at 27, is 5 entries long.
   IFileSaveDialog(super.ptr);
 
-  int SetSaveAsItem(Pointer<COMObject> psi) => ptr.ref.lpVtbl.value
+  int SetSaveAsItem(Pointer<COMObject> psi) => ptr.ref.vtable
           .elementAt(27)
           .cast<
               Pointer<
@@ -42,7 +42,7 @@ class IFileSaveDialog extends IFileDialog {
           .asFunction<int Function(Pointer, Pointer<COMObject> psi)>()(
       ptr.ref.lpVtbl, psi);
 
-  int SetProperties(Pointer<COMObject> pStore) => ptr.ref.lpVtbl.value
+  int SetProperties(Pointer<COMObject> pStore) => ptr.ref.vtable
           .elementAt(28)
           .cast<
               Pointer<
@@ -53,7 +53,7 @@ class IFileSaveDialog extends IFileDialog {
       ptr.ref.lpVtbl, pStore);
 
   int SetCollectedProperties(Pointer<COMObject> pList, int fAppendDefault) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(29)
           .cast<
               Pointer<
@@ -65,7 +65,7 @@ class IFileSaveDialog extends IFileDialog {
               int Function(Pointer, Pointer<COMObject> pList,
                   int fAppendDefault)>()(ptr.ref.lpVtbl, pList, fAppendDefault);
 
-  int GetProperties(Pointer<Pointer<COMObject>> ppStore) => ptr.ref.lpVtbl.value
+  int GetProperties(Pointer<Pointer<COMObject>> ppStore) => ptr.ref.vtable
           .elementAt(30)
           .cast<
               Pointer<
@@ -79,7 +79,7 @@ class IFileSaveDialog extends IFileDialog {
 
   int ApplyProperties(Pointer<COMObject> psi, Pointer<COMObject> pStore,
           int hwnd, Pointer<COMObject> pSink) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(31)
               .cast<
                   Pointer<

--- a/lib/src/com/iinspectable.dart
+++ b/lib/src/com/iinspectable.dart
@@ -33,7 +33,7 @@ class IInspectable extends IUnknown {
   IInspectable(super.ptr);
 
   int GetIids(Pointer<Uint32> iidCount, Pointer<Pointer<GUID>> iids) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -45,7 +45,7 @@ class IInspectable extends IUnknown {
           int Function(Pointer, Pointer<Uint32> iidCount,
               Pointer<Pointer<GUID>> iids)>()(ptr.ref.lpVtbl, iidCount, iids);
 
-  int GetRuntimeClassName(Pointer<IntPtr> className) => ptr.ref.lpVtbl.value
+  int GetRuntimeClassName(Pointer<IntPtr> className) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -55,7 +55,7 @@ class IInspectable extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<IntPtr> className)>()(
       ptr.ref.lpVtbl, className);
 
-  int GetTrustLevel(Pointer<Int32> trustLevel) => ptr.ref.lpVtbl.value
+  int GetTrustLevel(Pointer<Int32> trustLevel) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<

--- a/lib/src/com/iknownfolder.dart
+++ b/lib/src/com/iknownfolder.dart
@@ -32,7 +32,7 @@ class IKnownFolder extends IUnknown {
   // vtable begins at 3, is 9 entries long.
   IKnownFolder(super.ptr);
 
-  int GetId(Pointer<GUID> pkfid) => ptr.ref.lpVtbl.value
+  int GetId(Pointer<GUID> pkfid) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -41,7 +41,7 @@ class IKnownFolder extends IUnknown {
       .asFunction<
           int Function(Pointer, Pointer<GUID> pkfid)>()(ptr.ref.lpVtbl, pkfid);
 
-  int GetCategory(Pointer<Int32> pCategory) => ptr.ref.lpVtbl.value
+  int GetCategory(Pointer<Int32> pCategory) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -52,7 +52,7 @@ class IKnownFolder extends IUnknown {
       ptr.ref.lpVtbl, pCategory);
 
   int GetShellItem(int dwFlags, Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -64,8 +64,7 @@ class IKnownFolder extends IUnknown {
               int Function(Pointer, int dwFlags, Pointer<GUID> riid,
                   Pointer<Pointer> ppv)>()(ptr.ref.lpVtbl, dwFlags, riid, ppv);
 
-  int GetPath(int dwFlags, Pointer<Pointer<Utf16>> ppszPath) => ptr
-          .ref.lpVtbl.value
+  int GetPath(int dwFlags, Pointer<Pointer<Utf16>> ppszPath) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -78,7 +77,7 @@ class IKnownFolder extends IUnknown {
                   Pointer, int dwFlags, Pointer<Pointer<Utf16>> ppszPath)>()(
       ptr.ref.lpVtbl, dwFlags, ppszPath);
 
-  int SetPath(int dwFlags, Pointer<Utf16> pszPath) => ptr.ref.lpVtbl.value
+  int SetPath(int dwFlags, Pointer<Utf16> pszPath) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -91,7 +90,7 @@ class IKnownFolder extends IUnknown {
       ptr.ref.lpVtbl, dwFlags, pszPath);
 
   int GetIDList(int dwFlags, Pointer<Pointer<ITEMIDLIST>> ppidl) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -104,7 +103,7 @@ class IKnownFolder extends IUnknown {
                   Pointer, int dwFlags, Pointer<Pointer<ITEMIDLIST>> ppidl)>()(
       ptr.ref.lpVtbl, dwFlags, ppidl);
 
-  int GetFolderType(Pointer<GUID> pftid) => ptr.ref.lpVtbl.value
+  int GetFolderType(Pointer<GUID> pftid) => ptr.ref.vtable
       .elementAt(9)
       .cast<
           Pointer<
@@ -114,7 +113,7 @@ class IKnownFolder extends IUnknown {
           int Function(Pointer, Pointer<GUID> pftid)>()(ptr.ref.lpVtbl, pftid);
 
   int GetRedirectionCapabilities(Pointer<Uint32> pCapabilities) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(10)
       .cast<
           Pointer<
@@ -126,7 +125,7 @@ class IKnownFolder extends IUnknown {
               Pointer<Uint32> pCapabilities)>()(ptr.ref.lpVtbl, pCapabilities);
 
   int GetFolderDefinition(Pointer<KNOWNFOLDER_DEFINITION> pKFD) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(11)
           .cast<
               Pointer<

--- a/lib/src/com/iknownfoldermanager.dart
+++ b/lib/src/com/iknownfoldermanager.dart
@@ -32,7 +32,7 @@ class IKnownFolderManager extends IUnknown {
   // vtable begins at 3, is 10 entries long.
   IKnownFolderManager(super.ptr);
 
-  int FolderIdFromCsidl(int nCsidl, Pointer<GUID> pfid) => ptr.ref.lpVtbl.value
+  int FolderIdFromCsidl(int nCsidl, Pointer<GUID> pfid) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -44,7 +44,7 @@ class IKnownFolderManager extends IUnknown {
               Pointer<GUID> pfid)>()(ptr.ref.lpVtbl, nCsidl, pfid);
 
   int FolderIdToCsidl(Pointer<GUID> rfid, Pointer<Int32> pnCsidl) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(4)
       .cast<
           Pointer<
@@ -57,7 +57,7 @@ class IKnownFolderManager extends IUnknown {
               Pointer<Int32> pnCsidl)>()(ptr.ref.lpVtbl, rfid, pnCsidl);
 
   int GetFolderIds(Pointer<Pointer<GUID>> ppKFId, Pointer<Uint32> pCount) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -70,7 +70,7 @@ class IKnownFolderManager extends IUnknown {
                   Pointer<Uint32> pCount)>()(ptr.ref.lpVtbl, ppKFId, pCount);
 
   int GetFolder(Pointer<GUID> rfid, Pointer<Pointer<COMObject>> ppkf) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(6)
       .cast<
           Pointer<
@@ -84,7 +84,7 @@ class IKnownFolderManager extends IUnknown {
 
   int GetFolderByName(
           Pointer<Utf16> pszCanonicalName, Pointer<Pointer<COMObject>> ppkf) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -101,7 +101,7 @@ class IKnownFolderManager extends IUnknown {
 
   int RegisterFolder(
           Pointer<GUID> rfid, Pointer<KNOWNFOLDER_DEFINITION> pKFD) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -114,7 +114,7 @@ class IKnownFolderManager extends IUnknown {
                       Pointer<KNOWNFOLDER_DEFINITION> pKFD)>()(
           ptr.ref.lpVtbl, rfid, pKFD);
 
-  int UnregisterFolder(Pointer<GUID> rfid) => ptr.ref.lpVtbl.value
+  int UnregisterFolder(Pointer<GUID> rfid) => ptr.ref.vtable
       .elementAt(9)
       .cast<
           Pointer<
@@ -125,7 +125,7 @@ class IKnownFolderManager extends IUnknown {
 
   int FindFolderFromPath(
           Pointer<Utf16> pszPath, int mode, Pointer<Pointer<COMObject>> ppkf) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<
@@ -140,7 +140,7 @@ class IKnownFolderManager extends IUnknown {
 
   int FindFolderFromIDList(
           Pointer<ITEMIDLIST> pidl, Pointer<Pointer<COMObject>> ppkf) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -161,7 +161,7 @@ class IKnownFolderManager extends IUnknown {
           int cFolders,
           Pointer<GUID> pExclusion,
           Pointer<Pointer<Utf16>> ppszError) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(12)
               .cast<
                   Pointer<

--- a/lib/src/com/immdevice.dart
+++ b/lib/src/com/immdevice.dart
@@ -37,7 +37,7 @@ class IMMDevice extends IUnknown {
           int dwClsCtx,
           Pointer<PROPVARIANT> pActivationParams,
           Pointer<Pointer> ppInterface) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -61,7 +61,7 @@ class IMMDevice extends IUnknown {
   int OpenPropertyStore(
           int stgmAccess, Pointer<Pointer<COMObject>> ppProperties) =>
       ptr
-              .ref.lpVtbl.value
+              .ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -74,7 +74,7 @@ class IMMDevice extends IUnknown {
                       Pointer<Pointer<COMObject>> ppProperties)>()(
           ptr.ref.lpVtbl, stgmAccess, ppProperties);
 
-  int GetId(Pointer<Pointer<Utf16>> ppstrId) => ptr.ref.lpVtbl.value
+  int GetId(Pointer<Pointer<Utf16>> ppstrId) => ptr.ref.vtable
       .elementAt(5)
       .cast<
           Pointer<
@@ -85,7 +85,7 @@ class IMMDevice extends IUnknown {
           int Function(Pointer,
               Pointer<Pointer<Utf16>> ppstrId)>()(ptr.ref.lpVtbl, ppstrId);
 
-  int GetState(Pointer<Uint32> pdwState) => ptr.ref.lpVtbl.value
+  int GetState(Pointer<Uint32> pdwState) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<

--- a/lib/src/com/immdeviceenumerator.dart
+++ b/lib/src/com/immdeviceenumerator.dart
@@ -34,7 +34,7 @@ class IMMDeviceEnumerator extends IUnknown {
 
   int EnumAudioEndpoints(int dataFlow, int dwStateMask,
           Pointer<Pointer<COMObject>> ppDevices) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -52,7 +52,7 @@ class IMMDeviceEnumerator extends IUnknown {
 
   int GetDefaultAudioEndpoint(
           int dataFlow, int role, Pointer<Pointer<COMObject>> ppEndpoint) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -66,7 +66,7 @@ class IMMDeviceEnumerator extends IUnknown {
           ptr.ref.lpVtbl, dataFlow, role, ppEndpoint);
 
   int GetDevice(Pointer<Utf16> pwstrId, Pointer<Pointer<COMObject>> ppDevice) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -80,7 +80,7 @@ class IMMDeviceEnumerator extends IUnknown {
           ptr.ref.lpVtbl, pwstrId, ppDevice);
 
   int RegisterEndpointNotificationCallback(Pointer<COMObject> pClient) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -91,7 +91,7 @@ class IMMDeviceEnumerator extends IUnknown {
       ptr.ref.lpVtbl, pClient);
 
   int UnregisterEndpointNotificationCallback(Pointer<COMObject> pClient) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(7)
           .cast<
               Pointer<

--- a/lib/src/com/imodalwindow.dart
+++ b/lib/src/com/imodalwindow.dart
@@ -32,7 +32,7 @@ class IModalWindow extends IUnknown {
   // vtable begins at 3, is 1 entries long.
   IModalWindow(super.ptr);
 
-  int Show(int hwndOwner) => ptr.ref.lpVtbl.value
+  int Show(int hwndOwner) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, IntPtr hwndOwner)>>>()

--- a/lib/src/com/imoniker.dart
+++ b/lib/src/com/imoniker.dart
@@ -34,7 +34,7 @@ class IMoniker extends IPersistStream {
 
   int BindToObject(Pointer<COMObject> pbc, Pointer<COMObject> pmkToLeft,
           Pointer<GUID> riidResult, Pointer<Pointer> ppvResult) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -57,7 +57,7 @@ class IMoniker extends IPersistStream {
 
   int BindToStorage(Pointer<COMObject> pbc, Pointer<COMObject> pmkToLeft,
           Pointer<GUID> riid, Pointer<Pointer> ppvObj) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -83,7 +83,7 @@ class IMoniker extends IPersistStream {
           int dwReduceHowFar,
           Pointer<Pointer<COMObject>> ppmkToLeft,
           Pointer<Pointer<COMObject>> ppmkReduced) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<
@@ -106,7 +106,7 @@ class IMoniker extends IPersistStream {
 
   int ComposeWith(Pointer<COMObject> pmkRight, int fOnlyIfNotGeneric,
           Pointer<Pointer<COMObject>> ppmkComposite) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -126,7 +126,7 @@ class IMoniker extends IPersistStream {
           ptr.ref.lpVtbl, pmkRight, fOnlyIfNotGeneric, ppmkComposite);
 
   int Enum(int fForward, Pointer<Pointer<COMObject>> ppenumMoniker) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(12)
               .cast<
                   Pointer<
@@ -139,7 +139,7 @@ class IMoniker extends IPersistStream {
                       Pointer<Pointer<COMObject>> ppenumMoniker)>()(
           ptr.ref.lpVtbl, fForward, ppenumMoniker);
 
-  int IsEqual(Pointer<COMObject> pmkOtherMoniker) => ptr.ref.lpVtbl.value
+  int IsEqual(Pointer<COMObject> pmkOtherMoniker) => ptr.ref.vtable
           .elementAt(13)
           .cast<
               Pointer<
@@ -151,7 +151,7 @@ class IMoniker extends IPersistStream {
               int Function(Pointer, Pointer<COMObject> pmkOtherMoniker)>()(
       ptr.ref.lpVtbl, pmkOtherMoniker);
 
-  int Hash(Pointer<Uint32> pdwHash) => ptr.ref.lpVtbl.value
+  int Hash(Pointer<Uint32> pdwHash) => ptr.ref.vtable
           .elementAt(14)
           .cast<
               Pointer<
@@ -163,7 +163,7 @@ class IMoniker extends IPersistStream {
 
   int IsRunning(Pointer<COMObject> pbc, Pointer<COMObject> pmkToLeft,
           Pointer<COMObject> pmkNewlyRunning) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(15)
               .cast<
                   Pointer<
@@ -184,7 +184,7 @@ class IMoniker extends IPersistStream {
 
   int GetTimeOfLastChange(Pointer<COMObject> pbc, Pointer<COMObject> pmkToLeft,
           Pointer<FILETIME> pFileTime) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(16)
               .cast<
                   Pointer<
@@ -203,7 +203,7 @@ class IMoniker extends IPersistStream {
                       Pointer<FILETIME> pFileTime)>()(
           ptr.ref.lpVtbl, pbc, pmkToLeft, pFileTime);
 
-  int Inverse(Pointer<Pointer<COMObject>> ppmk) => ptr.ref.lpVtbl.value
+  int Inverse(Pointer<Pointer<COMObject>> ppmk) => ptr.ref.vtable
       .elementAt(17)
       .cast<
           Pointer<
@@ -216,7 +216,7 @@ class IMoniker extends IPersistStream {
 
   int CommonPrefixWith(Pointer<COMObject> pmkOther,
           Pointer<Pointer<COMObject>> ppmkPrefix) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(18)
               .cast<
                   Pointer<
@@ -231,7 +231,7 @@ class IMoniker extends IPersistStream {
 
   int RelativePathTo(Pointer<COMObject> pmkOther,
           Pointer<Pointer<COMObject>> ppmkRelPath) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(19)
               .cast<
                   Pointer<
@@ -246,7 +246,7 @@ class IMoniker extends IPersistStream {
 
   int GetDisplayName(Pointer<COMObject> pbc, Pointer<COMObject> pmkToLeft,
           Pointer<Pointer<Utf16>> ppszDisplayName) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(20)
               .cast<
                   Pointer<
@@ -271,7 +271,7 @@ class IMoniker extends IPersistStream {
           Pointer<Utf16> pszDisplayName,
           Pointer<Uint32> pchEaten,
           Pointer<Pointer<COMObject>> ppmkOut) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(21)
               .cast<
                   Pointer<
@@ -294,7 +294,7 @@ class IMoniker extends IPersistStream {
                       Pointer<Pointer<COMObject>> ppmkOut)>()(
           ptr.ref.lpVtbl, pbc, pmkToLeft, pszDisplayName, pchEaten, ppmkOut);
 
-  int IsSystemMoniker(Pointer<Uint32> pdwMksys) => ptr.ref.lpVtbl.value
+  int IsSystemMoniker(Pointer<Uint32> pdwMksys) => ptr.ref.vtable
           .elementAt(22)
           .cast<
               Pointer<

--- a/lib/src/com/inetwork.dart
+++ b/lib/src/com/inetwork.dart
@@ -32,7 +32,7 @@ class INetwork extends IDispatch {
   // vtable begins at 7, is 13 entries long.
   INetwork(super.ptr);
 
-  int GetName(Pointer<Pointer<Utf16>> pszNetworkName) => ptr.ref.lpVtbl.value
+  int GetName(Pointer<Pointer<Utf16>> pszNetworkName) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -45,7 +45,7 @@ class INetwork extends IDispatch {
       ptr.ref.lpVtbl, pszNetworkName);
 
   int SetName(Pointer<Utf16> szNetworkNewName) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -57,8 +57,7 @@ class INetwork extends IDispatch {
                   int Function(Pointer, Pointer<Utf16> szNetworkNewName)>()(
           ptr.ref.lpVtbl, szNetworkNewName);
 
-  int GetDescription(Pointer<Pointer<Utf16>> pszDescription) => ptr
-          .ref.lpVtbl.value
+  int GetDescription(Pointer<Pointer<Utf16>> pszDescription) => ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
@@ -70,7 +69,7 @@ class INetwork extends IDispatch {
               int Function(Pointer, Pointer<Pointer<Utf16>> pszDescription)>()(
       ptr.ref.lpVtbl, pszDescription);
 
-  int SetDescription(Pointer<Utf16> szDescription) => ptr.ref.lpVtbl.value
+  int SetDescription(Pointer<Utf16> szDescription) => ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -81,7 +80,7 @@ class INetwork extends IDispatch {
       ptr.ref.lpVtbl, szDescription);
 
   int GetNetworkId(Pointer<GUID> pgdGuidNetworkId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -93,7 +92,7 @@ class INetwork extends IDispatch {
                   int Function(Pointer, Pointer<GUID> pgdGuidNetworkId)>()(
           ptr.ref.lpVtbl, pgdGuidNetworkId);
 
-  int GetDomainType(Pointer<Int32> pNetworkType) => ptr.ref.lpVtbl.value
+  int GetDomainType(Pointer<Int32> pNetworkType) => ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -106,7 +105,7 @@ class INetwork extends IDispatch {
   int GetNetworkConnections(
           Pointer<Pointer<COMObject>> ppEnumNetworkConnection) =>
       ptr
-              .ref.lpVtbl.value
+              .ref.vtable
               .elementAt(13)
               .cast<
                   Pointer<
@@ -126,7 +125,7 @@ class INetwork extends IDispatch {
           Pointer<Uint32> pdwHighDateTimeCreated,
           Pointer<Uint32> pdwLowDateTimeConnected,
           Pointer<Uint32> pdwHighDateTimeConnected) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(14)
               .cast<
                   Pointer<
@@ -155,7 +154,7 @@ class INetwork extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(15)
           .cast<
               Pointer<
@@ -179,7 +178,7 @@ class INetwork extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(16)
           .cast<
               Pointer<
@@ -199,7 +198,7 @@ class INetwork extends IDispatch {
     }
   }
 
-  int GetConnectivity(Pointer<Int32> pConnectivity) => ptr.ref.lpVtbl.value
+  int GetConnectivity(Pointer<Int32> pConnectivity) => ptr.ref.vtable
           .elementAt(17)
           .cast<
               Pointer<
@@ -209,7 +208,7 @@ class INetwork extends IDispatch {
           .asFunction<int Function(Pointer, Pointer<Int32> pConnectivity)>()(
       ptr.ref.lpVtbl, pConnectivity);
 
-  int GetCategory(Pointer<Int32> pCategory) => ptr.ref.lpVtbl.value
+  int GetCategory(Pointer<Int32> pCategory) => ptr.ref.vtable
           .elementAt(18)
           .cast<
               Pointer<
@@ -219,7 +218,7 @@ class INetwork extends IDispatch {
           .asFunction<int Function(Pointer, Pointer<Int32> pCategory)>()(
       ptr.ref.lpVtbl, pCategory);
 
-  int SetCategory(int NewCategory) => ptr.ref.lpVtbl.value
+  int SetCategory(int NewCategory) => ptr.ref.vtable
       .elementAt(19)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, Int32 NewCategory)>>>()

--- a/lib/src/com/inetworkconnection.dart
+++ b/lib/src/com/inetworkconnection.dart
@@ -32,7 +32,7 @@ class INetworkConnection extends IDispatch {
   // vtable begins at 7, is 7 entries long.
   INetworkConnection(super.ptr);
 
-  int GetNetwork(Pointer<Pointer<COMObject>> ppNetwork) => ptr.ref.lpVtbl.value
+  int GetNetwork(Pointer<Pointer<COMObject>> ppNetwork) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -48,7 +48,7 @@ class INetworkConnection extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -72,7 +72,7 @@ class INetworkConnection extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
@@ -92,7 +92,7 @@ class INetworkConnection extends IDispatch {
     }
   }
 
-  int GetConnectivity(Pointer<Int32> pConnectivity) => ptr.ref.lpVtbl.value
+  int GetConnectivity(Pointer<Int32> pConnectivity) => ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -103,7 +103,7 @@ class INetworkConnection extends IDispatch {
       ptr.ref.lpVtbl, pConnectivity);
 
   int GetConnectionId(Pointer<GUID> pgdConnectionId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -115,7 +115,7 @@ class INetworkConnection extends IDispatch {
                   int Function(Pointer, Pointer<GUID> pgdConnectionId)>()(
           ptr.ref.lpVtbl, pgdConnectionId);
 
-  int GetAdapterId(Pointer<GUID> pgdAdapterId) => ptr.ref.lpVtbl.value
+  int GetAdapterId(Pointer<GUID> pgdAdapterId) => ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -125,7 +125,7 @@ class INetworkConnection extends IDispatch {
           .asFunction<int Function(Pointer, Pointer<GUID> pgdAdapterId)>()(
       ptr.ref.lpVtbl, pgdAdapterId);
 
-  int GetDomainType(Pointer<Int32> pDomainType) => ptr.ref.lpVtbl.value
+  int GetDomainType(Pointer<Int32> pDomainType) => ptr.ref.vtable
           .elementAt(13)
           .cast<
               Pointer<

--- a/lib/src/com/inetworklistmanager.dart
+++ b/lib/src/com/inetworklistmanager.dart
@@ -33,7 +33,7 @@ class INetworkListManager extends IDispatch {
   INetworkListManager(super.ptr);
 
   int GetNetworks(int Flags, Pointer<Pointer<COMObject>> ppEnumNetwork) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -47,7 +47,7 @@ class INetworkListManager extends IDispatch {
           ptr.ref.lpVtbl, Flags, ppEnumNetwork);
 
   int GetNetwork(GUID gdNetworkId, Pointer<Pointer<COMObject>> ppNetwork) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -61,7 +61,7 @@ class INetworkListManager extends IDispatch {
           ptr.ref.lpVtbl, gdNetworkId, ppNetwork);
 
   int GetNetworkConnections(Pointer<Pointer<COMObject>> ppEnum) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -76,7 +76,7 @@ class INetworkListManager extends IDispatch {
   int
       GetNetworkConnection(GUID gdNetworkConnectionId,
               Pointer<Pointer<COMObject>> ppNetworkConnection) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(10)
                   .cast<
                       Pointer<
@@ -96,7 +96,7 @@ class INetworkListManager extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -120,7 +120,7 @@ class INetworkListManager extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -140,7 +140,7 @@ class INetworkListManager extends IDispatch {
     }
   }
 
-  int GetConnectivity(Pointer<Int32> pConnectivity) => ptr.ref.lpVtbl.value
+  int GetConnectivity(Pointer<Int32> pConnectivity) => ptr.ref.vtable
           .elementAt(13)
           .cast<
               Pointer<
@@ -153,7 +153,7 @@ class INetworkListManager extends IDispatch {
   int SetSimulatedProfileInfo(
           Pointer<NLM_SIMULATED_PROFILE_INFO> pSimulatedInfo) =>
       ptr
-              .ref.lpVtbl.value
+              .ref.vtable
               .elementAt(14)
               .cast<
                   Pointer<
@@ -168,7 +168,7 @@ class INetworkListManager extends IDispatch {
                       Pointer<NLM_SIMULATED_PROFILE_INFO> pSimulatedInfo)>()(
           ptr.ref.lpVtbl, pSimulatedInfo);
 
-  int ClearSimulatedProfileInfo() => ptr.ref.lpVtbl.value
+  int ClearSimulatedProfileInfo() => ptr.ref.vtable
       .elementAt(15)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value

--- a/lib/src/com/inetworklistmanagerevents.dart
+++ b/lib/src/com/inetworklistmanagerevents.dart
@@ -32,7 +32,7 @@ class INetworkListManagerEvents extends IUnknown {
   // vtable begins at 3, is 1 entries long.
   INetworkListManagerEvents(super.ptr);
 
-  int ConnectivityChanged(int newConnectivity) => ptr.ref.lpVtbl.value
+  int ConnectivityChanged(int newConnectivity) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<

--- a/lib/src/com/ipersist.dart
+++ b/lib/src/com/ipersist.dart
@@ -32,7 +32,7 @@ class IPersist extends IUnknown {
   // vtable begins at 3, is 1 entries long.
   IPersist(super.ptr);
 
-  int GetClassID(Pointer<GUID> pClassID) => ptr.ref.lpVtbl.value
+  int GetClassID(Pointer<GUID> pClassID) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<

--- a/lib/src/com/ipersistfile.dart
+++ b/lib/src/com/ipersistfile.dart
@@ -32,13 +32,13 @@ class IPersistFile extends IPersist {
   // vtable begins at 4, is 5 entries long.
   IPersistFile(super.ptr);
 
-  int IsDirty() => ptr.ref.lpVtbl.value
+  int IsDirty() => ptr.ref.vtable
       .elementAt(4)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Load(Pointer<Utf16> pszFileName, int dwMode) => ptr.ref.lpVtbl.value
+  int Load(Pointer<Utf16> pszFileName, int dwMode) => ptr.ref.vtable
       .elementAt(5)
       .cast<
           Pointer<
@@ -50,7 +50,7 @@ class IPersistFile extends IPersist {
           int Function(Pointer, Pointer<Utf16> pszFileName,
               int dwMode)>()(ptr.ref.lpVtbl, pszFileName, dwMode);
 
-  int Save(Pointer<Utf16> pszFileName, int fRemember) => ptr.ref.lpVtbl.value
+  int Save(Pointer<Utf16> pszFileName, int fRemember) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<
@@ -62,7 +62,7 @@ class IPersistFile extends IPersist {
           int Function(Pointer, Pointer<Utf16> pszFileName,
               int fRemember)>()(ptr.ref.lpVtbl, pszFileName, fRemember);
 
-  int SaveCompleted(Pointer<Utf16> pszFileName) => ptr.ref.lpVtbl.value
+  int SaveCompleted(Pointer<Utf16> pszFileName) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -72,7 +72,7 @@ class IPersistFile extends IPersist {
           .asFunction<int Function(Pointer, Pointer<Utf16> pszFileName)>()(
       ptr.ref.lpVtbl, pszFileName);
 
-  int GetCurFile(Pointer<Pointer<Utf16>> ppszFileName) => ptr.ref.lpVtbl.value
+  int GetCurFile(Pointer<Pointer<Utf16>> ppszFileName) => ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<

--- a/lib/src/com/ipersistmemory.dart
+++ b/lib/src/com/ipersistmemory.dart
@@ -32,13 +32,13 @@ class IPersistMemory extends IPersist {
   // vtable begins at 4, is 5 entries long.
   IPersistMemory(super.ptr);
 
-  int IsDirty() => ptr.ref.lpVtbl.value
+  int IsDirty() => ptr.ref.vtable
       .elementAt(4)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Load(Pointer pMem, int cbSize) => ptr.ref.lpVtbl.value
+  int Load(Pointer pMem, int cbSize) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -48,7 +48,7 @@ class IPersistMemory extends IPersist {
           .asFunction<int Function(Pointer, Pointer pMem, int cbSize)>()(
       ptr.ref.lpVtbl, pMem, cbSize);
 
-  int Save(Pointer pMem, int fClearDirty, int cbSize) => ptr.ref.lpVtbl.value
+  int Save(Pointer pMem, int fClearDirty, int cbSize) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<
@@ -60,7 +60,7 @@ class IPersistMemory extends IPersist {
           int Function(Pointer, Pointer pMem, int fClearDirty,
               int cbSize)>()(ptr.ref.lpVtbl, pMem, fClearDirty, cbSize);
 
-  int GetSizeMax(Pointer<Uint32> pCbSize) => ptr.ref.lpVtbl.value
+  int GetSizeMax(Pointer<Uint32> pCbSize) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -70,7 +70,7 @@ class IPersistMemory extends IPersist {
           .asFunction<int Function(Pointer, Pointer<Uint32> pCbSize)>()(
       ptr.ref.lpVtbl, pCbSize);
 
-  int InitNew() => ptr.ref.lpVtbl.value
+  int InitNew() => ptr.ref.vtable
       .elementAt(8)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value

--- a/lib/src/com/ipersiststream.dart
+++ b/lib/src/com/ipersiststream.dart
@@ -32,13 +32,13 @@ class IPersistStream extends IPersist {
   // vtable begins at 4, is 4 entries long.
   IPersistStream(super.ptr);
 
-  int IsDirty() => ptr.ref.lpVtbl.value
+  int IsDirty() => ptr.ref.vtable
       .elementAt(4)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Load(Pointer<COMObject> pStm) => ptr.ref.lpVtbl.value
+  int Load(Pointer<COMObject> pStm) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -48,7 +48,7 @@ class IPersistStream extends IPersist {
           .asFunction<int Function(Pointer, Pointer<COMObject> pStm)>()(
       ptr.ref.lpVtbl, pStm);
 
-  int Save(Pointer<COMObject> pStm, int fClearDirty) => ptr.ref.lpVtbl.value
+  int Save(Pointer<COMObject> pStm, int fClearDirty) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<
@@ -60,7 +60,7 @@ class IPersistStream extends IPersist {
           int Function(Pointer, Pointer<COMObject> pStm,
               int fClearDirty)>()(ptr.ref.lpVtbl, pStm, fClearDirty);
 
-  int GetSizeMax(Pointer<Uint64> pcbSize) => ptr.ref.lpVtbl.value
+  int GetSizeMax(Pointer<Uint64> pcbSize) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<

--- a/lib/src/com/iprovideclassinfo.dart
+++ b/lib/src/com/iprovideclassinfo.dart
@@ -32,7 +32,7 @@ class IProvideClassInfo extends IUnknown {
   // vtable begins at 3, is 1 entries long.
   IProvideClassInfo(super.ptr);
 
-  int GetClassInfo(Pointer<Pointer<COMObject>> ppTI) => ptr.ref.lpVtbl.value
+  int GetClassInfo(Pointer<Pointer<COMObject>> ppTI) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<

--- a/lib/src/com/irunningobjecttable.dart
+++ b/lib/src/com/irunningobjecttable.dart
@@ -34,7 +34,7 @@ class IRunningObjectTable extends IUnknown {
 
   int Register(int grfFlags, Pointer<COMObject> punkObject,
           Pointer<COMObject> pmkObjectName, Pointer<Uint32> pdwRegister) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -55,7 +55,7 @@ class IRunningObjectTable extends IUnknown {
                       Pointer<Uint32> pdwRegister)>()(
           ptr.ref.lpVtbl, grfFlags, punkObject, pmkObjectName, pdwRegister);
 
-  int Revoke(int dwRegister) => ptr.ref.lpVtbl.value
+  int Revoke(int dwRegister) => ptr.ref.vtable
       .elementAt(4)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwRegister)>>>()
@@ -64,7 +64,7 @@ class IRunningObjectTable extends IUnknown {
           int Function(Pointer, int dwRegister)>()(ptr.ref.lpVtbl, dwRegister);
 
   int IsRunning(Pointer<COMObject> pmkObjectName) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -79,7 +79,7 @@ class IRunningObjectTable extends IUnknown {
   int
       GetObject(Pointer<COMObject> pmkObjectName,
               Pointer<Pointer<COMObject>> ppunkObject) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(6)
                   .cast<
                       Pointer<
@@ -95,7 +95,7 @@ class IRunningObjectTable extends IUnknown {
               ptr.ref.lpVtbl, pmkObjectName, ppunkObject);
 
   int NoteChangeTime(int dwRegister, Pointer<FILETIME> pfiletime) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -110,7 +110,7 @@ class IRunningObjectTable extends IUnknown {
 
   int GetTimeOfLastChange(
           Pointer<COMObject> pmkObjectName, Pointer<FILETIME> pfiletime) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -125,8 +125,7 @@ class IRunningObjectTable extends IUnknown {
                   Pointer<FILETIME>
                       pfiletime)>()(ptr.ref.lpVtbl, pmkObjectName, pfiletime);
 
-  int EnumRunning(Pointer<Pointer<COMObject>> ppenumMoniker) => ptr
-          .ref.lpVtbl.value
+  int EnumRunning(Pointer<Pointer<COMObject>> ppenumMoniker) => ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<

--- a/lib/src/com/isequentialstream.dart
+++ b/lib/src/com/isequentialstream.dart
@@ -32,7 +32,7 @@ class ISequentialStream extends IUnknown {
   // vtable begins at 3, is 2 entries long.
   ISequentialStream(super.ptr);
 
-  int Read(Pointer pv, int cb, Pointer<Uint32> pcbRead) => ptr.ref.lpVtbl.value
+  int Read(Pointer pv, int cb, Pointer<Uint32> pcbRead) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -44,8 +44,7 @@ class ISequentialStream extends IUnknown {
           int Function(Pointer, Pointer pv, int cb,
               Pointer<Uint32> pcbRead)>()(ptr.ref.lpVtbl, pv, cb, pcbRead);
 
-  int Write(Pointer pv, int cb, Pointer<Uint32> pcbWritten) => ptr
-          .ref.lpVtbl.value
+  int Write(Pointer pv, int cb, Pointer<Uint32> pcbWritten) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<

--- a/lib/src/com/ishellfolder.dart
+++ b/lib/src/com/ishellfolder.dart
@@ -39,7 +39,7 @@ class IShellFolder extends IUnknown {
           Pointer<Uint32> pchEaten,
           Pointer<Pointer<ITEMIDLIST>> ppidl,
           Pointer<Uint32> pdwAttributes) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -66,7 +66,7 @@ class IShellFolder extends IUnknown {
 
   int EnumObjects(
           int hwnd, int grfFlags, Pointer<Pointer<COMObject>> ppenumIDList) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -81,7 +81,7 @@ class IShellFolder extends IUnknown {
 
   int BindToObject(Pointer<ITEMIDLIST> pidl, Pointer<COMObject> pbc,
           Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -104,7 +104,7 @@ class IShellFolder extends IUnknown {
 
   int BindToStorage(Pointer<ITEMIDLIST> pidl, Pointer<COMObject> pbc,
           Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<
@@ -127,7 +127,7 @@ class IShellFolder extends IUnknown {
 
   int CompareIDs(
           int lParam, Pointer<ITEMIDLIST> pidl1, Pointer<ITEMIDLIST> pidl2) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -145,7 +145,7 @@ class IShellFolder extends IUnknown {
 
   int CreateViewObject(
           int hwndOwner, Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -160,7 +160,7 @@ class IShellFolder extends IUnknown {
 
   int GetAttributesOf(int cidl, Pointer<Pointer<ITEMIDLIST>> apidl,
           Pointer<Uint32> rgfInOut) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -186,7 +186,7 @@ class IShellFolder extends IUnknown {
           Pointer<GUID> riid,
           Pointer<Uint32> rgfReserved,
           Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<
@@ -213,7 +213,7 @@ class IShellFolder extends IUnknown {
 
   int GetDisplayNameOf(
           Pointer<ITEMIDLIST> pidl, int uFlags, Pointer<STRRET> pName) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -228,7 +228,7 @@ class IShellFolder extends IUnknown {
 
   int SetNameOf(int hwnd, Pointer<ITEMIDLIST> pidl, Pointer<Utf16> pszName,
           int uFlags, Pointer<Pointer<ITEMIDLIST>> ppidlOut) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(12)
               .cast<
                   Pointer<

--- a/lib/src/com/ishellitem.dart
+++ b/lib/src/com/ishellitem.dart
@@ -34,7 +34,7 @@ class IShellItem extends IUnknown {
 
   int BindToHandler(Pointer<COMObject> pbc, Pointer<GUID> bhid,
           Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -55,7 +55,7 @@ class IShellItem extends IUnknown {
                       Pointer<Pointer> ppv)>()(
           ptr.ref.lpVtbl, pbc, bhid, riid, ppv);
 
-  int GetParent(Pointer<Pointer<COMObject>> ppsi) => ptr.ref.lpVtbl.value
+  int GetParent(Pointer<Pointer<COMObject>> ppsi) => ptr.ref.vtable
       .elementAt(4)
       .cast<
           Pointer<
@@ -67,7 +67,7 @@ class IShellItem extends IUnknown {
               Pointer<Pointer<COMObject>> ppsi)>()(ptr.ref.lpVtbl, ppsi);
 
   int GetDisplayName(int sigdnName, Pointer<Pointer<Utf16>> ppszName) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -81,7 +81,7 @@ class IShellItem extends IUnknown {
       ptr.ref.lpVtbl, sigdnName, ppszName);
 
   int GetAttributes(int sfgaoMask, Pointer<Uint32> psfgaoAttribs) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<
@@ -95,7 +95,7 @@ class IShellItem extends IUnknown {
           ptr.ref.lpVtbl, sfgaoMask, psfgaoAttribs);
 
   int Compare(Pointer<COMObject> psi, int hint, Pointer<Int32> piOrder) => ptr
-      .ref.lpVtbl.value
+      .ref.vtable
       .elementAt(7)
       .cast<
           Pointer<

--- a/lib/src/com/ishellitem2.dart
+++ b/lib/src/com/ishellitem2.dart
@@ -33,7 +33,7 @@ class IShellItem2 extends IShellItem {
   IShellItem2(super.ptr);
 
   int GetPropertyStore(int flags, Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -50,7 +50,7 @@ class IShellItem2 extends IShellItem {
           Pointer<COMObject> punkCreateObject,
           Pointer<GUID> riid,
           Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -73,7 +73,7 @@ class IShellItem2 extends IShellItem {
 
   int GetPropertyStoreForKeys(Pointer<PROPERTYKEY> rgKeys, int cKeys, int flags,
           Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<
@@ -93,7 +93,7 @@ class IShellItem2 extends IShellItem {
 
   int GetPropertyDescriptionList(Pointer<PROPERTYKEY> keyType,
           Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -108,7 +108,7 @@ class IShellItem2 extends IShellItem {
                   Pointer<GUID> riid,
                   Pointer<Pointer> ppv)>()(ptr.ref.lpVtbl, keyType, riid, ppv);
 
-  int Update(Pointer<COMObject> pbc) => ptr.ref.lpVtbl.value
+  int Update(Pointer<COMObject> pbc) => ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -119,7 +119,7 @@ class IShellItem2 extends IShellItem {
       ptr.ref.lpVtbl, pbc);
 
   int GetProperty(Pointer<PROPERTYKEY> key, Pointer<PROPVARIANT> ppropvar) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(13)
               .cast<
                   Pointer<
@@ -132,34 +132,32 @@ class IShellItem2 extends IShellItem {
                       Pointer<PROPVARIANT> ppropvar)>()(
           ptr.ref.lpVtbl, key, ppropvar);
 
-  int GetCLSID(Pointer<PROPERTYKEY> key, Pointer<GUID> pclsid) =>
-      ptr.ref.lpVtbl.value
-          .elementAt(14)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      Int32 Function(Pointer, Pointer<PROPERTYKEY> key,
-                          Pointer<GUID> pclsid)>>>()
-          .value
-          .asFunction<
-              int Function(Pointer, Pointer<PROPERTYKEY> key,
-                  Pointer<GUID> pclsid)>()(ptr.ref.lpVtbl, key, pclsid);
+  int GetCLSID(Pointer<PROPERTYKEY> key, Pointer<GUID> pclsid) => ptr.ref.vtable
+      .elementAt(14)
+      .cast<
+          Pointer<
+              NativeFunction<
+                  Int32 Function(Pointer, Pointer<PROPERTYKEY> key,
+                      Pointer<GUID> pclsid)>>>()
+      .value
+      .asFunction<
+          int Function(Pointer, Pointer<PROPERTYKEY> key,
+              Pointer<GUID> pclsid)>()(ptr.ref.lpVtbl, key, pclsid);
 
-  int GetFileTime(Pointer<PROPERTYKEY> key, Pointer<FILETIME> pft) =>
-      ptr.ref.lpVtbl.value
-          .elementAt(15)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      Int32 Function(Pointer, Pointer<PROPERTYKEY> key,
-                          Pointer<FILETIME> pft)>>>()
-          .value
-          .asFunction<
-              int Function(Pointer, Pointer<PROPERTYKEY> key,
-                  Pointer<FILETIME> pft)>()(ptr.ref.lpVtbl, key, pft);
+  int GetFileTime(Pointer<PROPERTYKEY> key, Pointer<FILETIME> pft) => ptr
+      .ref.vtable
+      .elementAt(15)
+      .cast<
+          Pointer<
+              NativeFunction<
+                  Int32 Function(Pointer, Pointer<PROPERTYKEY> key,
+                      Pointer<FILETIME> pft)>>>()
+      .value
+      .asFunction<
+          int Function(Pointer, Pointer<PROPERTYKEY> key,
+              Pointer<FILETIME> pft)>()(ptr.ref.lpVtbl, key, pft);
 
-  int GetInt32(Pointer<PROPERTYKEY> key, Pointer<Int32> pi) => ptr
-      .ref.lpVtbl.value
+  int GetInt32(Pointer<PROPERTYKEY> key, Pointer<Int32> pi) => ptr.ref.vtable
       .elementAt(16)
       .cast<
           Pointer<
@@ -172,7 +170,7 @@ class IShellItem2 extends IShellItem {
               Pointer<Int32> pi)>()(ptr.ref.lpVtbl, key, pi);
 
   int GetString(Pointer<PROPERTYKEY> key, Pointer<Pointer<Utf16>> ppsz) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(17)
           .cast<
               Pointer<
@@ -184,21 +182,20 @@ class IShellItem2 extends IShellItem {
               int Function(Pointer, Pointer<PROPERTYKEY> key,
                   Pointer<Pointer<Utf16>> ppsz)>()(ptr.ref.lpVtbl, key, ppsz);
 
-  int GetUInt32(Pointer<PROPERTYKEY> key, Pointer<Uint32> pui) =>
-      ptr.ref.lpVtbl.value
-          .elementAt(18)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      Int32 Function(Pointer, Pointer<PROPERTYKEY> key,
-                          Pointer<Uint32> pui)>>>()
-          .value
-          .asFunction<
-              int Function(Pointer, Pointer<PROPERTYKEY> key,
-                  Pointer<Uint32> pui)>()(ptr.ref.lpVtbl, key, pui);
+  int GetUInt32(Pointer<PROPERTYKEY> key, Pointer<Uint32> pui) => ptr.ref.vtable
+      .elementAt(18)
+      .cast<
+          Pointer<
+              NativeFunction<
+                  Int32 Function(Pointer, Pointer<PROPERTYKEY> key,
+                      Pointer<Uint32> pui)>>>()
+      .value
+      .asFunction<
+          int Function(Pointer, Pointer<PROPERTYKEY> key,
+              Pointer<Uint32> pui)>()(ptr.ref.lpVtbl, key, pui);
 
   int GetUInt64(Pointer<PROPERTYKEY> key, Pointer<Uint64> pull) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(19)
           .cast<
               Pointer<
@@ -210,8 +207,7 @@ class IShellItem2 extends IShellItem {
               int Function(Pointer, Pointer<PROPERTYKEY> key,
                   Pointer<Uint64> pull)>()(ptr.ref.lpVtbl, key, pull);
 
-  int GetBool(Pointer<PROPERTYKEY> key, Pointer<Int32> pf) => ptr
-      .ref.lpVtbl.value
+  int GetBool(Pointer<PROPERTYKEY> key, Pointer<Int32> pf) => ptr.ref.vtable
       .elementAt(20)
       .cast<
           Pointer<

--- a/lib/src/com/ishellitemarray.dart
+++ b/lib/src/com/ishellitemarray.dart
@@ -34,7 +34,7 @@ class IShellItemArray extends IUnknown {
 
   int BindToHandler(Pointer<COMObject> pbc, Pointer<GUID> bhid,
           Pointer<GUID> riid, Pointer<Pointer> ppvOut) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -56,7 +56,7 @@ class IShellItemArray extends IUnknown {
           ptr.ref.lpVtbl, pbc, bhid, riid, ppvOut);
 
   int GetPropertyStore(int flags, Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -70,7 +70,7 @@ class IShellItemArray extends IUnknown {
 
   int GetPropertyDescriptionList(Pointer<PROPERTYKEY> keyType,
           Pointer<GUID> riid, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -88,7 +88,7 @@ class IShellItemArray extends IUnknown {
   int
       GetAttributes(
               int AttribFlags, int sfgaoMask, Pointer<Uint32> psfgaoAttribs) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(6)
                   .cast<
                       Pointer<
@@ -104,7 +104,7 @@ class IShellItemArray extends IUnknown {
                           Pointer<Uint32> psfgaoAttribs)>()(
               ptr.ref.lpVtbl, AttribFlags, sfgaoMask, psfgaoAttribs);
 
-  int GetCount(Pointer<Uint32> pdwNumItems) => ptr.ref.lpVtbl.value
+  int GetCount(Pointer<Uint32> pdwNumItems) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -114,8 +114,7 @@ class IShellItemArray extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint32> pdwNumItems)>()(
       ptr.ref.lpVtbl, pdwNumItems);
 
-  int GetItemAt(int dwIndex, Pointer<Pointer<COMObject>> ppsi) => ptr
-          .ref.lpVtbl.value
+  int GetItemAt(int dwIndex, Pointer<Pointer<COMObject>> ppsi) => ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -128,17 +127,16 @@ class IShellItemArray extends IUnknown {
                   Pointer, int dwIndex, Pointer<Pointer<COMObject>> ppsi)>()(
       ptr.ref.lpVtbl, dwIndex, ppsi);
 
-  int EnumItems(Pointer<Pointer<COMObject>> ppenumShellItems) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(9)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer,
-                              Pointer<Pointer<COMObject>> ppenumShellItems)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, Pointer<Pointer<COMObject>> ppenumShellItems)>()(
-          ptr.ref.lpVtbl, ppenumShellItems);
+  int EnumItems(Pointer<Pointer<COMObject>> ppenumShellItems) => ptr.ref.vtable
+          .elementAt(9)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer,
+                          Pointer<Pointer<COMObject>> ppenumShellItems)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, Pointer<Pointer<COMObject>> ppenumShellItems)>()(
+      ptr.ref.lpVtbl, ppenumShellItems);
 }

--- a/lib/src/com/ishellitemfilter.dart
+++ b/lib/src/com/ishellitemfilter.dart
@@ -32,7 +32,7 @@ class IShellItemFilter extends IUnknown {
   // vtable begins at 3, is 2 entries long.
   IShellItemFilter(super.ptr);
 
-  int IncludeItem(Pointer<COMObject> psi) => ptr.ref.lpVtbl.value
+  int IncludeItem(Pointer<COMObject> psi) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -43,7 +43,7 @@ class IShellItemFilter extends IUnknown {
       ptr.ref.lpVtbl, psi);
 
   int GetEnumFlagsForItem(Pointer<COMObject> psi, Pointer<Uint32> pgrfFlags) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<

--- a/lib/src/com/ishellitemimagefactory.dart
+++ b/lib/src/com/ishellitemimagefactory.dart
@@ -32,16 +32,15 @@ class IShellItemImageFactory extends IUnknown {
   // vtable begins at 3, is 1 entries long.
   IShellItemImageFactory(super.ptr);
 
-  int GetImage(SIZE size, int flags, Pointer<IntPtr> phbm) =>
-      ptr.ref.lpVtbl.value
-          .elementAt(3)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      Int32 Function(Pointer, SIZE size, Int32 flags,
-                          Pointer<IntPtr> phbm)>>>()
-          .value
-          .asFunction<
-              int Function(Pointer, SIZE size, int flags,
-                  Pointer<IntPtr> phbm)>()(ptr.ref.lpVtbl, size, flags, phbm);
+  int GetImage(SIZE size, int flags, Pointer<IntPtr> phbm) => ptr.ref.vtable
+      .elementAt(3)
+      .cast<
+          Pointer<
+              NativeFunction<
+                  Int32 Function(Pointer, SIZE size, Int32 flags,
+                      Pointer<IntPtr> phbm)>>>()
+      .value
+      .asFunction<
+          int Function(Pointer, SIZE size, int flags,
+              Pointer<IntPtr> phbm)>()(ptr.ref.lpVtbl, size, flags, phbm);
 }

--- a/lib/src/com/ishellitemresources.dart
+++ b/lib/src/com/ishellitemresources.dart
@@ -32,7 +32,7 @@ class IShellItemResources extends IUnknown {
   // vtable begins at 3, is 10 entries long.
   IShellItemResources(super.ptr);
 
-  int GetAttributes(Pointer<Uint32> pdwAttributes) => ptr.ref.lpVtbl.value
+  int GetAttributes(Pointer<Uint32> pdwAttributes) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -43,7 +43,7 @@ class IShellItemResources extends IUnknown {
           int Function(Pointer,
               Pointer<Uint32> pdwAttributes)>()(ptr.ref.lpVtbl, pdwAttributes);
 
-  int GetSize(Pointer<Uint64> pullSize) => ptr.ref.lpVtbl.value
+  int GetSize(Pointer<Uint64> pullSize) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -55,7 +55,7 @@ class IShellItemResources extends IUnknown {
 
   int GetTimes(Pointer<FILETIME> pftCreation, Pointer<FILETIME> pftWrite,
           Pointer<FILETIME> pftAccess) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -76,7 +76,7 @@ class IShellItemResources extends IUnknown {
 
   int SetTimes(Pointer<FILETIME> pftCreation, Pointer<FILETIME> pftWrite,
           Pointer<FILETIME> pftAccess) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<
@@ -97,7 +97,7 @@ class IShellItemResources extends IUnknown {
 
   int GetResourceDescription(Pointer<SHELL_ITEM_RESOURCE> pcsir,
           Pointer<Pointer<Utf16>> ppszDescription) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -112,7 +112,7 @@ class IShellItemResources extends IUnknown {
                       Pointer<Pointer<Utf16>> ppszDescription)>()(
           ptr.ref.lpVtbl, pcsir, ppszDescription);
 
-  int EnumResources(Pointer<Pointer<COMObject>> ppenumr) => ptr.ref.lpVtbl.value
+  int EnumResources(Pointer<Pointer<COMObject>> ppenumr) => ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -124,22 +124,21 @@ class IShellItemResources extends IUnknown {
               int Function(Pointer, Pointer<Pointer<COMObject>> ppenumr)>()(
       ptr.ref.lpVtbl, ppenumr);
 
-  int SupportsResource(Pointer<SHELL_ITEM_RESOURCE> pcsir) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(9)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(
-                              Pointer, Pointer<SHELL_ITEM_RESOURCE> pcsir)>>>()
-              .value
-              .asFunction<
-                  int Function(Pointer, Pointer<SHELL_ITEM_RESOURCE> pcsir)>()(
-          ptr.ref.lpVtbl, pcsir);
+  int SupportsResource(Pointer<SHELL_ITEM_RESOURCE> pcsir) => ptr.ref.vtable
+          .elementAt(9)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(
+                          Pointer, Pointer<SHELL_ITEM_RESOURCE> pcsir)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<SHELL_ITEM_RESOURCE> pcsir)>()(
+      ptr.ref.lpVtbl, pcsir);
 
   int OpenResource(Pointer<SHELL_ITEM_RESOURCE> pcsir, Pointer<GUID> riid,
           Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -159,7 +158,7 @@ class IShellItemResources extends IUnknown {
 
   int CreateResource(Pointer<SHELL_ITEM_RESOURCE> pcsir, Pointer<GUID> riid,
           Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -177,7 +176,7 @@ class IShellItemResources extends IUnknown {
                   Pointer<GUID> riid,
                   Pointer<Pointer> ppv)>()(ptr.ref.lpVtbl, pcsir, riid, ppv);
 
-  int MarkForDelete() => ptr.ref.lpVtbl.value
+  int MarkForDelete() => ptr.ref.vtable
       .elementAt(12)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value

--- a/lib/src/com/ishelllink.dart
+++ b/lib/src/com/ishelllink.dart
@@ -34,7 +34,7 @@ class IShellLink extends IUnknown {
 
   int GetPath(Pointer<Utf16> pszFile, int cch, Pointer<WIN32_FIND_DATA> pfd,
           int fFlags) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -50,7 +50,7 @@ class IShellLink extends IUnknown {
                   Pointer<WIN32_FIND_DATA> pfd,
                   int fFlags)>()(ptr.ref.lpVtbl, pszFile, cch, pfd, fFlags);
 
-  int GetIDList(Pointer<Pointer<ITEMIDLIST>> ppidl) => ptr.ref.lpVtbl.value
+  int GetIDList(Pointer<Pointer<ITEMIDLIST>> ppidl) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -62,7 +62,7 @@ class IShellLink extends IUnknown {
               int Function(Pointer, Pointer<Pointer<ITEMIDLIST>> ppidl)>()(
       ptr.ref.lpVtbl, ppidl);
 
-  int SetIDList(Pointer<ITEMIDLIST> pidl) => ptr.ref.lpVtbl.value
+  int SetIDList(Pointer<ITEMIDLIST> pidl) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -72,7 +72,7 @@ class IShellLink extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<ITEMIDLIST> pidl)>()(
       ptr.ref.lpVtbl, pidl);
 
-  int GetDescription(Pointer<Utf16> pszName, int cch) => ptr.ref.lpVtbl.value
+  int GetDescription(Pointer<Utf16> pszName, int cch) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -83,7 +83,7 @@ class IShellLink extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Utf16> pszName, int cch)>()(
       ptr.ref.lpVtbl, pszName, cch);
 
-  int SetDescription(Pointer<Utf16> pszName) => ptr.ref.lpVtbl.value
+  int SetDescription(Pointer<Utf16> pszName) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -93,8 +93,7 @@ class IShellLink extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Utf16> pszName)>()(
       ptr.ref.lpVtbl, pszName);
 
-  int GetWorkingDirectory(Pointer<Utf16> pszDir, int cch) => ptr
-      .ref.lpVtbl.value
+  int GetWorkingDirectory(Pointer<Utf16> pszDir, int cch) => ptr.ref.vtable
       .elementAt(8)
       .cast<
           Pointer<
@@ -105,7 +104,7 @@ class IShellLink extends IUnknown {
           int Function(Pointer, Pointer<Utf16> pszDir,
               int cch)>()(ptr.ref.lpVtbl, pszDir, cch);
 
-  int SetWorkingDirectory(Pointer<Utf16> pszDir) => ptr.ref.lpVtbl.value
+  int SetWorkingDirectory(Pointer<Utf16> pszDir) => ptr.ref.vtable
       .elementAt(9)
       .cast<
           Pointer<
@@ -115,7 +114,7 @@ class IShellLink extends IUnknown {
           int Function(
               Pointer, Pointer<Utf16> pszDir)>()(ptr.ref.lpVtbl, pszDir);
 
-  int GetArguments(Pointer<Utf16> pszArgs, int cch) => ptr.ref.lpVtbl.value
+  int GetArguments(Pointer<Utf16> pszArgs, int cch) => ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -126,7 +125,7 @@ class IShellLink extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Utf16> pszArgs, int cch)>()(
       ptr.ref.lpVtbl, pszArgs, cch);
 
-  int SetArguments(Pointer<Utf16> pszArgs) => ptr.ref.lpVtbl.value
+  int SetArguments(Pointer<Utf16> pszArgs) => ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -136,7 +135,7 @@ class IShellLink extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Utf16> pszArgs)>()(
       ptr.ref.lpVtbl, pszArgs);
 
-  int GetHotkey(Pointer<Uint16> pwHotkey) => ptr.ref.lpVtbl.value
+  int GetHotkey(Pointer<Uint16> pwHotkey) => ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -146,14 +145,14 @@ class IShellLink extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint16> pwHotkey)>()(
       ptr.ref.lpVtbl, pwHotkey);
 
-  int SetHotkey(int wHotkey) => ptr.ref.lpVtbl.value
+  int SetHotkey(int wHotkey) => ptr.ref.vtable
       .elementAt(13)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint16 wHotkey)>>>()
       .value
       .asFunction<
           int Function(Pointer, int wHotkey)>()(ptr.ref.lpVtbl, wHotkey);
 
-  int GetShowCmd(Pointer<Int32> piShowCmd) => ptr.ref.lpVtbl.value
+  int GetShowCmd(Pointer<Int32> piShowCmd) => ptr.ref.vtable
           .elementAt(14)
           .cast<
               Pointer<
@@ -163,7 +162,7 @@ class IShellLink extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Int32> piShowCmd)>()(
       ptr.ref.lpVtbl, piShowCmd);
 
-  int SetShowCmd(int iShowCmd) => ptr.ref.lpVtbl.value
+  int SetShowCmd(int iShowCmd) => ptr.ref.vtable
       .elementAt(15)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 iShowCmd)>>>()
       .value
@@ -173,7 +172,7 @@ class IShellLink extends IUnknown {
   int GetIconLocation(
           Pointer<Utf16> pszIconPath, int cch, Pointer<Int32> piIcon) =>
       ptr
-              .ref.lpVtbl.value
+              .ref.vtable
               .elementAt(16)
               .cast<
                   Pointer<
@@ -186,8 +185,7 @@ class IShellLink extends IUnknown {
                       Pointer<Int32> piIcon)>()(
           ptr.ref.lpVtbl, pszIconPath, cch, piIcon);
 
-  int SetIconLocation(Pointer<Utf16> pszIconPath, int iIcon) => ptr
-          .ref.lpVtbl.value
+  int SetIconLocation(Pointer<Utf16> pszIconPath, int iIcon) => ptr.ref.vtable
           .elementAt(17)
           .cast<
               Pointer<
@@ -199,20 +197,20 @@ class IShellLink extends IUnknown {
               int Function(Pointer, Pointer<Utf16> pszIconPath, int iIcon)>()(
       ptr.ref.lpVtbl, pszIconPath, iIcon);
 
-  int SetRelativePath(Pointer<Utf16> pszPathRel, int dwReserved) => ptr
-      .ref.lpVtbl.value
-      .elementAt(18)
-      .cast<
-          Pointer<
-              NativeFunction<
-                  Int32 Function(Pointer, Pointer<Utf16> pszPathRel,
-                      Uint32 dwReserved)>>>()
-      .value
-      .asFunction<
-          int Function(Pointer, Pointer<Utf16> pszPathRel,
-              int dwReserved)>()(ptr.ref.lpVtbl, pszPathRel, dwReserved);
+  int SetRelativePath(Pointer<Utf16> pszPathRel, int dwReserved) =>
+      ptr.ref.vtable
+          .elementAt(18)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, Pointer<Utf16> pszPathRel,
+                          Uint32 dwReserved)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Utf16> pszPathRel,
+                  int dwReserved)>()(ptr.ref.lpVtbl, pszPathRel, dwReserved);
 
-  int Resolve(int hwnd, int fFlags) => ptr.ref.lpVtbl.value
+  int Resolve(int hwnd, int fFlags) => ptr.ref.vtable
           .elementAt(19)
           .cast<
               Pointer<
@@ -222,7 +220,7 @@ class IShellLink extends IUnknown {
           .asFunction<int Function(Pointer, int hwnd, int fFlags)>()(
       ptr.ref.lpVtbl, hwnd, fFlags);
 
-  int SetPath(Pointer<Utf16> pszFile) => ptr.ref.lpVtbl.value
+  int SetPath(Pointer<Utf16> pszFile) => ptr.ref.vtable
           .elementAt(20)
           .cast<
               Pointer<

--- a/lib/src/com/ishelllinkdatalist.dart
+++ b/lib/src/com/ishelllinkdatalist.dart
@@ -32,7 +32,7 @@ class IShellLinkDataList extends IUnknown {
   // vtable begins at 3, is 5 entries long.
   IShellLinkDataList(super.ptr);
 
-  int AddDataBlock(Pointer pDataBlock) => ptr.ref.lpVtbl.value
+  int AddDataBlock(Pointer pDataBlock) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -42,8 +42,7 @@ class IShellLinkDataList extends IUnknown {
           int Function(
               Pointer, Pointer pDataBlock)>()(ptr.ref.lpVtbl, pDataBlock);
 
-  int CopyDataBlock(int dwSig, Pointer<Pointer> ppDataBlock) => ptr
-          .ref.lpVtbl.value
+  int CopyDataBlock(int dwSig, Pointer<Pointer> ppDataBlock) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -55,13 +54,13 @@ class IShellLinkDataList extends IUnknown {
               int Function(Pointer, int dwSig, Pointer<Pointer> ppDataBlock)>()(
       ptr.ref.lpVtbl, dwSig, ppDataBlock);
 
-  int RemoveDataBlock(int dwSig) => ptr.ref.lpVtbl.value
+  int RemoveDataBlock(int dwSig) => ptr.ref.vtable
       .elementAt(5)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwSig)>>>()
       .value
       .asFunction<int Function(Pointer, int dwSig)>()(ptr.ref.lpVtbl, dwSig);
 
-  int GetFlags(Pointer<Uint32> pdwFlags) => ptr.ref.lpVtbl.value
+  int GetFlags(Pointer<Uint32> pdwFlags) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -71,7 +70,7 @@ class IShellLinkDataList extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint32> pdwFlags)>()(
       ptr.ref.lpVtbl, pdwFlags);
 
-  int SetFlags(int dwFlags) => ptr.ref.lpVtbl.value
+  int SetFlags(int dwFlags) => ptr.ref.vtable
       .elementAt(7)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint32 dwFlags)>>>()
       .value

--- a/lib/src/com/ishelllinkdual.dart
+++ b/lib/src/com/ishelllinkdual.dart
@@ -36,7 +36,7 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -57,7 +57,7 @@ class IShellLinkDual extends IDispatch {
   }
 
   set Path(Pointer<Utf16> value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(8)
         .cast<
             Pointer<
@@ -73,7 +73,7 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
@@ -94,7 +94,7 @@ class IShellLinkDual extends IDispatch {
   }
 
   set Description(Pointer<Utf16> value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(10)
         .cast<
             Pointer<
@@ -110,7 +110,7 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -131,7 +131,7 @@ class IShellLinkDual extends IDispatch {
   }
 
   set WorkingDirectory(Pointer<Utf16> value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(12)
         .cast<
             Pointer<
@@ -147,7 +147,7 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(13)
           .cast<
               Pointer<
@@ -168,7 +168,7 @@ class IShellLinkDual extends IDispatch {
   }
 
   set Arguments(Pointer<Utf16> value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(14)
         .cast<
             Pointer<
@@ -184,7 +184,7 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(15)
               .cast<
                   Pointer<
@@ -204,7 +204,7 @@ class IShellLinkDual extends IDispatch {
   }
 
   set Hotkey(int value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(16)
         .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 iHK)>>>()
         .value
@@ -217,7 +217,7 @@ class IShellLinkDual extends IDispatch {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(17)
           .cast<
               Pointer<
@@ -238,7 +238,7 @@ class IShellLinkDual extends IDispatch {
   }
 
   set ShowCommand(int value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(18)
         .cast<
             Pointer<
@@ -250,14 +250,14 @@ class IShellLinkDual extends IDispatch {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  int Resolve(int fFlags) => ptr.ref.lpVtbl.value
+  int Resolve(int fFlags) => ptr.ref.vtable
       .elementAt(19)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 fFlags)>>>()
       .value
       .asFunction<int Function(Pointer, int fFlags)>()(ptr.ref.lpVtbl, fFlags);
 
   int GetIconLocation(Pointer<Pointer<Utf16>> pbs, Pointer<Int32> piIcon) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(20)
           .cast<
               Pointer<
@@ -269,7 +269,7 @@ class IShellLinkDual extends IDispatch {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbs,
                   Pointer<Int32> piIcon)>()(ptr.ref.lpVtbl, pbs, piIcon);
 
-  int SetIconLocation(Pointer<Utf16> bs, int iIcon) => ptr.ref.lpVtbl.value
+  int SetIconLocation(Pointer<Utf16> bs, int iIcon) => ptr.ref.vtable
       .elementAt(21)
       .cast<
           Pointer<
@@ -280,7 +280,7 @@ class IShellLinkDual extends IDispatch {
           int Function(Pointer, Pointer<Utf16> bs,
               int iIcon)>()(ptr.ref.lpVtbl, bs, iIcon);
 
-  int Save(VARIANT vWhere) => ptr.ref.lpVtbl.value
+  int Save(VARIANT vWhere) => ptr.ref.vtable
       .elementAt(22)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, VARIANT vWhere)>>>()
       .value

--- a/lib/src/com/ishellservice.dart
+++ b/lib/src/com/ishellservice.dart
@@ -32,7 +32,7 @@ class IShellService extends IUnknown {
   // vtable begins at 3, is 1 entries long.
   IShellService(super.ptr);
 
-  int SetOwner(Pointer<COMObject> punkOwner) => ptr.ref.lpVtbl.value
+  int SetOwner(Pointer<COMObject> punkOwner) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<

--- a/lib/src/com/isimpleaudiovolume.dart
+++ b/lib/src/com/isimpleaudiovolume.dart
@@ -32,21 +32,21 @@ class ISimpleAudioVolume extends IUnknown {
   // vtable begins at 3, is 4 entries long.
   ISimpleAudioVolume(super.ptr);
 
-  int SetMasterVolume(double fLevel, Pointer<GUID> EventContext) => ptr
-          .ref.lpVtbl.value
-          .elementAt(3)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      Int32 Function(Pointer, Float fLevel,
-                          Pointer<GUID> EventContext)>>>()
-          .value
-          .asFunction<
-              int Function(
-                  Pointer, double fLevel, Pointer<GUID> EventContext)>()(
-      ptr.ref.lpVtbl, fLevel, EventContext);
+  int SetMasterVolume(double fLevel, Pointer<GUID> EventContext) =>
+      ptr.ref.vtable
+              .elementAt(3)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          Int32 Function(Pointer, Float fLevel,
+                              Pointer<GUID> EventContext)>>>()
+              .value
+              .asFunction<
+                  int Function(
+                      Pointer, double fLevel, Pointer<GUID> EventContext)>()(
+          ptr.ref.lpVtbl, fLevel, EventContext);
 
-  int GetMasterVolume(Pointer<Float> pfLevel) => ptr.ref.lpVtbl.value
+  int GetMasterVolume(Pointer<Float> pfLevel) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -56,7 +56,7 @@ class ISimpleAudioVolume extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Float> pfLevel)>()(
       ptr.ref.lpVtbl, pfLevel);
 
-  int SetMute(int bMute, Pointer<GUID> EventContext) => ptr.ref.lpVtbl.value
+  int SetMute(int bMute, Pointer<GUID> EventContext) => ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -68,7 +68,7 @@ class ISimpleAudioVolume extends IUnknown {
               int Function(Pointer, int bMute, Pointer<GUID> EventContext)>()(
       ptr.ref.lpVtbl, bMute, EventContext);
 
-  int GetMute(Pointer<Int32> pbMute) => ptr.ref.lpVtbl.value
+  int GetMute(Pointer<Int32> pbMute) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<

--- a/lib/src/com/ispeechobjecttoken.dart
+++ b/lib/src/com/ispeechobjecttoken.dart
@@ -36,7 +36,7 @@ class ISpeechObjectToken extends IDispatch {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -61,7 +61,7 @@ class ISpeechObjectToken extends IDispatch {
     final retValuePtr = calloc<Pointer<COMObject>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -86,7 +86,7 @@ class ISpeechObjectToken extends IDispatch {
     final retValuePtr = calloc<Pointer<COMObject>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -109,7 +109,7 @@ class ISpeechObjectToken extends IDispatch {
   }
 
   int GetDescription(int Locale, Pointer<Pointer<Utf16>> Description) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -124,7 +124,7 @@ class ISpeechObjectToken extends IDispatch {
 
   int SetId(
           Pointer<Utf16> Id, Pointer<Utf16> CategoryID, int CreateIfNotExist) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -142,7 +142,7 @@ class ISpeechObjectToken extends IDispatch {
 
   int GetAttribute(Pointer<Utf16> AttributeName,
           Pointer<Pointer<Utf16>> AttributeValue) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(12)
               .cast<
                   Pointer<
@@ -157,7 +157,7 @@ class ISpeechObjectToken extends IDispatch {
 
   int CreateInstance(Pointer<COMObject> pUnkOuter, int ClsContext,
           Pointer<Pointer<COMObject>> Object) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(13)
               .cast<
                   Pointer<
@@ -173,7 +173,7 @@ class ISpeechObjectToken extends IDispatch {
                       int ClsContext, Pointer<Pointer<COMObject>> Object)>()(
           ptr.ref.lpVtbl, pUnkOuter, ClsContext, Object);
 
-  int Remove(Pointer<Utf16> ObjectStorageCLSID) => ptr.ref.lpVtbl.value
+  int Remove(Pointer<Utf16> ObjectStorageCLSID) => ptr.ref.vtable
           .elementAt(14)
           .cast<
               Pointer<
@@ -191,7 +191,7 @@ class ISpeechObjectToken extends IDispatch {
           Pointer<Utf16> FileName,
           int Folder,
           Pointer<Pointer<Utf16>> FilePath) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(15)
               .cast<
                   Pointer<
@@ -217,7 +217,7 @@ class ISpeechObjectToken extends IDispatch {
   int
       RemoveStorageFileName(Pointer<Utf16> ObjectStorageCLSID,
               Pointer<Utf16> KeyName, int DeleteFileA) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(16)
                   .cast<
                       Pointer<
@@ -235,7 +235,7 @@ class ISpeechObjectToken extends IDispatch {
 
   int IsUISupported(Pointer<Utf16> TypeOfUI, Pointer<VARIANT> ExtraData,
           Pointer<COMObject> Object, Pointer<Int16> Supported) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(17)
               .cast<
                   Pointer<
@@ -258,7 +258,7 @@ class ISpeechObjectToken extends IDispatch {
 
   int DisplayUI(int hWnd, Pointer<Utf16> Title, Pointer<Utf16> TypeOfUI,
           Pointer<VARIANT> ExtraData, Pointer<COMObject> Object) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(18)
               .cast<
                   Pointer<
@@ -282,7 +282,7 @@ class ISpeechObjectToken extends IDispatch {
           ptr.ref.lpVtbl, hWnd, Title, TypeOfUI, ExtraData, Object);
 
   int MatchesAttributes(Pointer<Utf16> Attributes, Pointer<Int16> Matches) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(19)
               .cast<
                   Pointer<

--- a/lib/src/com/ispeechobjecttokens.dart
+++ b/lib/src/com/ispeechobjecttokens.dart
@@ -36,7 +36,7 @@ class ISpeechObjectTokens extends IDispatch {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -55,7 +55,7 @@ class ISpeechObjectTokens extends IDispatch {
     }
   }
 
-  int Item(int Index, Pointer<Pointer<COMObject>> Token) => ptr.ref.lpVtbl.value
+  int Item(int Index, Pointer<Pointer<COMObject>> Token) => ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -72,7 +72,7 @@ class ISpeechObjectTokens extends IDispatch {
     final retValuePtr = calloc<Pointer<COMObject>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<

--- a/lib/src/com/ispellchecker.dart
+++ b/lib/src/com/ispellchecker.dart
@@ -36,7 +36,7 @@ class ISpellChecker extends IUnknown {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -58,7 +58,7 @@ class ISpellChecker extends IUnknown {
   }
 
   int Check(Pointer<Utf16> text, Pointer<Pointer<COMObject>> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -72,7 +72,7 @@ class ISpellChecker extends IUnknown {
           ptr.ref.lpVtbl, text, value);
 
   int Suggest(Pointer<Utf16> word, Pointer<Pointer<COMObject>> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -85,7 +85,7 @@ class ISpellChecker extends IUnknown {
                       Pointer<Pointer<COMObject>> value)>()(
           ptr.ref.lpVtbl, word, value);
 
-  int Add(Pointer<Utf16> word) => ptr.ref.lpVtbl.value
+  int Add(Pointer<Utf16> word) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<
@@ -94,7 +94,7 @@ class ISpellChecker extends IUnknown {
       .asFunction<
           int Function(Pointer, Pointer<Utf16> word)>()(ptr.ref.lpVtbl, word);
 
-  int Ignore(Pointer<Utf16> word) => ptr.ref.lpVtbl.value
+  int Ignore(Pointer<Utf16> word) => ptr.ref.vtable
       .elementAt(7)
       .cast<
           Pointer<
@@ -103,8 +103,7 @@ class ISpellChecker extends IUnknown {
       .asFunction<
           int Function(Pointer, Pointer<Utf16> word)>()(ptr.ref.lpVtbl, word);
 
-  int AutoCorrect(Pointer<Utf16> from, Pointer<Utf16> to) =>
-      ptr.ref.lpVtbl.value
+  int AutoCorrect(Pointer<Utf16> from, Pointer<Utf16> to) => ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -113,11 +112,11 @@ class ISpellChecker extends IUnknown {
                           Pointer, Pointer<Utf16> from, Pointer<Utf16> to)>>>()
           .value
           .asFunction<
-              int Function(Pointer, Pointer<Utf16> from,
-                  Pointer<Utf16> to)>()(ptr.ref.lpVtbl, from, to);
+              int Function(Pointer, Pointer<Utf16> from, Pointer<Utf16> to)>()(
+      ptr.ref.lpVtbl, from, to);
 
   int GetOptionValue(Pointer<Utf16> optionId, Pointer<Uint8> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
@@ -133,7 +132,7 @@ class ISpellChecker extends IUnknown {
     final retValuePtr = calloc<Pointer<COMObject>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<
@@ -158,7 +157,7 @@ class ISpellChecker extends IUnknown {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -183,7 +182,7 @@ class ISpellChecker extends IUnknown {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(12)
               .cast<
                   Pointer<
@@ -206,7 +205,7 @@ class ISpellChecker extends IUnknown {
 
   int add_SpellCheckerChanged(
           Pointer<COMObject> handler, Pointer<Uint32> eventCookie) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(13)
               .cast<
                   Pointer<
@@ -219,7 +218,7 @@ class ISpellChecker extends IUnknown {
                       Pointer<Uint32> eventCookie)>()(
           ptr.ref.lpVtbl, handler, eventCookie);
 
-  int remove_SpellCheckerChanged(int eventCookie) => ptr.ref.lpVtbl.value
+  int remove_SpellCheckerChanged(int eventCookie) => ptr.ref.vtable
       .elementAt(14)
       .cast<
           Pointer<
@@ -231,7 +230,7 @@ class ISpellChecker extends IUnknown {
 
   int GetOptionDescription(
           Pointer<Utf16> optionId, Pointer<Pointer<COMObject>> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(15)
               .cast<
                   Pointer<
@@ -246,7 +245,7 @@ class ISpellChecker extends IUnknown {
 
   int ComprehensiveCheck(
           Pointer<Utf16> text, Pointer<Pointer<COMObject>> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(16)
               .cast<
                   Pointer<

--- a/lib/src/com/ispellchecker2.dart
+++ b/lib/src/com/ispellchecker2.dart
@@ -32,7 +32,7 @@ class ISpellChecker2 extends ISpellChecker {
   // vtable begins at 17, is 1 entries long.
   ISpellChecker2(super.ptr);
 
-  int Remove(Pointer<Utf16> word) => ptr.ref.lpVtbl.value
+  int Remove(Pointer<Utf16> word) => ptr.ref.vtable
       .elementAt(17)
       .cast<
           Pointer<

--- a/lib/src/com/ispellcheckerchangedeventhandler.dart
+++ b/lib/src/com/ispellcheckerchangedeventhandler.dart
@@ -33,7 +33,7 @@ class ISpellCheckerChangedEventHandler extends IUnknown {
   // vtable begins at 3, is 1 entries long.
   ISpellCheckerChangedEventHandler(super.ptr);
 
-  int Invoke(Pointer<COMObject> sender) => ptr.ref.lpVtbl.value
+  int Invoke(Pointer<COMObject> sender) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<

--- a/lib/src/com/ispellcheckerfactory.dart
+++ b/lib/src/com/ispellcheckerfactory.dart
@@ -36,7 +36,7 @@ class ISpellCheckerFactory extends IUnknown {
     final retValuePtr = calloc<Pointer<COMObject>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -58,7 +58,7 @@ class ISpellCheckerFactory extends IUnknown {
   }
 
   int IsSupported(Pointer<Utf16> languageTag, Pointer<Int32> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -72,7 +72,7 @@ class ISpellCheckerFactory extends IUnknown {
 
   int CreateSpellChecker(
           Pointer<Utf16> languageTag, Pointer<Pointer<COMObject>> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<

--- a/lib/src/com/ispellingerror.dart
+++ b/lib/src/com/ispellingerror.dart
@@ -36,7 +36,7 @@ class ISpellingError extends IUnknown {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -59,7 +59,7 @@ class ISpellingError extends IUnknown {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -82,7 +82,7 @@ class ISpellingError extends IUnknown {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -105,7 +105,7 @@ class ISpellingError extends IUnknown {
     final retValuePtr = calloc<Pointer<Utf16>>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<

--- a/lib/src/com/ispeventsource.dart
+++ b/lib/src/com/ispeventsource.dart
@@ -32,23 +32,22 @@ class ISpEventSource extends ISpNotifySource {
   // vtable begins at 10, is 3 entries long.
   ISpEventSource(super.ptr);
 
-  int SetInterest(int ullEventInterest, int ullQueuedInterest) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(10)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer, Uint64 ullEventInterest,
-                              Uint64 ullQueuedInterest)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, int ullEventInterest, int ullQueuedInterest)>()(
-          ptr.ref.lpVtbl, ullEventInterest, ullQueuedInterest);
+  int SetInterest(int ullEventInterest, int ullQueuedInterest) => ptr.ref.vtable
+          .elementAt(10)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, Uint64 ullEventInterest,
+                          Uint64 ullQueuedInterest)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, int ullEventInterest, int ullQueuedInterest)>()(
+      ptr.ref.lpVtbl, ullEventInterest, ullQueuedInterest);
 
   int GetEvents(int ulCount, Pointer<SPEVENT> pEventArray,
           Pointer<Uint32> pulFetched) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -67,7 +66,7 @@ class ISpEventSource extends ISpNotifySource {
                       Pointer<Uint32> pulFetched)>()(
           ptr.ref.lpVtbl, ulCount, pEventArray, pulFetched);
 
-  int GetInfo(Pointer<SPEVENTSOURCEINFO> pInfo) => ptr.ref.lpVtbl.value
+  int GetInfo(Pointer<SPEVENTSOURCEINFO> pInfo) => ptr.ref.vtable
       .elementAt(12)
       .cast<
           Pointer<

--- a/lib/src/com/ispnotifysource.dart
+++ b/lib/src/com/ispnotifysource.dart
@@ -32,7 +32,7 @@ class ISpNotifySource extends IUnknown {
   // vtable begins at 3, is 7 entries long.
   ISpNotifySource(super.ptr);
 
-  int SetNotifySink(Pointer<COMObject> pNotifySink) => ptr.ref.lpVtbl.value
+  int SetNotifySink(Pointer<COMObject> pNotifySink) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<
@@ -44,7 +44,7 @@ class ISpNotifySource extends IUnknown {
               Pointer<COMObject> pNotifySink)>()(ptr.ref.lpVtbl, pNotifySink);
 
   int SetNotifyWindowMessage(int hWnd, int Msg, int wParam, int lParam) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -60,7 +60,7 @@ class ISpNotifySource extends IUnknown {
           Pointer<Pointer<NativeFunction<SpNotifyCallback>>> pfnCallback,
           int wParam,
           int lParam) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -82,7 +82,7 @@ class ISpNotifySource extends IUnknown {
 
   int SetNotifyCallbackInterface(
           Pointer<COMObject> pSpCallback, int wParam, int lParam) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -94,13 +94,13 @@ class ISpNotifySource extends IUnknown {
               int Function(Pointer, Pointer<COMObject> pSpCallback, int wParam,
                   int lParam)>()(ptr.ref.lpVtbl, pSpCallback, wParam, lParam);
 
-  int SetNotifyWin32Event() => ptr.ref.lpVtbl.value
+  int SetNotifyWin32Event() => ptr.ref.vtable
       .elementAt(7)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int WaitForNotifyEvent(int dwMilliseconds) => ptr.ref.lpVtbl.value
+  int WaitForNotifyEvent(int dwMilliseconds) => ptr.ref.vtable
       .elementAt(8)
       .cast<
           Pointer<
@@ -110,7 +110,7 @@ class ISpNotifySource extends IUnknown {
           int Function(
               Pointer, int dwMilliseconds)>()(ptr.ref.lpVtbl, dwMilliseconds);
 
-  int GetNotifyEventHandle() => ptr.ref.lpVtbl.value
+  int GetNotifyEventHandle() => ptr.ref.vtable
       .elementAt(9)
       .cast<Pointer<NativeFunction<IntPtr Function(Pointer)>>>()
       .value

--- a/lib/src/com/ispvoice.dart
+++ b/lib/src/com/ispvoice.dart
@@ -33,7 +33,7 @@ class ISpVoice extends ISpEventSource {
   ISpVoice(super.ptr);
 
   int SetOutput(Pointer<COMObject> pUnkOutput, int fAllowFormatChanges) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(13)
               .cast<
                   Pointer<
@@ -47,7 +47,7 @@ class ISpVoice extends ISpEventSource {
           ptr.ref.lpVtbl, pUnkOutput, fAllowFormatChanges);
 
   int GetOutputObjectToken(Pointer<Pointer<COMObject>> ppObjectToken) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(14)
               .cast<
                   Pointer<
@@ -60,8 +60,7 @@ class ISpVoice extends ISpEventSource {
                       Pointer, Pointer<Pointer<COMObject>> ppObjectToken)>()(
           ptr.ref.lpVtbl, ppObjectToken);
 
-  int GetOutputStream(Pointer<Pointer<COMObject>> ppStream) => ptr
-          .ref.lpVtbl.value
+  int GetOutputStream(Pointer<Pointer<COMObject>> ppStream) => ptr.ref.vtable
           .elementAt(15)
           .cast<
               Pointer<
@@ -73,19 +72,19 @@ class ISpVoice extends ISpEventSource {
               int Function(Pointer, Pointer<Pointer<COMObject>> ppStream)>()(
       ptr.ref.lpVtbl, ppStream);
 
-  int Pause() => ptr.ref.lpVtbl.value
+  int Pause() => ptr.ref.vtable
       .elementAt(16)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int Resume() => ptr.ref.lpVtbl.value
+  int Resume() => ptr.ref.vtable
       .elementAt(17)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int SetVoice(Pointer<COMObject> pToken) => ptr.ref.lpVtbl.value
+  int SetVoice(Pointer<COMObject> pToken) => ptr.ref.vtable
           .elementAt(18)
           .cast<
               Pointer<
@@ -95,7 +94,7 @@ class ISpVoice extends ISpEventSource {
           .asFunction<int Function(Pointer, Pointer<COMObject> pToken)>()(
       ptr.ref.lpVtbl, pToken);
 
-  int GetVoice(Pointer<Pointer<COMObject>> ppToken) => ptr.ref.lpVtbl.value
+  int GetVoice(Pointer<Pointer<COMObject>> ppToken) => ptr.ref.vtable
           .elementAt(19)
           .cast<
               Pointer<
@@ -110,7 +109,7 @@ class ISpVoice extends ISpEventSource {
   int
       Speak(Pointer<Utf16> pwcs, int dwFlags,
               Pointer<Uint32> pulStreamNumber) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(20)
                   .cast<
                       Pointer<
@@ -129,7 +128,7 @@ class ISpVoice extends ISpEventSource {
   int
       SpeakStream(Pointer<COMObject> pStream, int dwFlags,
               Pointer<Uint32> pulStreamNumber) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(21)
                   .cast<
                       Pointer<
@@ -148,7 +147,7 @@ class ISpVoice extends ISpEventSource {
   int
       GetStatus(Pointer<SPVOICESTATUS> pStatus,
               Pointer<Pointer<Utf16>> ppszLastBookmark) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(22)
                   .cast<
                       Pointer<
@@ -166,7 +165,7 @@ class ISpVoice extends ISpEventSource {
   int
       Skip(Pointer<Utf16> pItemType, int lNumItems,
               Pointer<Uint32> pulNumSkipped) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(23)
                   .cast<
                       Pointer<
@@ -182,14 +181,14 @@ class ISpVoice extends ISpEventSource {
                           int lNumItems, Pointer<Uint32> pulNumSkipped)>()(
               ptr.ref.lpVtbl, pItemType, lNumItems, pulNumSkipped);
 
-  int SetPriority(int ePriority) => ptr.ref.lpVtbl.value
+  int SetPriority(int ePriority) => ptr.ref.vtable
       .elementAt(24)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 ePriority)>>>()
       .value
       .asFunction<
           int Function(Pointer, int ePriority)>()(ptr.ref.lpVtbl, ePriority);
 
-  int GetPriority(Pointer<Int32> pePriority) => ptr.ref.lpVtbl.value
+  int GetPriority(Pointer<Int32> pePriority) => ptr.ref.vtable
           .elementAt(25)
           .cast<
               Pointer<
@@ -199,14 +198,14 @@ class ISpVoice extends ISpEventSource {
           .asFunction<int Function(Pointer, Pointer<Int32> pePriority)>()(
       ptr.ref.lpVtbl, pePriority);
 
-  int SetAlertBoundary(int eBoundary) => ptr.ref.lpVtbl.value
+  int SetAlertBoundary(int eBoundary) => ptr.ref.vtable
       .elementAt(26)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 eBoundary)>>>()
       .value
       .asFunction<
           int Function(Pointer, int eBoundary)>()(ptr.ref.lpVtbl, eBoundary);
 
-  int GetAlertBoundary(Pointer<Int32> peBoundary) => ptr.ref.lpVtbl.value
+  int GetAlertBoundary(Pointer<Int32> peBoundary) => ptr.ref.vtable
           .elementAt(27)
           .cast<
               Pointer<
@@ -216,7 +215,7 @@ class ISpVoice extends ISpEventSource {
           .asFunction<int Function(Pointer, Pointer<Int32> peBoundary)>()(
       ptr.ref.lpVtbl, peBoundary);
 
-  int SetRate(int RateAdjust) => ptr.ref.lpVtbl.value
+  int SetRate(int RateAdjust) => ptr.ref.vtable
       .elementAt(28)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, Int32 RateAdjust)>>>()
@@ -224,7 +223,7 @@ class ISpVoice extends ISpEventSource {
       .asFunction<
           int Function(Pointer, int RateAdjust)>()(ptr.ref.lpVtbl, RateAdjust);
 
-  int GetRate(Pointer<Int32> pRateAdjust) => ptr.ref.lpVtbl.value
+  int GetRate(Pointer<Int32> pRateAdjust) => ptr.ref.vtable
           .elementAt(29)
           .cast<
               Pointer<
@@ -234,14 +233,14 @@ class ISpVoice extends ISpEventSource {
           .asFunction<int Function(Pointer, Pointer<Int32> pRateAdjust)>()(
       ptr.ref.lpVtbl, pRateAdjust);
 
-  int SetVolume(int usVolume) => ptr.ref.lpVtbl.value
+  int SetVolume(int usVolume) => ptr.ref.vtable
       .elementAt(30)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Uint16 usVolume)>>>()
       .value
       .asFunction<
           int Function(Pointer, int usVolume)>()(ptr.ref.lpVtbl, usVolume);
 
-  int GetVolume(Pointer<Uint16> pusVolume) => ptr.ref.lpVtbl.value
+  int GetVolume(Pointer<Uint16> pusVolume) => ptr.ref.vtable
           .elementAt(31)
           .cast<
               Pointer<
@@ -251,7 +250,7 @@ class ISpVoice extends ISpEventSource {
           .asFunction<int Function(Pointer, Pointer<Uint16> pusVolume)>()(
       ptr.ref.lpVtbl, pusVolume);
 
-  int WaitUntilDone(int msTimeout) => ptr.ref.lpVtbl.value
+  int WaitUntilDone(int msTimeout) => ptr.ref.vtable
       .elementAt(32)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, Uint32 msTimeout)>>>()
@@ -259,7 +258,7 @@ class ISpVoice extends ISpEventSource {
       .asFunction<
           int Function(Pointer, int msTimeout)>()(ptr.ref.lpVtbl, msTimeout);
 
-  int SetSyncSpeakTimeout(int msTimeout) => ptr.ref.lpVtbl.value
+  int SetSyncSpeakTimeout(int msTimeout) => ptr.ref.vtable
       .elementAt(33)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, Uint32 msTimeout)>>>()
@@ -267,7 +266,7 @@ class ISpVoice extends ISpEventSource {
       .asFunction<
           int Function(Pointer, int msTimeout)>()(ptr.ref.lpVtbl, msTimeout);
 
-  int GetSyncSpeakTimeout(Pointer<Uint32> pmsTimeout) => ptr.ref.lpVtbl.value
+  int GetSyncSpeakTimeout(Pointer<Uint32> pmsTimeout) => ptr.ref.vtable
           .elementAt(34)
           .cast<
               Pointer<
@@ -277,7 +276,7 @@ class ISpVoice extends ISpEventSource {
           .asFunction<int Function(Pointer, Pointer<Uint32> pmsTimeout)>()(
       ptr.ref.lpVtbl, pmsTimeout);
 
-  int SpeakCompleteEvent() => ptr.ref.lpVtbl.value
+  int SpeakCompleteEvent() => ptr.ref.vtable
       .elementAt(35)
       .cast<Pointer<NativeFunction<IntPtr Function(Pointer)>>>()
       .value
@@ -285,7 +284,7 @@ class ISpVoice extends ISpEventSource {
 
   int IsUISupported(Pointer<Utf16> pszTypeOfUI, Pointer pvExtraData,
           int cbExtraData, Pointer<Int32> pfSupported) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(36)
               .cast<
                   Pointer<
@@ -308,7 +307,7 @@ class ISpVoice extends ISpEventSource {
 
   int DisplayUI(int hwndParent, Pointer<Utf16> pszTitle,
           Pointer<Utf16> pszTypeOfUI, Pointer pvExtraData, int cbExtraData) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(37)
               .cast<
                   Pointer<

--- a/lib/src/com/istream.dart
+++ b/lib/src/com/istream.dart
@@ -33,7 +33,7 @@ class IStream extends ISequentialStream {
   IStream(super.ptr);
 
   int Seek(int dlibMove, int dwOrigin, Pointer<Uint64> plibNewPosition) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -46,7 +46,7 @@ class IStream extends ISequentialStream {
                   Pointer<Uint64> plibNewPosition)>()(
       ptr.ref.lpVtbl, dlibMove, dwOrigin, plibNewPosition);
 
-  int SetSize(int libNewSize) => ptr.ref.lpVtbl.value
+  int SetSize(int libNewSize) => ptr.ref.vtable
       .elementAt(6)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, Uint64 libNewSize)>>>()
@@ -56,7 +56,7 @@ class IStream extends ISequentialStream {
 
   int CopyTo(Pointer<COMObject> pstm, int cb, Pointer<Uint64> pcbRead,
           Pointer<Uint64> pcbWritten) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -73,7 +73,7 @@ class IStream extends ISequentialStream {
                       Pointer<Uint64> pcbRead, Pointer<Uint64> pcbWritten)>()(
           ptr.ref.lpVtbl, pstm, cb, pcbRead, pcbWritten);
 
-  int Commit(int grfCommitFlags) => ptr.ref.lpVtbl.value
+  int Commit(int grfCommitFlags) => ptr.ref.vtable
       .elementAt(8)
       .cast<
           Pointer<
@@ -83,13 +83,13 @@ class IStream extends ISequentialStream {
           int Function(
               Pointer, int grfCommitFlags)>()(ptr.ref.lpVtbl, grfCommitFlags);
 
-  int Revert() => ptr.ref.lpVtbl.value
+  int Revert() => ptr.ref.vtable
       .elementAt(9)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
-  int LockRegion(int libOffset, int cb, int dwLockType) => ptr.ref.lpVtbl.value
+  int LockRegion(int libOffset, int cb, int dwLockType) => ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -101,8 +101,7 @@ class IStream extends ISequentialStream {
               int Function(Pointer, int libOffset, int cb, int dwLockType)>()(
       ptr.ref.lpVtbl, libOffset, cb, dwLockType);
 
-  int UnlockRegion(int libOffset, int cb, int dwLockType) =>
-      ptr.ref.lpVtbl.value
+  int UnlockRegion(int libOffset, int cb, int dwLockType) => ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -111,10 +110,10 @@ class IStream extends ISequentialStream {
                           Uint32 dwLockType)>>>()
           .value
           .asFunction<
-              int Function(Pointer, int libOffset, int cb,
-                  int dwLockType)>()(ptr.ref.lpVtbl, libOffset, cb, dwLockType);
+              int Function(Pointer, int libOffset, int cb, int dwLockType)>()(
+      ptr.ref.lpVtbl, libOffset, cb, dwLockType);
 
-  int Stat(Pointer<STATSTG> pstatstg, int grfStatFlag) => ptr.ref.lpVtbl.value
+  int Stat(Pointer<STATSTG> pstatstg, int grfStatFlag) => ptr.ref.vtable
       .elementAt(12)
       .cast<
           Pointer<
@@ -126,7 +125,7 @@ class IStream extends ISequentialStream {
           int Function(Pointer, Pointer<STATSTG> pstatstg,
               int grfStatFlag)>()(ptr.ref.lpVtbl, pstatstg, grfStatFlag);
 
-  int Clone(Pointer<Pointer<COMObject>> ppstm) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppstm) => ptr.ref.vtable
           .elementAt(13)
           .cast<
               Pointer<

--- a/lib/src/com/isupporterrorinfo.dart
+++ b/lib/src/com/isupporterrorinfo.dart
@@ -32,7 +32,7 @@ class ISupportErrorInfo extends IUnknown {
   // vtable begins at 3, is 1 entries long.
   ISupportErrorInfo(super.ptr);
 
-  int InterfaceSupportsErrorInfo(Pointer<GUID> riid) => ptr.ref.lpVtbl.value
+  int InterfaceSupportsErrorInfo(Pointer<GUID> riid) => ptr.ref.vtable
       .elementAt(3)
       .cast<
           Pointer<

--- a/lib/src/com/itypeinfo.dart
+++ b/lib/src/com/itypeinfo.dart
@@ -32,7 +32,7 @@ class ITypeInfo extends IUnknown {
   // vtable begins at 3, is 19 entries long.
   ITypeInfo(super.ptr);
 
-  int GetTypeAttr(Pointer<Pointer<TYPEATTR>> ppTypeAttr) => ptr.ref.lpVtbl.value
+  int GetTypeAttr(Pointer<Pointer<TYPEATTR>> ppTypeAttr) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -44,7 +44,7 @@ class ITypeInfo extends IUnknown {
               int Function(Pointer, Pointer<Pointer<TYPEATTR>> ppTypeAttr)>()(
       ptr.ref.lpVtbl, ppTypeAttr);
 
-  int GetTypeComp(Pointer<Pointer<COMObject>> ppTComp) => ptr.ref.lpVtbl.value
+  int GetTypeComp(Pointer<Pointer<COMObject>> ppTComp) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -57,7 +57,7 @@ class ITypeInfo extends IUnknown {
       ptr.ref.lpVtbl, ppTComp);
 
   int GetFuncDesc(int index, Pointer<Pointer<FUNCDESC>> ppFuncDesc) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -71,7 +71,7 @@ class ITypeInfo extends IUnknown {
       ptr.ref.lpVtbl, index, ppFuncDesc);
 
   int GetVarDesc(int index, Pointer<Pointer<VARDESC>> ppVarDesc) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -86,7 +86,7 @@ class ITypeInfo extends IUnknown {
 
   int GetNames(int memid, Pointer<Pointer<Utf16>> rgBstrNames, int cMaxNames,
           Pointer<Uint32> pcNames) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -108,7 +108,7 @@ class ITypeInfo extends IUnknown {
           ptr.ref.lpVtbl, memid, rgBstrNames, cMaxNames, pcNames);
 
   int GetRefTypeOfImplType(int index, Pointer<Uint32> pRefType) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -120,23 +120,23 @@ class ITypeInfo extends IUnknown {
               int Function(Pointer, int index,
                   Pointer<Uint32> pRefType)>()(ptr.ref.lpVtbl, index, pRefType);
 
-  int GetImplTypeFlags(int index, Pointer<Int32> pImplTypeFlags) => ptr
-          .ref.lpVtbl.value
-          .elementAt(9)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      Int32 Function(Pointer, Uint32 index,
-                          Pointer<Int32> pImplTypeFlags)>>>()
-          .value
-          .asFunction<
-              int Function(
-                  Pointer, int index, Pointer<Int32> pImplTypeFlags)>()(
-      ptr.ref.lpVtbl, index, pImplTypeFlags);
+  int GetImplTypeFlags(int index, Pointer<Int32> pImplTypeFlags) =>
+      ptr.ref.vtable
+              .elementAt(9)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          Int32 Function(Pointer, Uint32 index,
+                              Pointer<Int32> pImplTypeFlags)>>>()
+              .value
+              .asFunction<
+                  int Function(
+                      Pointer, int index, Pointer<Int32> pImplTypeFlags)>()(
+          ptr.ref.lpVtbl, index, pImplTypeFlags);
 
   int GetIDsOfNames(Pointer<Pointer<Utf16>> rgszNames, int cNames,
           Pointer<Int32> pMemId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -160,7 +160,7 @@ class ITypeInfo extends IUnknown {
           Pointer<VARIANT> pVarResult,
           Pointer<EXCEPINFO> pExcepInfo,
           Pointer<Uint32> puArgErr) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -193,7 +193,7 @@ class ITypeInfo extends IUnknown {
           Pointer<Pointer<Utf16>> pBstrDocString,
           Pointer<Uint32> pdwHelpContext,
           Pointer<Pointer<Utf16>> pBstrHelpFile) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(12)
               .cast<
                   Pointer<
@@ -218,7 +218,7 @@ class ITypeInfo extends IUnknown {
 
   int GetDllEntry(int memid, int invKind, Pointer<Pointer<Utf16>> pBstrDllName,
           Pointer<Pointer<Utf16>> pBstrName, Pointer<Uint16> pwOrdinal) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(13)
               .cast<
                   Pointer<
@@ -242,7 +242,7 @@ class ITypeInfo extends IUnknown {
           ptr.ref.lpVtbl, memid, invKind, pBstrDllName, pBstrName, pwOrdinal);
 
   int GetRefTypeInfo(int hRefType, Pointer<Pointer<COMObject>> ppTInfo) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(14)
               .cast<
                   Pointer<
@@ -256,7 +256,7 @@ class ITypeInfo extends IUnknown {
           ptr.ref.lpVtbl, hRefType, ppTInfo);
 
   int AddressOfMember(int memid, int invKind, Pointer<Pointer> ppv) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(15)
           .cast<
               Pointer<
@@ -270,7 +270,7 @@ class ITypeInfo extends IUnknown {
 
   int CreateInstance(Pointer<COMObject> pUnkOuter, Pointer<GUID> riid,
           Pointer<Pointer> ppvObj) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(16)
               .cast<
                   Pointer<
@@ -283,23 +283,22 @@ class ITypeInfo extends IUnknown {
                       Pointer<GUID> riid, Pointer<Pointer> ppvObj)>()(
           ptr.ref.lpVtbl, pUnkOuter, riid, ppvObj);
 
-  int GetMops(int memid, Pointer<Pointer<Utf16>> pBstrMops) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(17)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer, Int32 memid,
-                              Pointer<Pointer<Utf16>> pBstrMops)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, int memid, Pointer<Pointer<Utf16>> pBstrMops)>()(
-          ptr.ref.lpVtbl, memid, pBstrMops);
+  int GetMops(int memid, Pointer<Pointer<Utf16>> pBstrMops) => ptr.ref.vtable
+          .elementAt(17)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, Int32 memid,
+                          Pointer<Pointer<Utf16>> pBstrMops)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, int memid, Pointer<Pointer<Utf16>> pBstrMops)>()(
+      ptr.ref.lpVtbl, memid, pBstrMops);
 
   int GetContainingTypeLib(
           Pointer<Pointer<COMObject>> ppTLib, Pointer<Uint32> pIndex) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(18)
           .cast<
               Pointer<
@@ -313,7 +312,7 @@ class ITypeInfo extends IUnknown {
               int Function(Pointer, Pointer<Pointer<COMObject>> ppTLib,
                   Pointer<Uint32> pIndex)>()(ptr.ref.lpVtbl, ppTLib, pIndex);
 
-  void ReleaseTypeAttr(Pointer<TYPEATTR> pTypeAttr) => ptr.ref.lpVtbl.value
+  void ReleaseTypeAttr(Pointer<TYPEATTR> pTypeAttr) => ptr.ref.vtable
           .elementAt(19)
           .cast<
               Pointer<
@@ -323,7 +322,7 @@ class ITypeInfo extends IUnknown {
           .asFunction<void Function(Pointer, Pointer<TYPEATTR> pTypeAttr)>()(
       ptr.ref.lpVtbl, pTypeAttr);
 
-  void ReleaseFuncDesc(Pointer<FUNCDESC> pFuncDesc) => ptr.ref.lpVtbl.value
+  void ReleaseFuncDesc(Pointer<FUNCDESC> pFuncDesc) => ptr.ref.vtable
           .elementAt(20)
           .cast<
               Pointer<
@@ -333,7 +332,7 @@ class ITypeInfo extends IUnknown {
           .asFunction<void Function(Pointer, Pointer<FUNCDESC> pFuncDesc)>()(
       ptr.ref.lpVtbl, pFuncDesc);
 
-  void ReleaseVarDesc(Pointer<VARDESC> pVarDesc) => ptr.ref.lpVtbl.value
+  void ReleaseVarDesc(Pointer<VARDESC> pVarDesc) => ptr.ref.vtable
           .elementAt(21)
           .cast<
               Pointer<

--- a/lib/src/com/iuri.dart
+++ b/lib/src/com/iuri.dart
@@ -34,7 +34,7 @@ class IUri extends IUnknown {
 
   int GetPropertyBSTR(
           int uriProp, Pointer<Pointer<Utf16>> pbstrProperty, int dwFlags) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -52,7 +52,7 @@ class IUri extends IUnknown {
 
   int GetPropertyLength(
           int uriProp, Pointer<Uint32> pcchProperty, int dwFlags) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -66,7 +66,7 @@ class IUri extends IUnknown {
           ptr.ref.lpVtbl, uriProp, pcchProperty, dwFlags);
 
   int GetPropertyDWORD(int uriProp, Pointer<Uint32> pdwProperty, int dwFlags) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -79,8 +79,7 @@ class IUri extends IUnknown {
                       Pointer<Uint32> pdwProperty, int dwFlags)>()(
           ptr.ref.lpVtbl, uriProp, pdwProperty, dwFlags);
 
-  int HasProperty(int uriProp, Pointer<Int32> pfHasProperty) => ptr
-          .ref.lpVtbl.value
+  int HasProperty(int uriProp, Pointer<Int32> pfHasProperty) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -93,22 +92,20 @@ class IUri extends IUnknown {
                   Pointer, int uriProp, Pointer<Int32> pfHasProperty)>()(
       ptr.ref.lpVtbl, uriProp, pfHasProperty);
 
-  int GetAbsoluteUri(Pointer<Pointer<Utf16>> pbstrAbsoluteUri) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(7)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer,
-                              Pointer<Pointer<Utf16>> pbstrAbsoluteUri)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, Pointer<Pointer<Utf16>> pbstrAbsoluteUri)>()(
-          ptr.ref.lpVtbl, pbstrAbsoluteUri);
+  int GetAbsoluteUri(Pointer<Pointer<Utf16>> pbstrAbsoluteUri) => ptr.ref.vtable
+          .elementAt(7)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer,
+                          Pointer<Pointer<Utf16>> pbstrAbsoluteUri)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, Pointer<Pointer<Utf16>> pbstrAbsoluteUri)>()(
+      ptr.ref.lpVtbl, pbstrAbsoluteUri);
 
-  int GetAuthority(Pointer<Pointer<Utf16>> pbstrAuthority) => ptr
-          .ref.lpVtbl.value
+  int GetAuthority(Pointer<Pointer<Utf16>> pbstrAuthority) => ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -121,7 +118,7 @@ class IUri extends IUnknown {
       ptr.ref.lpVtbl, pbstrAuthority);
 
   int GetDisplayUri(Pointer<Pointer<Utf16>> pbstrDisplayString) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -134,7 +131,7 @@ class IUri extends IUnknown {
                       Pointer, Pointer<Pointer<Utf16>> pbstrDisplayString)>()(
           ptr.ref.lpVtbl, pbstrDisplayString);
 
-  int GetDomain(Pointer<Pointer<Utf16>> pbstrDomain) => ptr.ref.lpVtbl.value
+  int GetDomain(Pointer<Pointer<Utf16>> pbstrDomain) => ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -146,8 +143,7 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrDomain)>()(
       ptr.ref.lpVtbl, pbstrDomain);
 
-  int GetExtension(Pointer<Pointer<Utf16>> pbstrExtension) => ptr
-          .ref.lpVtbl.value
+  int GetExtension(Pointer<Pointer<Utf16>> pbstrExtension) => ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -159,7 +155,7 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrExtension)>()(
       ptr.ref.lpVtbl, pbstrExtension);
 
-  int GetFragment(Pointer<Pointer<Utf16>> pbstrFragment) => ptr.ref.lpVtbl.value
+  int GetFragment(Pointer<Pointer<Utf16>> pbstrFragment) => ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -171,7 +167,7 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrFragment)>()(
       ptr.ref.lpVtbl, pbstrFragment);
 
-  int GetHost(Pointer<Pointer<Utf16>> pbstrHost) => ptr.ref.lpVtbl.value
+  int GetHost(Pointer<Pointer<Utf16>> pbstrHost) => ptr.ref.vtable
           .elementAt(13)
           .cast<
               Pointer<
@@ -183,7 +179,7 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrHost)>()(
       ptr.ref.lpVtbl, pbstrHost);
 
-  int GetPassword(Pointer<Pointer<Utf16>> pbstrPassword) => ptr.ref.lpVtbl.value
+  int GetPassword(Pointer<Pointer<Utf16>> pbstrPassword) => ptr.ref.vtable
           .elementAt(14)
           .cast<
               Pointer<
@@ -195,7 +191,7 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrPassword)>()(
       ptr.ref.lpVtbl, pbstrPassword);
 
-  int GetPath(Pointer<Pointer<Utf16>> pbstrPath) => ptr.ref.lpVtbl.value
+  int GetPath(Pointer<Pointer<Utf16>> pbstrPath) => ptr.ref.vtable
           .elementAt(15)
           .cast<
               Pointer<
@@ -207,21 +203,21 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrPath)>()(
       ptr.ref.lpVtbl, pbstrPath);
 
-  int GetPathAndQuery(Pointer<Pointer<Utf16>> pbstrPathAndQuery) => ptr
-          .ref.lpVtbl.value
-          .elementAt(16)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      Int32 Function(Pointer,
-                          Pointer<Pointer<Utf16>> pbstrPathAndQuery)>>>()
-          .value
-          .asFunction<
-              int Function(
-                  Pointer, Pointer<Pointer<Utf16>> pbstrPathAndQuery)>()(
-      ptr.ref.lpVtbl, pbstrPathAndQuery);
+  int GetPathAndQuery(Pointer<Pointer<Utf16>> pbstrPathAndQuery) =>
+      ptr.ref.vtable
+              .elementAt(16)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          Int32 Function(Pointer,
+                              Pointer<Pointer<Utf16>> pbstrPathAndQuery)>>>()
+              .value
+              .asFunction<
+                  int Function(
+                      Pointer, Pointer<Pointer<Utf16>> pbstrPathAndQuery)>()(
+          ptr.ref.lpVtbl, pbstrPathAndQuery);
 
-  int GetQuery(Pointer<Pointer<Utf16>> pbstrQuery) => ptr.ref.lpVtbl.value
+  int GetQuery(Pointer<Pointer<Utf16>> pbstrQuery) => ptr.ref.vtable
           .elementAt(17)
           .cast<
               Pointer<
@@ -233,7 +229,7 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrQuery)>()(
       ptr.ref.lpVtbl, pbstrQuery);
 
-  int GetRawUri(Pointer<Pointer<Utf16>> pbstrRawUri) => ptr.ref.lpVtbl.value
+  int GetRawUri(Pointer<Pointer<Utf16>> pbstrRawUri) => ptr.ref.vtable
           .elementAt(18)
           .cast<
               Pointer<
@@ -245,8 +241,7 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrRawUri)>()(
       ptr.ref.lpVtbl, pbstrRawUri);
 
-  int GetSchemeName(Pointer<Pointer<Utf16>> pbstrSchemeName) => ptr
-          .ref.lpVtbl.value
+  int GetSchemeName(Pointer<Pointer<Utf16>> pbstrSchemeName) => ptr.ref.vtable
           .elementAt(19)
           .cast<
               Pointer<
@@ -258,7 +253,7 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrSchemeName)>()(
       ptr.ref.lpVtbl, pbstrSchemeName);
 
-  int GetUserInfo(Pointer<Pointer<Utf16>> pbstrUserInfo) => ptr.ref.lpVtbl.value
+  int GetUserInfo(Pointer<Pointer<Utf16>> pbstrUserInfo) => ptr.ref.vtable
           .elementAt(20)
           .cast<
               Pointer<
@@ -270,7 +265,7 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrUserInfo)>()(
       ptr.ref.lpVtbl, pbstrUserInfo);
 
-  int GetUserName(Pointer<Pointer<Utf16>> pbstrUserName) => ptr.ref.lpVtbl.value
+  int GetUserName(Pointer<Pointer<Utf16>> pbstrUserName) => ptr.ref.vtable
           .elementAt(21)
           .cast<
               Pointer<
@@ -282,7 +277,7 @@ class IUri extends IUnknown {
               int Function(Pointer, Pointer<Pointer<Utf16>> pbstrUserName)>()(
       ptr.ref.lpVtbl, pbstrUserName);
 
-  int GetHostType(Pointer<Uint32> pdwHostType) => ptr.ref.lpVtbl.value
+  int GetHostType(Pointer<Uint32> pdwHostType) => ptr.ref.vtable
           .elementAt(22)
           .cast<
               Pointer<
@@ -292,7 +287,7 @@ class IUri extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint32> pdwHostType)>()(
       ptr.ref.lpVtbl, pdwHostType);
 
-  int GetPort(Pointer<Uint32> pdwPort) => ptr.ref.lpVtbl.value
+  int GetPort(Pointer<Uint32> pdwPort) => ptr.ref.vtable
           .elementAt(23)
           .cast<
               Pointer<
@@ -302,7 +297,7 @@ class IUri extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint32> pdwPort)>()(
       ptr.ref.lpVtbl, pdwPort);
 
-  int GetScheme(Pointer<Uint32> pdwScheme) => ptr.ref.lpVtbl.value
+  int GetScheme(Pointer<Uint32> pdwScheme) => ptr.ref.vtable
           .elementAt(24)
           .cast<
               Pointer<
@@ -312,7 +307,7 @@ class IUri extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint32> pdwScheme)>()(
       ptr.ref.lpVtbl, pdwScheme);
 
-  int GetZone(Pointer<Uint32> pdwZone) => ptr.ref.lpVtbl.value
+  int GetZone(Pointer<Uint32> pdwZone) => ptr.ref.vtable
           .elementAt(25)
           .cast<
               Pointer<
@@ -322,7 +317,7 @@ class IUri extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint32> pdwZone)>()(
       ptr.ref.lpVtbl, pdwZone);
 
-  int GetProperties(Pointer<Uint32> pdwFlags) => ptr.ref.lpVtbl.value
+  int GetProperties(Pointer<Uint32> pdwFlags) => ptr.ref.vtable
           .elementAt(26)
           .cast<
               Pointer<
@@ -332,16 +327,15 @@ class IUri extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Uint32> pdwFlags)>()(
       ptr.ref.lpVtbl, pdwFlags);
 
-  int IsEqual(Pointer<COMObject> pUri, Pointer<Int32> pfEqual) =>
-      ptr.ref.lpVtbl.value
-          .elementAt(27)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      Int32 Function(Pointer, Pointer<COMObject> pUri,
-                          Pointer<Int32> pfEqual)>>>()
-          .value
-          .asFunction<
-              int Function(Pointer, Pointer<COMObject> pUri,
-                  Pointer<Int32> pfEqual)>()(ptr.ref.lpVtbl, pUri, pfEqual);
+  int IsEqual(Pointer<COMObject> pUri, Pointer<Int32> pfEqual) => ptr.ref.vtable
+      .elementAt(27)
+      .cast<
+          Pointer<
+              NativeFunction<
+                  Int32 Function(Pointer, Pointer<COMObject> pUri,
+                      Pointer<Int32> pfEqual)>>>()
+      .value
+      .asFunction<
+          int Function(Pointer, Pointer<COMObject> pUri,
+              Pointer<Int32> pfEqual)>()(ptr.ref.lpVtbl, pUri, pfEqual);
 }

--- a/lib/src/com/ivirtualdesktopmanager.dart
+++ b/lib/src/com/ivirtualdesktopmanager.dart
@@ -34,7 +34,7 @@ class IVirtualDesktopManager extends IUnknown {
 
   int IsWindowOnCurrentVirtualDesktop(
           int topLevelWindow, Pointer<Int32> onCurrentDesktop) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -48,7 +48,7 @@ class IVirtualDesktopManager extends IUnknown {
           ptr.ref.lpVtbl, topLevelWindow, onCurrentDesktop);
 
   int GetWindowDesktopId(int topLevelWindow, Pointer<GUID> desktopId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -61,19 +61,19 @@ class IVirtualDesktopManager extends IUnknown {
                       Pointer, int topLevelWindow, Pointer<GUID> desktopId)>()(
           ptr.ref.lpVtbl, topLevelWindow, desktopId);
 
-  int MoveWindowToDesktop(int topLevelWindow, Pointer<GUID> desktopId) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(5)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer, IntPtr topLevelWindow,
-                              Pointer<GUID> desktopId)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, int topLevelWindow, Pointer<GUID> desktopId)>()(
-          ptr.ref.lpVtbl, topLevelWindow, desktopId);
+  int MoveWindowToDesktop(int topLevelWindow, Pointer<GUID> desktopId) => ptr
+          .ref.vtable
+          .elementAt(5)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, IntPtr topLevelWindow,
+                          Pointer<GUID> desktopId)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, int topLevelWindow, Pointer<GUID> desktopId)>()(
+      ptr.ref.lpVtbl, topLevelWindow, desktopId);
 }
 
 /// @nodoc

--- a/lib/src/com/iwbemclassobject.dart
+++ b/lib/src/com/iwbemclassobject.dart
@@ -32,8 +32,7 @@ class IWbemClassObject extends IUnknown {
   // vtable begins at 3, is 24 entries long.
   IWbemClassObject(super.ptr);
 
-  int GetQualifierSet(Pointer<Pointer<COMObject>> ppQualSet) => ptr
-          .ref.lpVtbl.value
+  int GetQualifierSet(Pointer<Pointer<COMObject>> ppQualSet) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -47,7 +46,7 @@ class IWbemClassObject extends IUnknown {
 
   int Get(Pointer<Utf16> wszName, int lFlags, Pointer<VARIANT> pVal,
           Pointer<Int32> pType, Pointer<Int32> plFlavor) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -72,7 +71,7 @@ class IWbemClassObject extends IUnknown {
 
   int Put(Pointer<Utf16> wszName, int lFlags, Pointer<VARIANT> pVal,
           int Type) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(5)
           .cast<
               Pointer<
@@ -88,7 +87,7 @@ class IWbemClassObject extends IUnknown {
                   Pointer<VARIANT> pVal,
                   int Type)>()(ptr.ref.lpVtbl, wszName, lFlags, pVal, Type);
 
-  int Delete(Pointer<Utf16> wszName) => ptr.ref.lpVtbl.value
+  int Delete(Pointer<Utf16> wszName) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -100,7 +99,7 @@ class IWbemClassObject extends IUnknown {
 
   int GetNames(Pointer<Utf16> wszQualifierName, int lFlags,
           Pointer<VARIANT> pQualifierVal, Pointer<Pointer<SAFEARRAY>> pNames) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -121,7 +120,7 @@ class IWbemClassObject extends IUnknown {
                       Pointer<Pointer<SAFEARRAY>> pNames)>()(
           ptr.ref.lpVtbl, wszQualifierName, lFlags, pQualifierVal, pNames);
 
-  int BeginEnumeration(int lEnumFlags) => ptr.ref.lpVtbl.value
+  int BeginEnumeration(int lEnumFlags) => ptr.ref.vtable
       .elementAt(8)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, Int32 lEnumFlags)>>>()
@@ -131,7 +130,7 @@ class IWbemClassObject extends IUnknown {
 
   int Next(int lFlags, Pointer<Pointer<Utf16>> strName, Pointer<VARIANT> pVal,
           Pointer<Int32> pType, Pointer<Int32> plFlavor) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -154,7 +153,7 @@ class IWbemClassObject extends IUnknown {
                       Pointer<Int32> plFlavor)>()(
           ptr.ref.lpVtbl, lFlags, strName, pVal, pType, plFlavor);
 
-  int EndEnumeration() => ptr.ref.lpVtbl.value
+  int EndEnumeration() => ptr.ref.vtable
       .elementAt(10)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
@@ -162,7 +161,7 @@ class IWbemClassObject extends IUnknown {
 
   int GetPropertyQualifierSet(
           Pointer<Utf16> wszProperty, Pointer<Pointer<COMObject>> ppQualSet) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -175,7 +174,7 @@ class IWbemClassObject extends IUnknown {
                       Pointer<Pointer<COMObject>> ppQualSet)>()(
           ptr.ref.lpVtbl, wszProperty, ppQualSet);
 
-  int Clone(Pointer<Pointer<COMObject>> ppCopy) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppCopy) => ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -188,7 +187,7 @@ class IWbemClassObject extends IUnknown {
       ptr.ref.lpVtbl, ppCopy);
 
   int GetObjectText(int lFlags, Pointer<Pointer<Utf16>> pstrObjectText) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(13)
               .cast<
                   Pointer<
@@ -202,7 +201,7 @@ class IWbemClassObject extends IUnknown {
           ptr.ref.lpVtbl, lFlags, pstrObjectText);
 
   int SpawnDerivedClass(int lFlags, Pointer<Pointer<COMObject>> ppNewClass) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(14)
               .cast<
                   Pointer<
@@ -216,7 +215,7 @@ class IWbemClassObject extends IUnknown {
           ptr.ref.lpVtbl, lFlags, ppNewClass);
 
   int SpawnInstance(int lFlags, Pointer<Pointer<COMObject>> ppNewInstance) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(15)
               .cast<
                   Pointer<
@@ -229,23 +228,22 @@ class IWbemClassObject extends IUnknown {
                       Pointer<Pointer<COMObject>> ppNewInstance)>()(
           ptr.ref.lpVtbl, lFlags, ppNewInstance);
 
-  int CompareTo(int lFlags, Pointer<COMObject> pCompareTo) =>
-      ptr.ref.lpVtbl.value
-              .elementAt(16)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          Int32 Function(Pointer, Int32 lFlags,
-                              Pointer<COMObject> pCompareTo)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, int lFlags, Pointer<COMObject> pCompareTo)>()(
-          ptr.ref.lpVtbl, lFlags, pCompareTo);
+  int CompareTo(int lFlags, Pointer<COMObject> pCompareTo) => ptr.ref.vtable
+          .elementAt(16)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, Int32 lFlags,
+                          Pointer<COMObject> pCompareTo)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, int lFlags, Pointer<COMObject> pCompareTo)>()(
+      ptr.ref.lpVtbl, lFlags, pCompareTo);
 
   int GetPropertyOrigin(
           Pointer<Utf16> wszName, Pointer<Pointer<Utf16>> pstrClassName) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(17)
               .cast<
                   Pointer<
@@ -258,7 +256,7 @@ class IWbemClassObject extends IUnknown {
                       Pointer<Pointer<Utf16>> pstrClassName)>()(
           ptr.ref.lpVtbl, wszName, pstrClassName);
 
-  int InheritsFrom(Pointer<Utf16> strAncestor) => ptr.ref.lpVtbl.value
+  int InheritsFrom(Pointer<Utf16> strAncestor) => ptr.ref.vtable
           .elementAt(18)
           .cast<
               Pointer<
@@ -273,7 +271,7 @@ class IWbemClassObject extends IUnknown {
           int lFlags,
           Pointer<Pointer<COMObject>> ppInSignature,
           Pointer<Pointer<COMObject>> ppOutSignature) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(19)
               .cast<
                   Pointer<
@@ -296,7 +294,7 @@ class IWbemClassObject extends IUnknown {
 
   int PutMethod(Pointer<Utf16> wszName, int lFlags,
           Pointer<COMObject> pInSignature, Pointer<COMObject> pOutSignature) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(20)
               .cast<
                   Pointer<
@@ -317,7 +315,7 @@ class IWbemClassObject extends IUnknown {
                       Pointer<COMObject> pOutSignature)>()(
           ptr.ref.lpVtbl, wszName, lFlags, pInSignature, pOutSignature);
 
-  int DeleteMethod(Pointer<Utf16> wszName) => ptr.ref.lpVtbl.value
+  int DeleteMethod(Pointer<Utf16> wszName) => ptr.ref.vtable
           .elementAt(21)
           .cast<
               Pointer<
@@ -327,7 +325,7 @@ class IWbemClassObject extends IUnknown {
           .asFunction<int Function(Pointer, Pointer<Utf16> wszName)>()(
       ptr.ref.lpVtbl, wszName);
 
-  int BeginMethodEnumeration(int lEnumFlags) => ptr.ref.lpVtbl.value
+  int BeginMethodEnumeration(int lEnumFlags) => ptr.ref.vtable
       .elementAt(22)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, Int32 lEnumFlags)>>>()
@@ -340,7 +338,7 @@ class IWbemClassObject extends IUnknown {
           Pointer<Pointer<Utf16>> pstrName,
           Pointer<Pointer<COMObject>> ppInSignature,
           Pointer<Pointer<COMObject>> ppOutSignature) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(23)
               .cast<
                   Pointer<
@@ -361,7 +359,7 @@ class IWbemClassObject extends IUnknown {
                       Pointer<Pointer<COMObject>> ppOutSignature)>()(
           ptr.ref.lpVtbl, lFlags, pstrName, ppInSignature, ppOutSignature);
 
-  int EndMethodEnumeration() => ptr.ref.lpVtbl.value
+  int EndMethodEnumeration() => ptr.ref.vtable
       .elementAt(24)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
@@ -369,7 +367,7 @@ class IWbemClassObject extends IUnknown {
 
   int GetMethodQualifierSet(
           Pointer<Utf16> wszMethod, Pointer<Pointer<COMObject>> ppQualSet) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(25)
               .cast<
                   Pointer<
@@ -384,7 +382,7 @@ class IWbemClassObject extends IUnknown {
 
   int GetMethodOrigin(Pointer<Utf16> wszMethodName,
           Pointer<Pointer<Utf16>> pstrClassName) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(26)
               .cast<
                   Pointer<

--- a/lib/src/com/iwbemconfigurerefresher.dart
+++ b/lib/src/com/iwbemconfigurerefresher.dart
@@ -39,7 +39,7 @@ class IWbemConfigureRefresher extends IUnknown {
           Pointer<COMObject> pContext,
           Pointer<Pointer<COMObject>> ppRefreshable,
           Pointer<Int32> plId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -71,7 +71,7 @@ class IWbemConfigureRefresher extends IUnknown {
           Pointer<COMObject> pContext,
           Pointer<Pointer<COMObject>> ppRefreshable,
           Pointer<Int32> plId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(4)
               .cast<
                   Pointer<
@@ -98,7 +98,7 @@ class IWbemConfigureRefresher extends IUnknown {
 
   int AddRefresher(
           Pointer<COMObject> pRefresher, int lFlags, Pointer<Int32> plId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -111,7 +111,7 @@ class IWbemConfigureRefresher extends IUnknown {
                       int lFlags, Pointer<Int32> plId)>()(
           ptr.ref.lpVtbl, pRefresher, lFlags, plId);
 
-  int Remove(int lId, int lFlags) => ptr.ref.lpVtbl.value
+  int Remove(int lId, int lFlags) => ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -128,7 +128,7 @@ class IWbemConfigureRefresher extends IUnknown {
           Pointer<COMObject> pContext,
           Pointer<Pointer<COMObject>> ppEnum,
           Pointer<Int32> plId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<

--- a/lib/src/com/iwbemcontext.dart
+++ b/lib/src/com/iwbemcontext.dart
@@ -32,7 +32,7 @@ class IWbemContext extends IUnknown {
   // vtable begins at 3, is 9 entries long.
   IWbemContext(super.ptr);
 
-  int Clone(Pointer<Pointer<COMObject>> ppNewCopy) => ptr.ref.lpVtbl.value
+  int Clone(Pointer<Pointer<COMObject>> ppNewCopy) => ptr.ref.vtable
           .elementAt(3)
           .cast<
               Pointer<
@@ -44,8 +44,7 @@ class IWbemContext extends IUnknown {
               int Function(Pointer, Pointer<Pointer<COMObject>> ppNewCopy)>()(
       ptr.ref.lpVtbl, ppNewCopy);
 
-  int GetNames(int lFlags, Pointer<Pointer<SAFEARRAY>> pNames) => ptr
-          .ref.lpVtbl.value
+  int GetNames(int lFlags, Pointer<Pointer<SAFEARRAY>> pNames) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -58,7 +57,7 @@ class IWbemContext extends IUnknown {
                   Pointer, int lFlags, Pointer<Pointer<SAFEARRAY>> pNames)>()(
       ptr.ref.lpVtbl, lFlags, pNames);
 
-  int BeginEnumeration(int lFlags) => ptr.ref.lpVtbl.value
+  int BeginEnumeration(int lFlags) => ptr.ref.vtable
       .elementAt(5)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 lFlags)>>>()
       .value
@@ -66,7 +65,7 @@ class IWbemContext extends IUnknown {
 
   int Next(int lFlags, Pointer<Pointer<Utf16>> pstrName,
           Pointer<VARIANT> pValue) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<
@@ -85,14 +84,14 @@ class IWbemContext extends IUnknown {
                       Pointer<VARIANT> pValue)>()(
           ptr.ref.lpVtbl, lFlags, pstrName, pValue);
 
-  int EndEnumeration() => ptr.ref.lpVtbl.value
+  int EndEnumeration() => ptr.ref.vtable
       .elementAt(7)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value
       .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
   int SetValue(Pointer<Utf16> wszName, int lFlags, Pointer<VARIANT> pValue) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -106,7 +105,7 @@ class IWbemContext extends IUnknown {
           ptr.ref.lpVtbl, wszName, lFlags, pValue);
 
   int GetValue(Pointer<Utf16> wszName, int lFlags, Pointer<VARIANT> pValue) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -119,7 +118,7 @@ class IWbemContext extends IUnknown {
                       Pointer<VARIANT> pValue)>()(
           ptr.ref.lpVtbl, wszName, lFlags, pValue);
 
-  int DeleteValue(Pointer<Utf16> wszName, int lFlags) => ptr.ref.lpVtbl.value
+  int DeleteValue(Pointer<Utf16> wszName, int lFlags) => ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -131,7 +130,7 @@ class IWbemContext extends IUnknown {
               int Function(Pointer, Pointer<Utf16> wszName, int lFlags)>()(
       ptr.ref.lpVtbl, wszName, lFlags);
 
-  int DeleteAll() => ptr.ref.lpVtbl.value
+  int DeleteAll() => ptr.ref.vtable
       .elementAt(11)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
       .value

--- a/lib/src/com/iwbemhiperfenum.dart
+++ b/lib/src/com/iwbemhiperfenum.dart
@@ -34,7 +34,7 @@ class IWbemHiPerfEnum extends IUnknown {
 
   int AddObjects(int lFlags, int uNumObjects, Pointer<Int32> apIds,
           Pointer<Pointer<COMObject>> apObj) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -56,7 +56,7 @@ class IWbemHiPerfEnum extends IUnknown {
           ptr.ref.lpVtbl, lFlags, uNumObjects, apIds, apObj);
 
   int RemoveObjects(int lFlags, int uNumObjects, Pointer<Int32> apIds) => ptr
-          .ref.lpVtbl.value
+          .ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -71,7 +71,7 @@ class IWbemHiPerfEnum extends IUnknown {
 
   int GetObjects(int lFlags, int uNumObjects, Pointer<Pointer<COMObject>> apObj,
           Pointer<Uint32> puReturned) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(5)
               .cast<
                   Pointer<
@@ -92,7 +92,7 @@ class IWbemHiPerfEnum extends IUnknown {
                       Pointer<Uint32> puReturned)>()(
           ptr.ref.lpVtbl, lFlags, uNumObjects, apObj, puReturned);
 
-  int RemoveAll(int lFlags) => ptr.ref.lpVtbl.value
+  int RemoveAll(int lFlags) => ptr.ref.vtable
       .elementAt(6)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 lFlags)>>>()
       .value

--- a/lib/src/com/iwbemlocator.dart
+++ b/lib/src/com/iwbemlocator.dart
@@ -41,7 +41,7 @@ class IWbemLocator extends IUnknown {
           Pointer<Utf16> strAuthority,
           Pointer<COMObject> pCtx,
           Pointer<Pointer<COMObject>> ppNamespace) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<

--- a/lib/src/com/iwbemobjectaccess.dart
+++ b/lib/src/com/iwbemobjectaccess.dart
@@ -35,7 +35,7 @@ class IWbemObjectAccess extends IWbemClassObject {
   int
       GetPropertyHandle(Pointer<Utf16> wszPropertyName, Pointer<Int32> pType,
               Pointer<Int32> plHandle) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(27)
                   .cast<
                       Pointer<
@@ -52,7 +52,7 @@ class IWbemObjectAccess extends IWbemClassObject {
               ptr.ref.lpVtbl, wszPropertyName, pType, plHandle);
 
   int WritePropertyValue(int lHandle, int lNumBytes, Pointer<Uint8> aData) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(28)
           .cast<
               Pointer<
@@ -71,7 +71,7 @@ class IWbemObjectAccess extends IWbemClassObject {
   int
       ReadPropertyValue(int lHandle, int lBufferSize, Pointer<Int32> plNumBytes,
               Pointer<Uint8> aData) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(29)
                   .cast<
                       Pointer<
@@ -88,7 +88,7 @@ class IWbemObjectAccess extends IWbemClassObject {
                           Pointer<Int32> plNumBytes, Pointer<Uint8> aData)>()(
               ptr.ref.lpVtbl, lHandle, lBufferSize, plNumBytes, aData);
 
-  int ReadDWORD(int lHandle, Pointer<Uint32> pdw) => ptr.ref.lpVtbl.value
+  int ReadDWORD(int lHandle, Pointer<Uint32> pdw) => ptr.ref.vtable
           .elementAt(30)
           .cast<
               Pointer<
@@ -100,7 +100,7 @@ class IWbemObjectAccess extends IWbemClassObject {
               int Function(Pointer, int lHandle, Pointer<Uint32> pdw)>()(
       ptr.ref.lpVtbl, lHandle, pdw);
 
-  int WriteDWORD(int lHandle, int dw) => ptr.ref.lpVtbl.value
+  int WriteDWORD(int lHandle, int dw) => ptr.ref.vtable
           .elementAt(31)
           .cast<
               Pointer<
@@ -110,7 +110,7 @@ class IWbemObjectAccess extends IWbemClassObject {
           .asFunction<int Function(Pointer, int lHandle, int dw)>()(
       ptr.ref.lpVtbl, lHandle, dw);
 
-  int ReadQWORD(int lHandle, Pointer<Uint64> pqw) => ptr.ref.lpVtbl.value
+  int ReadQWORD(int lHandle, Pointer<Uint64> pqw) => ptr.ref.vtable
           .elementAt(32)
           .cast<
               Pointer<
@@ -122,7 +122,7 @@ class IWbemObjectAccess extends IWbemClassObject {
               int Function(Pointer, int lHandle, Pointer<Uint64> pqw)>()(
       ptr.ref.lpVtbl, lHandle, pqw);
 
-  int WriteQWORD(int lHandle, int pw) => ptr.ref.lpVtbl.value
+  int WriteQWORD(int lHandle, int pw) => ptr.ref.vtable
           .elementAt(33)
           .cast<
               Pointer<
@@ -134,7 +134,7 @@ class IWbemObjectAccess extends IWbemClassObject {
 
   int GetPropertyInfoByHandle(int lHandle, Pointer<Pointer<Utf16>> pstrName,
           Pointer<Int32> pType) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(34)
               .cast<
                   Pointer<
@@ -153,13 +153,13 @@ class IWbemObjectAccess extends IWbemClassObject {
                       Pointer<Int32> pType)>()(
           ptr.ref.lpVtbl, lHandle, pstrName, pType);
 
-  int Lock(int lFlags) => ptr.ref.lpVtbl.value
+  int Lock(int lFlags) => ptr.ref.vtable
       .elementAt(35)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 lFlags)>>>()
       .value
       .asFunction<int Function(Pointer, int lFlags)>()(ptr.ref.lpVtbl, lFlags);
 
-  int Unlock(int lFlags) => ptr.ref.lpVtbl.value
+  int Unlock(int lFlags) => ptr.ref.vtable
       .elementAt(36)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 lFlags)>>>()
       .value

--- a/lib/src/com/iwbemrefresher.dart
+++ b/lib/src/com/iwbemrefresher.dart
@@ -32,7 +32,7 @@ class IWbemRefresher extends IUnknown {
   // vtable begins at 3, is 1 entries long.
   IWbemRefresher(super.ptr);
 
-  int Refresh(int lFlags) => ptr.ref.lpVtbl.value
+  int Refresh(int lFlags) => ptr.ref.vtable
       .elementAt(3)
       .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32 lFlags)>>>()
       .value

--- a/lib/src/com/iwbemservices.dart
+++ b/lib/src/com/iwbemservices.dart
@@ -38,7 +38,7 @@ class IWbemServices extends IUnknown {
           Pointer<COMObject> pCtx,
           Pointer<Pointer<COMObject>> ppWorkingNamespace,
           Pointer<Pointer<COMObject>> ppResult) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(3)
               .cast<
                   Pointer<
@@ -61,7 +61,7 @@ class IWbemServices extends IUnknown {
                       Pointer<Pointer<COMObject>> ppResult)>()(ptr.ref.lpVtbl,
           strNamespace, lFlags, pCtx, ppWorkingNamespace, ppResult);
 
-  int CancelAsyncCall(Pointer<COMObject> pSink) => ptr.ref.lpVtbl.value
+  int CancelAsyncCall(Pointer<COMObject> pSink) => ptr.ref.vtable
           .elementAt(4)
           .cast<
               Pointer<
@@ -74,7 +74,7 @@ class IWbemServices extends IUnknown {
   int
       QueryObjectSink(
               int lFlags, Pointer<Pointer<COMObject>> ppResponseHandler) =>
-          ptr.ref.lpVtbl.value
+          ptr.ref.vtable
                   .elementAt(5)
                   .cast<
                       Pointer<
@@ -96,7 +96,7 @@ class IWbemServices extends IUnknown {
           Pointer<COMObject> pCtx,
           Pointer<Pointer<COMObject>> ppObject,
           Pointer<Pointer<COMObject>> ppCallResult) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<
@@ -121,7 +121,7 @@ class IWbemServices extends IUnknown {
 
   int GetObjectAsync(Pointer<Utf16> strObjectPath, int lFlags,
           Pointer<COMObject> pCtx, Pointer<COMObject> pResponseHandler) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -144,7 +144,7 @@ class IWbemServices extends IUnknown {
 
   int PutClass(Pointer<COMObject> pObject, int lFlags, Pointer<COMObject> pCtx,
           Pointer<Pointer<COMObject>> ppCallResult) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -167,7 +167,7 @@ class IWbemServices extends IUnknown {
 
   int PutClassAsync(Pointer<COMObject> pObject, int lFlags,
           Pointer<COMObject> pCtx, Pointer<COMObject> pResponseHandler) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -190,7 +190,7 @@ class IWbemServices extends IUnknown {
 
   int DeleteClass(Pointer<Utf16> strClass, int lFlags, Pointer<COMObject> pCtx,
           Pointer<Pointer<COMObject>> ppCallResult) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<
@@ -213,7 +213,7 @@ class IWbemServices extends IUnknown {
 
   int DeleteClassAsync(Pointer<Utf16> strClass, int lFlags,
           Pointer<COMObject> pCtx, Pointer<COMObject> pResponseHandler) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -236,7 +236,7 @@ class IWbemServices extends IUnknown {
 
   int CreateClassEnum(Pointer<Utf16> strSuperclass, int lFlags,
           Pointer<COMObject> pCtx, Pointer<Pointer<COMObject>> ppEnum) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(12)
               .cast<
                   Pointer<
@@ -259,7 +259,7 @@ class IWbemServices extends IUnknown {
 
   int CreateClassEnumAsync(Pointer<Utf16> strSuperclass, int lFlags,
           Pointer<COMObject> pCtx, Pointer<COMObject> pResponseHandler) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(13)
               .cast<
                   Pointer<
@@ -282,7 +282,7 @@ class IWbemServices extends IUnknown {
 
   int PutInstance(Pointer<COMObject> pInst, int lFlags, Pointer<COMObject> pCtx,
           Pointer<Pointer<COMObject>> ppCallResult) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(14)
               .cast<
                   Pointer<
@@ -305,7 +305,7 @@ class IWbemServices extends IUnknown {
 
   int PutInstanceAsync(Pointer<COMObject> pInst, int lFlags,
           Pointer<COMObject> pCtx, Pointer<COMObject> pResponseHandler) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(15)
               .cast<
                   Pointer<
@@ -328,7 +328,7 @@ class IWbemServices extends IUnknown {
 
   int DeleteInstance(Pointer<Utf16> strObjectPath, int lFlags,
           Pointer<COMObject> pCtx, Pointer<Pointer<COMObject>> ppCallResult) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(16)
               .cast<
                   Pointer<
@@ -351,7 +351,7 @@ class IWbemServices extends IUnknown {
 
   int DeleteInstanceAsync(Pointer<Utf16> strObjectPath, int lFlags,
           Pointer<COMObject> pCtx, Pointer<COMObject> pResponseHandler) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(17)
               .cast<
                   Pointer<
@@ -374,7 +374,7 @@ class IWbemServices extends IUnknown {
 
   int CreateInstanceEnum(Pointer<Utf16> strFilter, int lFlags,
           Pointer<COMObject> pCtx, Pointer<Pointer<COMObject>> ppEnum) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(18)
               .cast<
                   Pointer<
@@ -397,7 +397,7 @@ class IWbemServices extends IUnknown {
 
   int CreateInstanceEnumAsync(Pointer<Utf16> strFilter, int lFlags,
           Pointer<COMObject> pCtx, Pointer<COMObject> pResponseHandler) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(19)
               .cast<
                   Pointer<
@@ -424,7 +424,7 @@ class IWbemServices extends IUnknown {
           int lFlags,
           Pointer<COMObject> pCtx,
           Pointer<Pointer<COMObject>> ppEnum) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(20)
               .cast<
                   Pointer<
@@ -453,7 +453,7 @@ class IWbemServices extends IUnknown {
           int lFlags,
           Pointer<COMObject> pCtx,
           Pointer<COMObject> pResponseHandler) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(21)
               .cast<
                   Pointer<
@@ -482,7 +482,7 @@ class IWbemServices extends IUnknown {
           int lFlags,
           Pointer<COMObject> pCtx,
           Pointer<Pointer<COMObject>> ppEnum) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(22)
               .cast<
                   Pointer<
@@ -511,7 +511,7 @@ class IWbemServices extends IUnknown {
           int lFlags,
           Pointer<COMObject> pCtx,
           Pointer<COMObject> pResponseHandler) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(23)
               .cast<
                   Pointer<
@@ -542,7 +542,7 @@ class IWbemServices extends IUnknown {
           Pointer<COMObject> pInParams,
           Pointer<Pointer<COMObject>> ppOutParams,
           Pointer<Pointer<COMObject>> ppCallResult) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(24)
               .cast<
                   Pointer<
@@ -583,7 +583,7 @@ class IWbemServices extends IUnknown {
           Pointer<COMObject> pCtx,
           Pointer<COMObject> pInParams,
           Pointer<COMObject> pResponseHandler) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(25)
               .cast<
                   Pointer<

--- a/lib/src/winrt/iasyncaction.dart
+++ b/lib/src/winrt/iasyncaction.dart
@@ -42,7 +42,7 @@ class IAsyncAction extends IAsyncInfo {
   IAsyncAction(super.ptr);
 
   set Completed(Pointer value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(11)
         .cast<Pointer<NativeFunction<_put_Completed_Native>>>()
         .value
@@ -55,7 +55,7 @@ class IAsyncAction extends IAsyncInfo {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(12)
           .cast<Pointer<NativeFunction<_get_Completed_Native>>>()
           .value
@@ -70,7 +70,7 @@ class IAsyncAction extends IAsyncInfo {
     }
   }
 
-  int GetResults() => ptr.ref.lpVtbl.value
+  int GetResults() => ptr.ref.vtable
       .elementAt(13)
       .cast<Pointer<NativeFunction<_GetResults_Native>>>()
       .value

--- a/lib/src/winrt/iasyncoperation.dart
+++ b/lib/src/winrt/iasyncoperation.dart
@@ -43,7 +43,7 @@ class IAsyncOperation<TResult> extends IAsyncInfo {
   IAsyncOperation(super.ptr);
 
   set Completed(Pointer value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(11)
         .cast<Pointer<NativeFunction<_put_Completed_Native>>>()
         .value
@@ -56,7 +56,7 @@ class IAsyncOperation<TResult> extends IAsyncInfo {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(12)
           .cast<Pointer<NativeFunction<_get_Completed_Native>>>()
           .value
@@ -71,7 +71,7 @@ class IAsyncOperation<TResult> extends IAsyncInfo {
     }
   }
 
-  int GetResults(Pointer<Pointer> result) => ptr.ref.lpVtbl.value
+  int GetResults(Pointer<Pointer> result) => ptr.ref.vtable
       .elementAt(13)
       .cast<Pointer<NativeFunction<_GetResults_Native>>>()
       .value

--- a/lib/src/winrt/igamepadstatics.dart
+++ b/lib/src/winrt/igamepadstatics.dart
@@ -50,12 +50,11 @@ class IGamepadStatics extends IInspectable {
 
   IGamepadStatics(super.ptr);
 
-  int add_GamepadAdded(Pointer value, Pointer<Uint32> result) =>
-      ptr.ref.vtable
-          .elementAt(6)
-          .cast<Pointer<NativeFunction<_add_GamepadAdded_Native>>>()
-          .value
-          .asFunction<_add_GamepadAdded_Dart>()(ptr.ref.lpVtbl, value, result);
+  int add_GamepadAdded(Pointer value, Pointer<Uint32> result) => ptr.ref.vtable
+      .elementAt(6)
+      .cast<Pointer<NativeFunction<_add_GamepadAdded_Native>>>()
+      .value
+      .asFunction<_add_GamepadAdded_Dart>()(ptr.ref.lpVtbl, value, result);
 
   int remove_GamepadAdded(int token) => ptr.ref.vtable
       .elementAt(7)

--- a/lib/src/winrt/igamepadstatics.dart
+++ b/lib/src/winrt/igamepadstatics.dart
@@ -51,13 +51,13 @@ class IGamepadStatics extends IInspectable {
   IGamepadStatics(super.ptr);
 
   int add_GamepadAdded(Pointer value, Pointer<Uint32> result) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(6)
           .cast<Pointer<NativeFunction<_add_GamepadAdded_Native>>>()
           .value
           .asFunction<_add_GamepadAdded_Dart>()(ptr.ref.lpVtbl, value, result);
 
-  int remove_GamepadAdded(int token) => ptr.ref.lpVtbl.value
+  int remove_GamepadAdded(int token) => ptr.ref.vtable
       .elementAt(7)
       .cast<Pointer<NativeFunction<_remove_GamepadAdded_Native>>>()
       .value
@@ -70,7 +70,7 @@ class IGamepadStatics extends IInspectable {
       .value
       .asFunction<_add_GamepadRemoved_Dart>()(ptr.ref.lpVtbl, value, result);
 
-  int remove_GamepadRemoved(int token) => ptr.ref.lpVtbl.value
+  int remove_GamepadRemoved(int token) => ptr.ref.vtable
       .elementAt(9)
       .cast<Pointer<NativeFunction<_remove_GamepadRemoved_Native>>>()
       .value
@@ -80,7 +80,7 @@ class IGamepadStatics extends IInspectable {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(10)
           .cast<Pointer<NativeFunction<_get_Gamepads_Native>>>()
           .value

--- a/lib/src/winrt/inetworkinformationstatics.dart
+++ b/lib/src/winrt/inetworkinformationstatics.dart
@@ -41,7 +41,7 @@ class INetworkInformationStatics extends IInspectable {
   Pointer<COMObject> GetConnectionProfiles() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(6)
         .cast<
             Pointer<
@@ -68,7 +68,7 @@ class INetworkInformationStatics extends IInspectable {
   Pointer<COMObject> GetInternetConnectionProfile() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(7)
         .cast<
             Pointer<
@@ -95,7 +95,7 @@ class INetworkInformationStatics extends IInspectable {
   Pointer<COMObject> GetLanIdentifiers() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(8)
         .cast<
             Pointer<
@@ -122,7 +122,7 @@ class INetworkInformationStatics extends IInspectable {
   List<IHostName> GetHostNames() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(9)
         .cast<
             Pointer<
@@ -159,7 +159,7 @@ class INetworkInformationStatics extends IInspectable {
   ) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(10)
         .cast<
             Pointer<
@@ -192,7 +192,7 @@ class INetworkInformationStatics extends IInspectable {
   ) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(11)
         .cast<
             Pointer<
@@ -229,7 +229,7 @@ class INetworkInformationStatics extends IInspectable {
   //   final retValuePtr = calloc<EventRegistrationToken>();
 
   //   try {
-  //     final hr = ptr.ref.lpVtbl.value
+  //     final hr = ptr.ref.vtable
   //         .elementAt(12)
   //         .cast<
   //             Pointer<
@@ -265,7 +265,7 @@ class INetworkInformationStatics extends IInspectable {
   // void remove_NetworkStatusChanged(
   //   EventRegistrationToken eventCookie,
   // ) =>
-  //     ptr.ref.lpVtbl.value
+  //     ptr.ref.vtable
   //         .elementAt(13)
   //         .cast<
   //             Pointer<

--- a/lib/src/winrt/ipropertyvalue.dart
+++ b/lib/src/winrt/ipropertyvalue.dart
@@ -195,7 +195,7 @@ class IPropertyValue extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<Pointer<NativeFunction<_get_Type_Native>>>()
           .value
@@ -214,7 +214,7 @@ class IPropertyValue extends IInspectable {
     final retValuePtr = calloc< /* Boolean */ Uint8>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(7)
           .cast<Pointer<NativeFunction<_get_IsNumericScalar_Native>>>()
           .value
@@ -229,109 +229,109 @@ class IPropertyValue extends IInspectable {
     }
   }
 
-  int GetUInt8(Pointer<Uint8> result) => ptr.ref.lpVtbl.value
+  int GetUInt8(Pointer<Uint8> result) => ptr.ref.vtable
       .elementAt(8)
       .cast<Pointer<NativeFunction<_GetUInt8_Native>>>()
       .value
       .asFunction<_GetUInt8_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetInt16(Pointer<Int16> result) => ptr.ref.lpVtbl.value
+  int GetInt16(Pointer<Int16> result) => ptr.ref.vtable
       .elementAt(9)
       .cast<Pointer<NativeFunction<_GetInt16_Native>>>()
       .value
       .asFunction<_GetInt16_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetUInt16(Pointer<Uint16> result) => ptr.ref.lpVtbl.value
+  int GetUInt16(Pointer<Uint16> result) => ptr.ref.vtable
       .elementAt(10)
       .cast<Pointer<NativeFunction<_GetUInt16_Native>>>()
       .value
       .asFunction<_GetUInt16_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetInt32(Pointer<Int32> result) => ptr.ref.lpVtbl.value
+  int GetInt32(Pointer<Int32> result) => ptr.ref.vtable
       .elementAt(11)
       .cast<Pointer<NativeFunction<_GetInt32_Native>>>()
       .value
       .asFunction<_GetInt32_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetUInt32(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+  int GetUInt32(Pointer<Uint32> result) => ptr.ref.vtable
       .elementAt(12)
       .cast<Pointer<NativeFunction<_GetUInt32_Native>>>()
       .value
       .asFunction<_GetUInt32_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetInt64(Pointer<Int64> result) => ptr.ref.lpVtbl.value
+  int GetInt64(Pointer<Int64> result) => ptr.ref.vtable
       .elementAt(13)
       .cast<Pointer<NativeFunction<_GetInt64_Native>>>()
       .value
       .asFunction<_GetInt64_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetUInt64(Pointer<Uint64> result) => ptr.ref.lpVtbl.value
+  int GetUInt64(Pointer<Uint64> result) => ptr.ref.vtable
       .elementAt(14)
       .cast<Pointer<NativeFunction<_GetUInt64_Native>>>()
       .value
       .asFunction<_GetUInt64_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetSingle(Pointer<Float> result) => ptr.ref.lpVtbl.value
+  int GetSingle(Pointer<Float> result) => ptr.ref.vtable
       .elementAt(15)
       .cast<Pointer<NativeFunction<_GetSingle_Native>>>()
       .value
       .asFunction<_GetSingle_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetDouble(Pointer<Double> result) => ptr.ref.lpVtbl.value
+  int GetDouble(Pointer<Double> result) => ptr.ref.vtable
       .elementAt(16)
       .cast<Pointer<NativeFunction<_GetDouble_Native>>>()
       .value
       .asFunction<_GetDouble_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetChar16(Pointer<Uint16> result) => ptr.ref.lpVtbl.value
+  int GetChar16(Pointer<Uint16> result) => ptr.ref.vtable
       .elementAt(17)
       .cast<Pointer<NativeFunction<_GetChar16_Native>>>()
       .value
       .asFunction<_GetChar16_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetBoolean(Pointer< /* Boolean */ Uint8> result) => ptr.ref.lpVtbl.value
+  int GetBoolean(Pointer< /* Boolean */ Uint8> result) => ptr.ref.vtable
       .elementAt(18)
       .cast<Pointer<NativeFunction<_GetBoolean_Native>>>()
       .value
       .asFunction<_GetBoolean_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetString(Pointer<IntPtr> result) => ptr.ref.lpVtbl.value
+  int GetString(Pointer<IntPtr> result) => ptr.ref.vtable
       .elementAt(19)
       .cast<Pointer<NativeFunction<_GetString_Native>>>()
       .value
       .asFunction<_GetString_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetGuid(Pointer<GUID> result) => ptr.ref.lpVtbl.value
+  int GetGuid(Pointer<GUID> result) => ptr.ref.vtable
       .elementAt(20)
       .cast<Pointer<NativeFunction<_GetGuid_Native>>>()
       .value
       .asFunction<_GetGuid_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetDateTime(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+  int GetDateTime(Pointer<Uint32> result) => ptr.ref.vtable
       .elementAt(21)
       .cast<Pointer<NativeFunction<_GetDateTime_Native>>>()
       .value
       .asFunction<_GetDateTime_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetTimeSpan(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+  int GetTimeSpan(Pointer<Uint32> result) => ptr.ref.vtable
       .elementAt(22)
       .cast<Pointer<NativeFunction<_GetTimeSpan_Native>>>()
       .value
       .asFunction<_GetTimeSpan_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetPoint(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+  int GetPoint(Pointer<Uint32> result) => ptr.ref.vtable
       .elementAt(23)
       .cast<Pointer<NativeFunction<_GetPoint_Native>>>()
       .value
       .asFunction<_GetPoint_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetSize(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+  int GetSize(Pointer<Uint32> result) => ptr.ref.vtable
       .elementAt(24)
       .cast<Pointer<NativeFunction<_GetSize_Native>>>()
       .value
       .asFunction<_GetSize_Dart>()(ptr.ref.lpVtbl, result);
 
-  int GetRect(Pointer<Uint32> result) => ptr.ref.lpVtbl.value
+  int GetRect(Pointer<Uint32> result) => ptr.ref.vtable
       .elementAt(25)
       .cast<Pointer<NativeFunction<_GetRect_Native>>>()
       .value
@@ -409,7 +409,7 @@ class IPropertyValue extends IInspectable {
 
   int GetBooleanArray(
           Pointer<Uint32> __valueSize, Pointer< /* Boolean */ Uint8> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(36)
               .cast<Pointer<NativeFunction<_GetBooleanArray_Native>>>()
               .value
@@ -425,7 +425,7 @@ class IPropertyValue extends IInspectable {
 
   int GetInspectableArray(
           Pointer<Uint32> __valueSize, Pointer<COMObject> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(38)
               .cast<Pointer<NativeFunction<_GetInspectableArray_Native>>>()
               .value
@@ -433,14 +433,14 @@ class IPropertyValue extends IInspectable {
           ptr.ref.lpVtbl, __valueSize, value);
 
   int GetGuidArray(Pointer<Uint32> __valueSize, Pointer<GUID> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(39)
           .cast<Pointer<NativeFunction<_GetGuidArray_Native>>>()
           .value
           .asFunction<_GetGuidArray_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
   int GetDateTimeArray(Pointer<Uint32> __valueSize, Pointer<Uint32> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(40)
               .cast<Pointer<NativeFunction<_GetDateTimeArray_Native>>>()
               .value
@@ -448,7 +448,7 @@ class IPropertyValue extends IInspectable {
           ptr.ref.lpVtbl, __valueSize, value);
 
   int GetTimeSpanArray(Pointer<Uint32> __valueSize, Pointer<Uint32> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(41)
               .cast<Pointer<NativeFunction<_GetTimeSpanArray_Native>>>()
               .value
@@ -463,14 +463,14 @@ class IPropertyValue extends IInspectable {
       .asFunction<_GetPointArray_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
   int GetSizeArray(Pointer<Uint32> __valueSize, Pointer<Uint32> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(43)
           .cast<Pointer<NativeFunction<_GetSizeArray_Native>>>()
           .value
           .asFunction<_GetSizeArray_Dart>()(ptr.ref.lpVtbl, __valueSize, value);
 
   int GetRectArray(Pointer<Uint32> __valueSize, Pointer<Uint32> value) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(44)
           .cast<Pointer<NativeFunction<_GetRectArray_Native>>>()
           .value

--- a/lib/src/winrt/ivector.dart
+++ b/lib/src/winrt/ivector.dart
@@ -113,7 +113,7 @@ class IVector<T> extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -145,7 +145,7 @@ class IVector<T> extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -173,7 +173,7 @@ class IVector<T> extends IInspectable {
   List<T> get GetView {
     final retValuePtr = allocator<COMObject>();
 
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(8)
         .cast<
             Pointer<
@@ -250,7 +250,7 @@ class IVector<T> extends IInspectable {
     final hValue = convertToHString(value);
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
@@ -293,7 +293,7 @@ class IVector<T> extends IInspectable {
   }
 
   void _SetAt_COMObject(int index, T value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(10)
         .cast<
             Pointer<
@@ -317,7 +317,7 @@ class IVector<T> extends IInspectable {
     final hValue = convertToHString(value);
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -358,7 +358,7 @@ class IVector<T> extends IInspectable {
   }
 
   void _InsertAt_COMObject(int index, T value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(11)
         .cast<
             Pointer<
@@ -382,7 +382,7 @@ class IVector<T> extends IInspectable {
     final hValue = convertToHString(value);
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -406,7 +406,7 @@ class IVector<T> extends IInspectable {
   }
 
   void RemoveAt(int index) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(12)
         .cast<
             Pointer<
@@ -437,7 +437,7 @@ class IVector<T> extends IInspectable {
   }
 
   void _Append_COMObject(T value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
             .elementAt(13)
             .cast<
                 Pointer<
@@ -457,7 +457,7 @@ class IVector<T> extends IInspectable {
     final hValue = convertToHString(value);
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(13)
           .cast<
               Pointer<
@@ -476,7 +476,7 @@ class IVector<T> extends IInspectable {
   }
 
   void RemoveAtEnd() {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(14)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
@@ -486,7 +486,7 @@ class IVector<T> extends IInspectable {
   }
 
   void Clear() {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(15)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
@@ -547,7 +547,7 @@ class IVector<T> extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
               .elementAt(16)
               .cast<
                   Pointer<
@@ -599,7 +599,7 @@ class IVector<T> extends IInspectable {
     }
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(17)
           .cast<
               Pointer<
@@ -632,7 +632,7 @@ class IVector<T> extends IInspectable {
     }
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(17)
           .cast<
               Pointer<

--- a/lib/src/winrt/ivectorview.dart
+++ b/lib/src/winrt/ivectorview.dart
@@ -109,7 +109,7 @@ class IVectorView<T> extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -141,7 +141,7 @@ class IVectorView<T> extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -221,7 +221,7 @@ class IVectorView<T> extends IInspectable {
     final hValue = convertToHString(value);
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -308,7 +308,7 @@ class IVectorView<T> extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<

--- a/lib/src/winrt/toastnotification.dart
+++ b/lib/src/winrt/toastnotification.dart
@@ -73,7 +73,7 @@ class ToastNotification extends IInspectable {
     final retValuePtr = calloc<Pointer>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<Pointer<NativeFunction<_get_Content_Native>>>()
           .value
@@ -89,7 +89,7 @@ class ToastNotification extends IInspectable {
   }
 
   set ExpirationTime(int value) {
-    final hr = ptr.ref.lpVtbl.value
+    final hr = ptr.ref.vtable
         .elementAt(7)
         .cast<Pointer<NativeFunction<_put_ExpirationTime_Native>>>()
         .value
@@ -102,7 +102,7 @@ class ToastNotification extends IInspectable {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(8)
           .cast<Pointer<NativeFunction<_get_ExpirationTime_Native>>>()
           .value
@@ -118,39 +118,39 @@ class ToastNotification extends IInspectable {
   }
 
   int add_Dismissed(Pointer handler, Pointer<Uint32> result) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(9)
           .cast<Pointer<NativeFunction<_add_Dismissed_Native>>>()
           .value
           .asFunction<_add_Dismissed_Dart>()(ptr.ref.lpVtbl, handler, result);
 
-  int remove_Dismissed(int token) => ptr.ref.lpVtbl.value
+  int remove_Dismissed(int token) => ptr.ref.vtable
       .elementAt(10)
       .cast<Pointer<NativeFunction<_remove_Dismissed_Native>>>()
       .value
       .asFunction<_remove_Dismissed_Dart>()(ptr.ref.lpVtbl, token);
 
   int add_Activated(Pointer handler, Pointer<Uint32> result) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(11)
           .cast<Pointer<NativeFunction<_add_Activated_Native>>>()
           .value
           .asFunction<_add_Activated_Dart>()(ptr.ref.lpVtbl, handler, result);
 
-  int remove_Activated(int token) => ptr.ref.lpVtbl.value
+  int remove_Activated(int token) => ptr.ref.vtable
       .elementAt(12)
       .cast<Pointer<NativeFunction<_remove_Activated_Native>>>()
       .value
       .asFunction<_remove_Activated_Dart>()(ptr.ref.lpVtbl, token);
 
   int add_Failed(Pointer handler, Pointer<Uint32> result) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
           .elementAt(13)
           .cast<Pointer<NativeFunction<_add_Failed_Native>>>()
           .value
           .asFunction<_add_Failed_Dart>()(ptr.ref.lpVtbl, handler, result);
 
-  int remove_Failed(int token) => ptr.ref.lpVtbl.value
+  int remove_Failed(int token) => ptr.ref.vtable
       .elementAt(14)
       .cast<Pointer<NativeFunction<_remove_Failed_Native>>>()
       .value

--- a/lib/src/winrt/toastnotification.dart
+++ b/lib/src/winrt/toastnotification.dart
@@ -117,12 +117,11 @@ class ToastNotification extends IInspectable {
     }
   }
 
-  int add_Dismissed(Pointer handler, Pointer<Uint32> result) =>
-      ptr.ref.vtable
-          .elementAt(9)
-          .cast<Pointer<NativeFunction<_add_Dismissed_Native>>>()
-          .value
-          .asFunction<_add_Dismissed_Dart>()(ptr.ref.lpVtbl, handler, result);
+  int add_Dismissed(Pointer handler, Pointer<Uint32> result) => ptr.ref.vtable
+      .elementAt(9)
+      .cast<Pointer<NativeFunction<_add_Dismissed_Native>>>()
+      .value
+      .asFunction<_add_Dismissed_Dart>()(ptr.ref.lpVtbl, handler, result);
 
   int remove_Dismissed(int token) => ptr.ref.vtable
       .elementAt(10)
@@ -130,12 +129,11 @@ class ToastNotification extends IInspectable {
       .value
       .asFunction<_remove_Dismissed_Dart>()(ptr.ref.lpVtbl, token);
 
-  int add_Activated(Pointer handler, Pointer<Uint32> result) =>
-      ptr.ref.vtable
-          .elementAt(11)
-          .cast<Pointer<NativeFunction<_add_Activated_Native>>>()
-          .value
-          .asFunction<_add_Activated_Dart>()(ptr.ref.lpVtbl, handler, result);
+  int add_Activated(Pointer handler, Pointer<Uint32> result) => ptr.ref.vtable
+      .elementAt(11)
+      .cast<Pointer<NativeFunction<_add_Activated_Native>>>()
+      .value
+      .asFunction<_add_Activated_Dart>()(ptr.ref.lpVtbl, handler, result);
 
   int remove_Activated(int token) => ptr.ref.vtable
       .elementAt(12)
@@ -143,12 +141,11 @@ class ToastNotification extends IInspectable {
       .value
       .asFunction<_remove_Activated_Dart>()(ptr.ref.lpVtbl, token);
 
-  int add_Failed(Pointer handler, Pointer<Uint32> result) =>
-      ptr.ref.vtable
-          .elementAt(13)
-          .cast<Pointer<NativeFunction<_add_Failed_Native>>>()
-          .value
-          .asFunction<_add_Failed_Dart>()(ptr.ref.lpVtbl, handler, result);
+  int add_Failed(Pointer handler, Pointer<Uint32> result) => ptr.ref.vtable
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<_add_Failed_Native>>>()
+      .value
+      .asFunction<_add_Failed_Dart>()(ptr.ref.lpVtbl, handler, result);
 
   int remove_Failed(int token) => ptr.ref.vtable
       .elementAt(14)

--- a/test/winrt_collections_test.dart
+++ b/test/winrt_collections_test.dart
@@ -257,7 +257,7 @@ void main() {
           Pointer<COMObject> ptr, Allocator allocator) {
         final retValuePtr = allocator<COMObject>();
 
-        final hr = ptr.ref.lpVtbl.value
+        final hr = ptr.ref.vtable
             .elementAt(9)
             .cast<
                 Pointer<
@@ -341,7 +341,7 @@ void main() {
           Pointer<COMObject> ptr, Allocator allocator) {
         final retValuePtr = allocator<COMObject>();
 
-        final hr = ptr.ref.lpVtbl.value
+        final hr = ptr.ref.vtable
             .elementAt(9)
             .cast<
                 Pointer<

--- a/tool/generator/lib/src/projection/com_method.dart
+++ b/tool/generator/lib/src/projection/com_method.dart
@@ -42,7 +42,7 @@ class ComMethodProjection extends MethodProjection {
   String toString() {
     try {
       return '''
-      ${returnType.dartType} $name($methodParams) => ptr.ref.lpVtbl.value
+      ${returnType.dartType} $name($methodParams) => ptr.ref.vtable
         .elementAt($vtableOffset)
         .cast<Pointer<NativeFunction<$nativePrototype>>>()
         .value

--- a/tool/generator/lib/src/projection/com_property.dart
+++ b/tool/generator/lib/src/projection/com_property.dart
@@ -32,7 +32,7 @@ class ComGetPropertyProjection extends ComPropertyProjection {
         final retValuePtr = calloc<${returnValue.nativeType}>();
         
         try {
-          final hr = ptr.ref.lpVtbl.value
+          final hr = ptr.ref.vtable
             .elementAt($vtableOffset)
             .cast<Pointer<NativeFunction<$nativePrototype>>>()
             .value
@@ -56,7 +56,7 @@ class ComSetPropertyProjection extends ComPropertyProjection {
   @override
   String toString() => '''
     set $exposedMethodName(${parameters.first.type.dartType} value) {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
         .elementAt($vtableOffset)
         .cast<Pointer<NativeFunction<$nativePrototype>>>()
         .value

--- a/tool/generator/test/goldens/inetwork.golden
+++ b/tool/generator/test/goldens/inetwork.golden
@@ -32,7 +32,7 @@ class INetwork extends IDispatch {
   // vtable begins at 7, is 13 entries long.
   INetwork(super.ptr);
 
-  int GetName(Pointer<Pointer<Utf16>> pszNetworkName) => ptr.ref.lpVtbl.value
+  int GetName(Pointer<Pointer<Utf16>> pszNetworkName) => ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -45,7 +45,7 @@ class INetwork extends IDispatch {
       ptr.ref.lpVtbl, pszNetworkName);
 
   int SetName(Pointer<Utf16> szNetworkNewName) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -57,8 +57,7 @@ class INetwork extends IDispatch {
                   int Function(Pointer, Pointer<Utf16> szNetworkNewName)>()(
           ptr.ref.lpVtbl, szNetworkNewName);
 
-  int GetDescription(Pointer<Pointer<Utf16>> pszDescription) => ptr
-          .ref.lpVtbl.value
+  int GetDescription(Pointer<Pointer<Utf16>> pszDescription) => ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
@@ -70,7 +69,7 @@ class INetwork extends IDispatch {
               int Function(Pointer, Pointer<Pointer<Utf16>> pszDescription)>()(
       ptr.ref.lpVtbl, pszDescription);
 
-  int SetDescription(Pointer<Utf16> szDescription) => ptr.ref.lpVtbl.value
+  int SetDescription(Pointer<Utf16> szDescription) => ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -81,7 +80,7 @@ class INetwork extends IDispatch {
       ptr.ref.lpVtbl, szDescription);
 
   int GetNetworkId(Pointer<GUID> pgdGuidNetworkId) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -93,7 +92,7 @@ class INetwork extends IDispatch {
                   int Function(Pointer, Pointer<GUID> pgdGuidNetworkId)>()(
           ptr.ref.lpVtbl, pgdGuidNetworkId);
 
-  int GetDomainType(Pointer<Int32> pNetworkType) => ptr.ref.lpVtbl.value
+  int GetDomainType(Pointer<Int32> pNetworkType) => ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
@@ -106,7 +105,7 @@ class INetwork extends IDispatch {
   int GetNetworkConnections(
           Pointer<Pointer<COMObject>> ppEnumNetworkConnection) =>
       ptr
-              .ref.lpVtbl.value
+              .ref.vtable
               .elementAt(13)
               .cast<
                   Pointer<
@@ -126,7 +125,7 @@ class INetwork extends IDispatch {
           Pointer<Uint32> pdwHighDateTimeCreated,
           Pointer<Uint32> pdwLowDateTimeConnected,
           Pointer<Uint32> pdwHighDateTimeConnected) =>
-      ptr.ref.lpVtbl.value
+      ptr.ref.vtable
               .elementAt(14)
               .cast<
                   Pointer<
@@ -155,7 +154,7 @@ class INetwork extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(15)
           .cast<
               Pointer<
@@ -179,7 +178,7 @@ class INetwork extends IDispatch {
     final retValuePtr = calloc<Int16>();
 
     try {
-      final hr = ptr.ref.lpVtbl.value
+      final hr = ptr.ref.vtable
           .elementAt(16)
           .cast<
               Pointer<
@@ -199,7 +198,7 @@ class INetwork extends IDispatch {
     }
   }
 
-  int GetConnectivity(Pointer<Int32> pConnectivity) => ptr.ref.lpVtbl.value
+  int GetConnectivity(Pointer<Int32> pConnectivity) => ptr.ref.vtable
           .elementAt(17)
           .cast<
               Pointer<
@@ -209,7 +208,7 @@ class INetwork extends IDispatch {
           .asFunction<int Function(Pointer, Pointer<Int32> pConnectivity)>()(
       ptr.ref.lpVtbl, pConnectivity);
 
-  int GetCategory(Pointer<Int32> pCategory) => ptr.ref.lpVtbl.value
+  int GetCategory(Pointer<Int32> pCategory) => ptr.ref.vtable
           .elementAt(18)
           .cast<
               Pointer<
@@ -219,7 +218,7 @@ class INetwork extends IDispatch {
           .asFunction<int Function(Pointer, Pointer<Int32> pCategory)>()(
       ptr.ref.lpVtbl, pCategory);
 
-  int SetCategory(int NewCategory) => ptr.ref.lpVtbl.value
+  int SetCategory(int NewCategory) => ptr.ref.vtable
       .elementAt(19)
       .cast<
           Pointer<NativeFunction<Int32 Function(Pointer, Int32 NewCategory)>>>()


### PR DESCRIPTION
Since you recently updated the generator to use the `vtable` getter on the `WinRT` projection, I thought it would be a good idea to also use it on the `COM` projection for consistency.