### PR TITLE
Project WinRT structs

### DIFF
--- a/example/shell_notify_icon/_menu.dart
+++ b/example/shell_notify_icon/_menu.dart
@@ -2,7 +2,7 @@ import 'dart:ffi';
 import 'dart:math';
 
 import 'package:ffi/ffi.dart';
-import 'package:win32/win32.dart';
+import 'package:win32/win32.dart' hide Point;
 
 import '_app.dart' as app;
 import '_tray.dart' as tray;

--- a/example/tetris/pieceset.dart
+++ b/example/tetris/pieceset.dart
@@ -1,6 +1,6 @@
 import 'dart:math' show Random;
 
-import 'package:win32/win32.dart';
+import 'package:win32/win32.dart' hide Point;
 
 import 'piece.dart';
 

--- a/lib/src/winrt/structs.g.dart
+++ b/lib/src/winrt/structs.g.dart
@@ -1,0 +1,214 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart representations of common structs used in the Windows Runtime APIs.
+
+// THIS FILE IS GENERATED AUTOMATICALLY AND SHOULD NOT BE EDITED DIRECTLY.
+
+// ignore_for_file: camel_case_extensions, camel_case_types
+// ignore_for_file: directives_ordering, unnecessary_getters_setters
+// ignore_for_file: unused_field, unused_import
+// ignore_for_file: non_constant_identifier_names
+
+import 'dart:ffi';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart';
+
+/// Describes a 3*2 floating point matrix.
+///
+/// {@category Struct}
+class Matrix3x2 extends Struct {
+  @Float()
+  external double M11;
+
+  @Float()
+  external double M12;
+
+  @Float()
+  external double M21;
+
+  @Float()
+  external double M22;
+
+  @Float()
+  external double M31;
+
+  @Float()
+  external double M32;
+}
+
+/// Describes a 4*4 floating point matrix.
+///
+/// {@category Struct}
+class Matrix4x4 extends Struct {
+  @Float()
+  external double M11;
+
+  @Float()
+  external double M12;
+
+  @Float()
+  external double M13;
+
+  @Float()
+  external double M14;
+
+  @Float()
+  external double M21;
+
+  @Float()
+  external double M22;
+
+  @Float()
+  external double M23;
+
+  @Float()
+  external double M24;
+
+  @Float()
+  external double M31;
+
+  @Float()
+  external double M32;
+
+  @Float()
+  external double M33;
+
+  @Float()
+  external double M34;
+
+  @Float()
+  external double M41;
+
+  @Float()
+  external double M42;
+
+  @Float()
+  external double M43;
+
+  @Float()
+  external double M44;
+}
+
+/// Describes a plane (a flat, two-dimensional surface).
+///
+/// {@category Struct}
+class Plane extends Struct {
+  external Vector3 Normal;
+
+  @Float()
+  external double D;
+}
+
+/// Represents an x- and y-coordinate pair in two-dimensional space. Can
+/// also represent a logical point for certain property usages.
+///
+/// {@category Struct}
+class Point extends Struct {
+  @Float()
+  external double X;
+
+  @Float()
+  external double Y;
+}
+
+/// Describes a quaternion, which is an abstract representation of an
+/// orientation in space that is based on complex numbers.
+///
+/// {@category Struct}
+class Quaternion extends Struct {
+  @Float()
+  external double X;
+
+  @Float()
+  external double Y;
+
+  @Float()
+  external double Z;
+
+  @Float()
+  external double W;
+}
+
+/// Describes a number that can be created by the division of 2 integers.
+///
+/// {@category Struct}
+class Rational extends Struct {
+  @Uint32()
+  external int Numerator;
+
+  @Uint32()
+  external int Denominator;
+}
+
+/// Describes the width, height, and point origin of a rectangle.
+///
+/// {@category Struct}
+class Rect extends Struct {
+  @Float()
+  external double X;
+
+  @Float()
+  external double Y;
+
+  @Float()
+  external double Width;
+
+  @Float()
+  external double Height;
+}
+
+/// Describes the width and height of an object.
+///
+/// {@category Struct}
+class Size extends Struct {
+  @Float()
+  external double Width;
+
+  @Float()
+  external double Height;
+}
+
+/// Describes a vector of two floating-point components.
+///
+/// {@category Struct}
+class Vector2 extends Struct {
+  @Float()
+  external double X;
+
+  @Float()
+  external double Y;
+}
+
+/// Describes a vector of three floating-point components.
+///
+/// {@category Struct}
+class Vector3 extends Struct {
+  @Float()
+  external double X;
+
+  @Float()
+  external double Y;
+
+  @Float()
+  external double Z;
+}
+
+/// Describes a vector of four floating-point components.
+///
+/// {@category Struct}
+class Vector4 extends Struct {
+  @Float()
+  external double X;
+
+  @Float()
+  external double Y;
+
+  @Float()
+  external double Z;
+
+  @Float()
+  external double W;
+}

--- a/lib/win32.dart
+++ b/lib/win32.dart
@@ -142,6 +142,7 @@ export 'src/api_ms_win_wsl_api_l1_1_0.dart';
 
 // COM and Windows Runtime foundational exports
 export 'src/combase.dart';
+export 'src/winrt/structs.g.dart';
 export 'src/winrt_constants.dart';
 export 'src/winrt_helpers.dart';
 

--- a/tool/generator/lib/src/inputs/structs.dart
+++ b/tool/generator/lib/src/inputs/structs.dart
@@ -590,3 +590,27 @@ const structsToGenerate = <String, String>{
   "Windows.Win32.UI.Input.XboxController.XINPUT_VIBRATION":
       "Specifies motor speed levels for the vibration function of a controller."
 };
+
+const windowsRuntimeStructsToGenerate = <String, String>{
+  "Windows.Foundation.Numerics.Matrix3x2":
+      "Describes a 3*2 floating point matrix.",
+  "Windows.Foundation.Numerics.Matrix4x4":
+      "Describes a 4*4 floating point matrix.",
+  "Windows.Foundation.Numerics.Plane":
+      "Describes a plane (a flat, two-dimensional surface).",
+  "Windows.Foundation.Numerics.Quaternion":
+      "Describes a quaternion, which is an abstract representation of an orientation in space that is based on complex numbers.",
+  "Windows.Foundation.Numerics.Rational":
+      "Describes a number that can be created by the division of 2 integers.",
+  "Windows.Foundation.Numerics.Vector2":
+      "Describes a vector of two floating-point components.",
+  "Windows.Foundation.Numerics.Vector3":
+      "Describes a vector of three floating-point components.",
+  "Windows.Foundation.Numerics.Vector4":
+      "Describes a vector of four floating-point components.",
+  "Windows.Foundation.Point":
+      "Represents an x- and y-coordinate pair in two-dimensional space. Can also represent a logical point for certain property usages.",
+  "Windows.Foundation.Rect":
+      "Describes the width, height, and point origin of a rectangle.",
+  "Windows.Foundation.Size": "Describes the width and height of an object.",
+};

--- a/tool/generator/lib/src/projection/headers.dart
+++ b/tool/generator/lib/src/projection/headers.dart
@@ -51,6 +51,24 @@ import 'oleaut32.dart';
 import 'structs.dart';
 ''';
 
+const winrtStructFileHeader = '''
+$copyrightHeader
+
+// Dart representations of common structs used in the Windows Runtime APIs.
+
+// THIS FILE IS GENERATED AUTOMATICALLY AND SHOULD NOT BE EDITED DIRECTLY.
+
+// ignore_for_file: camel_case_extensions, camel_case_types
+// ignore_for_file: directives_ordering, unnecessary_getters_setters
+// ignore_for_file: unused_field, unused_import
+// ignore_for_file: non_constant_identifier_names
+
+import 'dart:ffi';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart';
+''';
+
 const testFunctionsHeader = '''
 $copyrightHeader
 


### PR DESCRIPTION
Added support for generating WinRT structs automatically. For now, I've only projected the structs within the `Windows.Foundation` namespace. I specifically need `Point`, `Size`, and `Rect` structs to extend the supported types of `IVector` & `IVectorView` and also for adding support for the `IMap` & `IMapView` interfaces.