### PR TITLE
Update WinRT generation

### DIFF
--- a/lib/src/winrt/calendar.dart
+++ b/lib/src/winrt/calendar.dart
@@ -28,10 +28,7 @@ import 'icalendarfactory.dart';
 import 'icalendarfactory2.dart';
 import '../com/iinspectable.dart';
 
-/// @nodoc
-const IID_Calendar = 'null';
-
-/// {@category Interface}
+/// {@category Class}
 /// {@category winrt}
 class Calendar extends IInspectable implements ICalendar, ITimeZoneOnCalendar {
   Calendar({Allocator allocator = calloc})

--- a/lib/src/winrt/iapplicationdatastatics.dart
+++ b/lib/src/winrt/iapplicationdatastatics.dart
@@ -33,13 +33,10 @@ class IApplicationDataStatics extends IInspectable {
   // vtable begins at 6, is 1 entries long.
   IApplicationDataStatics(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr =
-      toInterface(IID_IApplicationDataStatics);
-
   Pointer<COMObject> get Current {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -47,7 +44,7 @@ class IApplicationDataStatics extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/iasyncinfo.dart
+++ b/lib/src/winrt/iasyncinfo.dart
@@ -33,21 +33,19 @@ class IAsyncInfo extends IInspectable {
   // vtable begins at 6, is 5 entries long.
   IAsyncInfo(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IAsyncInfo);
-
   int get Id {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<Uint32>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<Uint32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<Uint32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -62,7 +60,7 @@ class IAsyncInfo extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
@@ -70,7 +68,7 @@ class IAsyncInfo extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -85,7 +83,7 @@ class IAsyncInfo extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -93,7 +91,7 @@ class IAsyncInfo extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -105,21 +103,21 @@ class IAsyncInfo extends IInspectable {
   }
 
   void Cancel() {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(9)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
-        .asFunction<int Function(Pointer)>()(_thisPtr.ref.lpVtbl);
+        .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void Close() {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(10)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
-        .asFunction<int Function(Pointer)>()(_thisPtr.ref.lpVtbl);
+        .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/lib/src/winrt/icalendar.dart
+++ b/lib/src/winrt/icalendar.dart
@@ -33,12 +33,10 @@ class ICalendar extends IInspectable {
   // vtable begins at 6, is 98 entries long.
   ICalendar(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_ICalendar);
-
   Pointer<COMObject> Clone() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -46,7 +44,7 @@ class ICalendar extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -54,21 +52,21 @@ class ICalendar extends IInspectable {
   }
 
   void SetToMin() {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(7)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
-        .asFunction<int Function(Pointer)>()(_thisPtr.ref.lpVtbl);
+        .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void SetToMax() {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(8)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
-        .asFunction<int Function(Pointer)>()(_thisPtr.ref.lpVtbl);
+        .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -76,7 +74,7 @@ class ICalendar extends IInspectable {
   List<String> get Languages {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(9)
             .cast<
                 Pointer<
@@ -84,7 +82,7 @@ class ICalendar extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -99,15 +97,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -123,11 +121,11 @@ class ICalendar extends IInspectable {
     final hstr = convertToHString(value);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(11)
           .cast<Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr)>>>()
           .value
-          .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, hstr);
+          .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, hstr);
 
       if (FAILED(hr)) throw WindowsException(hr);
     } finally {
@@ -139,15 +137,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -161,14 +159,13 @@ class ICalendar extends IInspectable {
 
   void ChangeCalendarSystem(String value) {
     final valueHstring = convertToHString(value);
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(13)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr value)>>>()
         .value
         .asFunction<
-            int Function(
-                Pointer, int value)>()(_thisPtr.ref.lpVtbl, valueHstring);
+            int Function(Pointer, int value)>()(ptr.ref.lpVtbl, valueHstring);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -179,15 +176,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(14)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -201,14 +198,13 @@ class ICalendar extends IInspectable {
 
   void ChangeClock(String value) {
     final valueHstring = convertToHString(value);
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(15)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr value)>>>()
         .value
         .asFunction<
-            int Function(
-                Pointer, int value)>()(_thisPtr.ref.lpVtbl, valueHstring);
+            int Function(Pointer, int value)>()(ptr.ref.lpVtbl, valueHstring);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -219,15 +215,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Uint64>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(16)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<Uint64>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<Uint64>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<Uint64>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -241,24 +237,23 @@ class ICalendar extends IInspectable {
   void SetDateTime(DateTime value) {
     final valueDateTime =
         value.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(17)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, Uint64 value)>>>()
         .value
         .asFunction<
-            int Function(
-                Pointer, int value)>()(_thisPtr.ref.lpVtbl, valueDateTime);
+            int Function(Pointer, int value)>()(ptr.ref.lpVtbl, valueDateTime);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void SetToNow() {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(18)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
-        .asFunction<int Function(Pointer)>()(_thisPtr.ref.lpVtbl);
+        .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -267,7 +262,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(19)
           .cast<
               Pointer<
@@ -275,7 +270,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -290,7 +285,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(20)
           .cast<
               Pointer<
@@ -298,7 +293,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -313,7 +308,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(21)
           .cast<
               Pointer<
@@ -321,7 +316,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -336,7 +331,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(22)
           .cast<
               Pointer<
@@ -344,7 +339,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -356,22 +351,21 @@ class ICalendar extends IInspectable {
   }
 
   set Era(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(23)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddEras(int eras) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(24)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32 eras)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int eras)>()(_thisPtr.ref.lpVtbl, eras);
+        .asFunction<int Function(Pointer, int eras)>()(ptr.ref.lpVtbl, eras);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -380,15 +374,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(25)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -404,7 +398,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(26)
               .cast<
                   Pointer<
@@ -414,7 +408,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -430,7 +424,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(27)
           .cast<
               Pointer<
@@ -438,7 +432,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -453,7 +447,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(28)
           .cast<
               Pointer<
@@ -461,7 +455,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -476,7 +470,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(29)
           .cast<
               Pointer<
@@ -484,7 +478,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -499,7 +493,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(30)
           .cast<
               Pointer<
@@ -507,7 +501,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -519,22 +513,21 @@ class ICalendar extends IInspectable {
   }
 
   set Year(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(31)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddYears(int years) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(32)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32 years)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int years)>()(_thisPtr.ref.lpVtbl, years);
+        .asFunction<int Function(Pointer, int years)>()(ptr.ref.lpVtbl, years);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -543,15 +536,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(33)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -567,7 +560,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(34)
               .cast<
                   Pointer<
@@ -578,7 +571,7 @@ class ICalendar extends IInspectable {
               .asFunction<
                   int Function(
                       Pointer, int remainingDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, remainingDigits, retValuePtr);
+          ptr.ref.lpVtbl, remainingDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -594,7 +587,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(35)
               .cast<
                   Pointer<
@@ -604,7 +597,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -620,7 +613,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(36)
           .cast<
               Pointer<
@@ -628,7 +621,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -643,7 +636,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(37)
           .cast<
               Pointer<
@@ -651,7 +644,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -666,7 +659,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(38)
           .cast<
               Pointer<
@@ -674,7 +667,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -689,7 +682,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(39)
           .cast<
               Pointer<
@@ -697,7 +690,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -709,23 +702,23 @@ class ICalendar extends IInspectable {
   }
 
   set Month(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(40)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddMonths(int months) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(41)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, Int32 months)>>>()
         .value
         .asFunction<
-            int Function(Pointer, int months)>()(_thisPtr.ref.lpVtbl, months);
+            int Function(Pointer, int months)>()(ptr.ref.lpVtbl, months);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -734,15 +727,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(42)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -758,7 +751,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(43)
               .cast<
                   Pointer<
@@ -768,7 +761,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -784,15 +777,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(44)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -808,7 +801,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(45)
               .cast<
                   Pointer<
@@ -818,7 +811,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -834,15 +827,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(46)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -858,7 +851,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(47)
               .cast<
                   Pointer<
@@ -868,7 +861,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -881,12 +874,11 @@ class ICalendar extends IInspectable {
   }
 
   void AddWeeks(int weeks) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(48)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32 weeks)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int weeks)>()(_thisPtr.ref.lpVtbl, weeks);
+        .asFunction<int Function(Pointer, int weeks)>()(ptr.ref.lpVtbl, weeks);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -895,7 +887,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(49)
           .cast<
               Pointer<
@@ -903,7 +895,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -918,7 +910,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(50)
           .cast<
               Pointer<
@@ -926,7 +918,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -941,7 +933,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(51)
           .cast<
               Pointer<
@@ -949,7 +941,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -964,7 +956,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(52)
           .cast<
               Pointer<
@@ -972,7 +964,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -984,22 +976,21 @@ class ICalendar extends IInspectable {
   }
 
   set Day(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(53)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddDays(int days) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(54)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32 days)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int days)>()(_thisPtr.ref.lpVtbl, days);
+        .asFunction<int Function(Pointer, int days)>()(ptr.ref.lpVtbl, days);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1008,15 +999,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(55)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1032,7 +1023,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(56)
               .cast<
                   Pointer<
@@ -1042,7 +1033,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1058,7 +1049,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(57)
           .cast<
               Pointer<
@@ -1066,7 +1057,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1081,15 +1072,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(58)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1105,7 +1096,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(59)
               .cast<
                   Pointer<
@@ -1115,7 +1106,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1131,15 +1122,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(60)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1155,7 +1146,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(61)
               .cast<
                   Pointer<
@@ -1165,7 +1156,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1181,7 +1172,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(62)
           .cast<
               Pointer<
@@ -1189,7 +1180,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1204,7 +1195,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(63)
           .cast<
               Pointer<
@@ -1212,7 +1203,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1227,7 +1218,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(64)
           .cast<
               Pointer<
@@ -1235,7 +1226,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1250,7 +1241,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(65)
           .cast<
               Pointer<
@@ -1258,7 +1249,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1270,23 +1261,23 @@ class ICalendar extends IInspectable {
   }
 
   set Period(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(66)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddPeriods(int periods) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(67)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, Int32 periods)>>>()
         .value
         .asFunction<
-            int Function(Pointer, int periods)>()(_thisPtr.ref.lpVtbl, periods);
+            int Function(Pointer, int periods)>()(ptr.ref.lpVtbl, periods);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1295,15 +1286,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(68)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1319,7 +1310,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(69)
               .cast<
                   Pointer<
@@ -1329,7 +1320,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1345,7 +1336,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(70)
           .cast<
               Pointer<
@@ -1353,7 +1344,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1368,7 +1359,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(71)
           .cast<
               Pointer<
@@ -1376,7 +1367,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1391,7 +1382,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(72)
           .cast<
               Pointer<
@@ -1399,7 +1390,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1414,7 +1405,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(73)
           .cast<
               Pointer<
@@ -1422,7 +1413,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1434,22 +1425,21 @@ class ICalendar extends IInspectable {
   }
 
   set Hour(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(74)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddHours(int hours) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(75)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32 hours)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int hours)>()(_thisPtr.ref.lpVtbl, hours);
+        .asFunction<int Function(Pointer, int hours)>()(ptr.ref.lpVtbl, hours);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1458,15 +1448,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(76)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1482,7 +1472,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(77)
               .cast<
                   Pointer<
@@ -1492,7 +1482,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1508,7 +1498,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(78)
           .cast<
               Pointer<
@@ -1516,7 +1506,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1528,23 +1518,23 @@ class ICalendar extends IInspectable {
   }
 
   set Minute(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(79)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddMinutes(int minutes) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(80)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, Int32 minutes)>>>()
         .value
         .asFunction<
-            int Function(Pointer, int minutes)>()(_thisPtr.ref.lpVtbl, minutes);
+            int Function(Pointer, int minutes)>()(ptr.ref.lpVtbl, minutes);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1553,15 +1543,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(81)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1577,7 +1567,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(82)
               .cast<
                   Pointer<
@@ -1587,7 +1577,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1603,7 +1593,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(83)
           .cast<
               Pointer<
@@ -1611,7 +1601,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1623,23 +1613,23 @@ class ICalendar extends IInspectable {
   }
 
   set Second(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(84)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddSeconds(int seconds) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(85)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, Int32 seconds)>>>()
         .value
         .asFunction<
-            int Function(Pointer, int seconds)>()(_thisPtr.ref.lpVtbl, seconds);
+            int Function(Pointer, int seconds)>()(ptr.ref.lpVtbl, seconds);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1648,15 +1638,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(86)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1672,7 +1662,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(87)
               .cast<
                   Pointer<
@@ -1682,7 +1672,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1698,7 +1688,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(88)
           .cast<
               Pointer<
@@ -1706,7 +1696,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1718,17 +1708,17 @@ class ICalendar extends IInspectable {
   }
 
   set Nanosecond(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(89)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddNanoseconds(int nanoseconds) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(90)
         .cast<
             Pointer<
@@ -1736,7 +1726,7 @@ class ICalendar extends IInspectable {
         .value
         .asFunction<
             int Function(
-                Pointer, int nanoseconds)>()(_thisPtr.ref.lpVtbl, nanoseconds);
+                Pointer, int nanoseconds)>()(ptr.ref.lpVtbl, nanoseconds);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1745,15 +1735,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(91)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1769,7 +1759,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(92)
               .cast<
                   Pointer<
@@ -1779,7 +1769,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1795,7 +1785,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(93)
               .cast<
                   Pointer<
@@ -1806,9 +1796,7 @@ class ICalendar extends IInspectable {
               .asFunction<
                   int Function(
                       Pointer, Pointer<COMObject> other, Pointer<Int32>)>()(
-          _thisPtr.ref.lpVtbl,
-          other.cast<Pointer<COMObject>>().value,
-          retValuePtr);
+          ptr.ref.lpVtbl, other.cast<Pointer<COMObject>>().value, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1825,7 +1813,7 @@ class ICalendar extends IInspectable {
         other.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(94)
               .cast<
                   Pointer<
@@ -1834,7 +1822,7 @@ class ICalendar extends IInspectable {
                               Pointer, Uint64 other, Pointer<Int32>)>>>()
               .value
               .asFunction<int Function(Pointer, int other, Pointer<Int32>)>()(
-          _thisPtr.ref.lpVtbl, otherDateTime, retValuePtr);
+          ptr.ref.lpVtbl, otherDateTime, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1846,7 +1834,7 @@ class ICalendar extends IInspectable {
   }
 
   void CopyTo(Pointer<COMObject> other) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(95)
             .cast<
                 Pointer<
@@ -1854,7 +1842,7 @@ class ICalendar extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject> other)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject> other)>()(
-        _thisPtr.ref.lpVtbl, other.cast<Pointer<COMObject>>().value);
+        ptr.ref.lpVtbl, other.cast<Pointer<COMObject>>().value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1863,7 +1851,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(96)
           .cast<
               Pointer<
@@ -1871,7 +1859,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1886,7 +1874,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(97)
           .cast<
               Pointer<
@@ -1894,7 +1882,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1909,7 +1897,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(98)
           .cast<
               Pointer<
@@ -1917,7 +1905,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1932,7 +1920,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(99)
           .cast<
               Pointer<
@@ -1940,7 +1928,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1955,7 +1943,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(100)
           .cast<
               Pointer<
@@ -1963,7 +1951,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1978,7 +1966,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(101)
           .cast<
               Pointer<
@@ -1986,7 +1974,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -2001,15 +1989,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(102)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -2025,7 +2013,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Bool>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(103)
           .cast<
               Pointer<
@@ -2033,7 +2021,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Bool>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Bool>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/icalendarfactory.dart
+++ b/lib/src/winrt/icalendarfactory.dart
@@ -33,13 +33,11 @@ class ICalendarFactory extends IInspectable {
   // vtable begins at 6, is 2 entries long.
   ICalendarFactory(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_ICalendarFactory);
-
   Pointer<COMObject> CreateCalendarDefaultCalendarAndClock(
       Pointer<COMObject> languages) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -49,7 +47,7 @@ class ICalendarFactory extends IInspectable {
             .value
             .asFunction<
                 int Function(Pointer, Pointer<COMObject> languages,
-                    Pointer<COMObject>)>()(_thisPtr.ref.lpVtbl,
+                    Pointer<COMObject>)>()(ptr.ref.lpVtbl,
         languages.cast<Pointer<COMObject>>().value, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -64,7 +62,7 @@ class ICalendarFactory extends IInspectable {
     final calendarHstring = convertToHString(calendar);
     final clockHstring = convertToHString(clock);
     final hr =
-        _thisPtr.ref.vtable
+        ptr.ref.vtable
                 .elementAt(7)
                 .cast<
                     Pointer<
@@ -79,7 +77,7 @@ class ICalendarFactory extends IInspectable {
                 .asFunction<
                     int Function(Pointer, Pointer<COMObject> languages,
                         int calendar, int clock, Pointer<COMObject>)>()(
-            _thisPtr.ref.lpVtbl,
+            ptr.ref.lpVtbl,
             languages.cast<Pointer<COMObject>>().value,
             calendarHstring,
             clockHstring,

--- a/lib/src/winrt/icalendarfactory2.dart
+++ b/lib/src/winrt/icalendarfactory2.dart
@@ -33,8 +33,6 @@ class ICalendarFactory2 extends IInspectable {
   // vtable begins at 6, is 1 entries long.
   ICalendarFactory2(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_ICalendarFactory2);
-
   Pointer<COMObject> CreateCalendarWithTimeZone(Pointer<COMObject> languages,
       String calendar, String clock, String timeZoneId) {
     final retValuePtr = calloc<COMObject>();
@@ -42,7 +40,7 @@ class ICalendarFactory2 extends IInspectable {
     final calendarHstring = convertToHString(calendar);
     final clockHstring = convertToHString(clock);
     final timeZoneIdHstring = convertToHString(timeZoneId);
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -63,7 +61,7 @@ class ICalendarFactory2 extends IInspectable {
                     int clock,
                     int timeZoneId,
                     Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl,
+        ptr.ref.lpVtbl,
         languages.cast<Pointer<COMObject>>().value,
         calendarHstring,
         clockHstring,

--- a/lib/src/winrt/iclosable.dart
+++ b/lib/src/winrt/iclosable.dart
@@ -33,14 +33,12 @@ class IClosable extends IInspectable {
   // vtable begins at 6, is 1 entries long.
   IClosable(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IClosable);
-
   void Close() {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(6)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
-        .asFunction<int Function(Pointer)>()(_thisPtr.ref.lpVtbl);
+        .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/lib/src/winrt/ifileopenpicker.dart
+++ b/lib/src/winrt/ifileopenpicker.dart
@@ -33,13 +33,11 @@ class IFileOpenPicker extends IInspectable {
   // vtable begins at 6, is 11 entries long.
   IFileOpenPicker(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IFileOpenPicker);
-
   int get ViewMode {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -47,7 +45,7 @@ class IFileOpenPicker extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -59,11 +57,11 @@ class IFileOpenPicker extends IInspectable {
   }
 
   set ViewMode(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(7)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -72,15 +70,15 @@ class IFileOpenPicker extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -96,11 +94,11 @@ class IFileOpenPicker extends IInspectable {
     final hstr = convertToHString(value);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(9)
           .cast<Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr)>>>()
           .value
-          .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, hstr);
+          .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, hstr);
 
       if (FAILED(hr)) throw WindowsException(hr);
     } finally {
@@ -112,7 +110,7 @@ class IFileOpenPicker extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -120,7 +118,7 @@ class IFileOpenPicker extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -132,11 +130,11 @@ class IFileOpenPicker extends IInspectable {
   }
 
   set SuggestedStartLocation(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(11)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -145,15 +143,15 @@ class IFileOpenPicker extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -169,11 +167,11 @@ class IFileOpenPicker extends IInspectable {
     final hstr = convertToHString(value);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(13)
           .cast<Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr)>>>()
           .value
-          .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, hstr);
+          .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, hstr);
 
       if (FAILED(hr)) throw WindowsException(hr);
     } finally {
@@ -184,7 +182,7 @@ class IFileOpenPicker extends IInspectable {
   IVector<String> get FileTypeFilter {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(14)
             .cast<
                 Pointer<
@@ -192,7 +190,7 @@ class IFileOpenPicker extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -202,7 +200,7 @@ class IFileOpenPicker extends IInspectable {
   Pointer<COMObject> PickSingleFileAsync() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(15)
             .cast<
                 Pointer<
@@ -210,7 +208,7 @@ class IFileOpenPicker extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -220,7 +218,7 @@ class IFileOpenPicker extends IInspectable {
   Pointer<COMObject> PickMultipleFilesAsync() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(16)
             .cast<
                 Pointer<
@@ -228,7 +226,7 @@ class IFileOpenPicker extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/igamepadstatics2.dart
+++ b/lib/src/winrt/igamepadstatics2.dart
@@ -34,13 +34,11 @@ class IGamepadStatics2 extends IGamepadStatics {
   // vtable begins at 6, is 1 entries long.
   IGamepadStatics2(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IGamepadStatics2);
-
   Pointer<COMObject> FromGameController(Pointer<COMObject> gameController) {
     final retValuePtr = calloc<COMObject>();
 
     final hr =
-        _thisPtr.ref.vtable
+        ptr.ref.vtable
                 .elementAt(6)
                 .cast<
                     Pointer<
@@ -52,7 +50,7 @@ class IGamepadStatics2 extends IGamepadStatics {
                 .value
                 .asFunction<
                     int Function(Pointer, Pointer<COMObject> gameController,
-                        Pointer<COMObject>)>()(_thisPtr.ref.lpVtbl,
+                        Pointer<COMObject>)>()(ptr.ref.lpVtbl,
             gameController.cast<Pointer<COMObject>>().value, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);

--- a/lib/src/winrt/ihostname.dart
+++ b/lib/src/winrt/ihostname.dart
@@ -33,12 +33,10 @@ class IHostName extends IInspectable {
   // vtable begins at 6, is 6 entries long.
   IHostName(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IHostName);
-
   Pointer<COMObject> get IPInformation {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -46,7 +44,7 @@ class IHostName extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -57,15 +55,15 @@ class IHostName extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -81,15 +79,15 @@ class IHostName extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -105,15 +103,15 @@ class IHostName extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -129,7 +127,7 @@ class IHostName extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
@@ -137,7 +135,7 @@ class IHostName extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -152,7 +150,7 @@ class IHostName extends IInspectable {
     final retValuePtr = calloc<Bool>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(11)
               .cast<
                   Pointer<
@@ -163,7 +161,7 @@ class IHostName extends IInspectable {
               .asFunction<
                   int Function(
                       Pointer, Pointer<COMObject> hostName, Pointer<Bool>)>()(
-          _thisPtr.ref.lpVtbl,
+          ptr.ref.lpVtbl,
           hostName.cast<Pointer<COMObject>>().value,
           retValuePtr);
 

--- a/lib/src/winrt/iphonenumberformatter.dart
+++ b/lib/src/winrt/iphonenumberformatter.dart
@@ -33,14 +33,11 @@ class IPhoneNumberFormatter extends IInspectable {
   // vtable begins at 6, is 5 entries long.
   IPhoneNumberFormatter(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr =
-      toInterface(IID_IPhoneNumberFormatter);
-
   String Format(Pointer<COMObject> number) {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(6)
               .cast<
                   Pointer<
@@ -51,9 +48,7 @@ class IPhoneNumberFormatter extends IInspectable {
               .asFunction<
                   int Function(
                       Pointer, Pointer<COMObject> number, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl,
-          number.cast<Pointer<COMObject>>().value,
-          retValuePtr);
+          ptr.ref.lpVtbl, number.cast<Pointer<COMObject>>().value, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -69,7 +64,7 @@ class IPhoneNumberFormatter extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -79,7 +74,7 @@ class IPhoneNumberFormatter extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, Pointer<COMObject> number,
-                      int numberFormat, Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl,
+                      int numberFormat, Pointer<IntPtr>)>()(ptr.ref.lpVtbl,
           number.cast<Pointer<COMObject>>().value, numberFormat, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -97,7 +92,7 @@ class IPhoneNumberFormatter extends IInspectable {
     final numberHstring = convertToHString(number);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -106,7 +101,7 @@ class IPhoneNumberFormatter extends IInspectable {
                               Pointer, IntPtr number, Pointer<IntPtr>)>>>()
               .value
               .asFunction<int Function(Pointer, int number, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, numberHstring, retValuePtr);
+          ptr.ref.lpVtbl, numberHstring, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -124,7 +119,7 @@ class IPhoneNumberFormatter extends IInspectable {
     final numberHstring = convertToHString(number);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -133,7 +128,7 @@ class IPhoneNumberFormatter extends IInspectable {
                               Pointer, IntPtr number, Pointer<IntPtr>)>>>()
               .value
               .asFunction<int Function(Pointer, int number, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, numberHstring, retValuePtr);
+          ptr.ref.lpVtbl, numberHstring, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -151,7 +146,7 @@ class IPhoneNumberFormatter extends IInspectable {
     final numberHstring = convertToHString(number);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(10)
               .cast<
                   Pointer<
@@ -160,7 +155,7 @@ class IPhoneNumberFormatter extends IInspectable {
                               Pointer, IntPtr number, Pointer<IntPtr>)>>>()
               .value
               .asFunction<int Function(Pointer, int number, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, numberHstring, retValuePtr);
+          ptr.ref.lpVtbl, numberHstring, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/iphonenumberformatterstatics.dart
+++ b/lib/src/winrt/iphonenumberformatterstatics.dart
@@ -34,13 +34,10 @@ class IPhoneNumberFormatterStatics extends IInspectable {
   // vtable begins at 6, is 4 entries long.
   IPhoneNumberFormatterStatics(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr =
-      toInterface(IID_IPhoneNumberFormatterStatics);
-
   void TryCreate(String regionCode, Pointer<COMObject> phoneNumber) {
     final regionCodeHstring = convertToHString(regionCode);
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -51,7 +48,7 @@ class IPhoneNumberFormatterStatics extends IInspectable {
             .asFunction<
                 int Function(
                     Pointer, int regionCode, Pointer<COMObject> phoneNumber)>()(
-        _thisPtr.ref.lpVtbl, regionCodeHstring, phoneNumber);
+        ptr.ref.lpVtbl, regionCodeHstring, phoneNumber);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -63,7 +60,7 @@ class IPhoneNumberFormatterStatics extends IInspectable {
     final regionCodeHstring = convertToHString(regionCode);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(7)
               .cast<
                   Pointer<
@@ -73,7 +70,7 @@ class IPhoneNumberFormatterStatics extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int regionCode, Pointer<Int32>)>()(
-          _thisPtr.ref.lpVtbl, regionCodeHstring, retValuePtr);
+          ptr.ref.lpVtbl, regionCodeHstring, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -91,7 +88,7 @@ class IPhoneNumberFormatterStatics extends IInspectable {
     final regionCodeHstring = convertToHString(regionCode);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(8)
               .cast<
                   Pointer<
@@ -102,7 +99,7 @@ class IPhoneNumberFormatterStatics extends IInspectable {
               .asFunction<
                   int Function(Pointer, int regionCode, bool stripNonDigit,
                       Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, regionCodeHstring, stripNonDigit, retValuePtr);
+          ptr.ref.lpVtbl, regionCodeHstring, stripNonDigit, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -121,7 +118,7 @@ class IPhoneNumberFormatterStatics extends IInspectable {
     final numberHstring = convertToHString(number);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -130,7 +127,7 @@ class IPhoneNumberFormatterStatics extends IInspectable {
                               Pointer, IntPtr number, Pointer<IntPtr>)>>>()
               .value
               .asFunction<int Function(Pointer, int number, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, numberHstring, retValuePtr);
+          ptr.ref.lpVtbl, numberHstring, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/istringable.dart
+++ b/lib/src/winrt/istringable.dart
@@ -33,21 +33,19 @@ class IStringable extends IInspectable {
   // vtable begins at 6, is 1 entries long.
   IStringable(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IStringable);
-
   String ToString() {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/itimezoneoncalendar.dart
+++ b/lib/src/winrt/itimezoneoncalendar.dart
@@ -33,21 +33,19 @@ class ITimeZoneOnCalendar extends IInspectable {
   // vtable begins at 6, is 4 entries long.
   ITimeZoneOnCalendar(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_ITimeZoneOnCalendar);
-
   String GetTimeZone() {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -61,15 +59,15 @@ class ITimeZoneOnCalendar extends IInspectable {
 
   void ChangeTimeZone(String timeZoneId) {
     final timeZoneIdHstring = convertToHString(timeZoneId);
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(7)
         .cast<
             Pointer<
                 NativeFunction<HRESULT Function(Pointer, IntPtr timeZoneId)>>>()
         .value
         .asFunction<
-            int Function(Pointer,
-                int timeZoneId)>()(_thisPtr.ref.lpVtbl, timeZoneIdHstring);
+            int Function(
+                Pointer, int timeZoneId)>()(ptr.ref.lpVtbl, timeZoneIdHstring);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -80,15 +78,15 @@ class ITimeZoneOnCalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -104,7 +102,7 @@ class ITimeZoneOnCalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(9)
               .cast<
                   Pointer<
@@ -114,7 +112,7 @@ class ITimeZoneOnCalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/itoastnotification.dart
+++ b/lib/src/winrt/itoastnotification.dart
@@ -33,12 +33,10 @@ class IToastNotification extends IInspectable {
   // vtable begins at 6, is 9 entries long.
   IToastNotification(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IToastNotification);
-
   Pointer<COMObject> get Content {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -46,7 +44,7 @@ class IToastNotification extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -54,7 +52,7 @@ class IToastNotification extends IInspectable {
   }
 
   set ExpirationTime(Pointer<COMObject> value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(7)
             .cast<
                 Pointer<
@@ -62,7 +60,7 @@ class IToastNotification extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, value);
+        ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -70,7 +68,7 @@ class IToastNotification extends IInspectable {
   Pointer<COMObject> get ExpirationTime {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(8)
             .cast<
                 Pointer<
@@ -78,7 +76,7 @@ class IToastNotification extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -86,37 +84,34 @@ class IToastNotification extends IInspectable {
   }
 
   void remove_Dismissed(int token) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(10)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr token)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int token)>()(_thisPtr.ref.lpVtbl, token);
+        .asFunction<int Function(Pointer, int token)>()(ptr.ref.lpVtbl, token);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void remove_Activated(int token) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(12)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr token)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int token)>()(_thisPtr.ref.lpVtbl, token);
+        .asFunction<int Function(Pointer, int token)>()(ptr.ref.lpVtbl, token);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void remove_Failed(int token) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(14)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr token)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int token)>()(_thisPtr.ref.lpVtbl, token);
+        .asFunction<int Function(Pointer, int token)>()(ptr.ref.lpVtbl, token);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/lib/src/winrt/itoastnotification2.dart
+++ b/lib/src/winrt/itoastnotification2.dart
@@ -33,17 +33,15 @@ class IToastNotification2 extends IInspectable {
   // vtable begins at 6, is 6 entries long.
   IToastNotification2(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IToastNotification2);
-
   set Tag(String value) {
     final hstr = convertToHString(value);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr)>>>()
           .value
-          .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, hstr);
+          .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, hstr);
 
       if (FAILED(hr)) throw WindowsException(hr);
     } finally {
@@ -55,15 +53,15 @@ class IToastNotification2 extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(7)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -79,11 +77,11 @@ class IToastNotification2 extends IInspectable {
     final hstr = convertToHString(value);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(8)
           .cast<Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr)>>>()
           .value
-          .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, hstr);
+          .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, hstr);
 
       if (FAILED(hr)) throw WindowsException(hr);
     } finally {
@@ -95,15 +93,15 @@ class IToastNotification2 extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(9)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -116,11 +114,11 @@ class IToastNotification2 extends IInspectable {
   }
 
   set SuppressPopup(bool value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(10)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Bool)>>>()
         .value
-        .asFunction<int Function(Pointer, bool)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, bool)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -129,7 +127,7 @@ class IToastNotification2 extends IInspectable {
     final retValuePtr = calloc<Bool>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(11)
           .cast<
               Pointer<
@@ -137,7 +135,7 @@ class IToastNotification2 extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Bool>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Bool>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/itoastnotification3.dart
+++ b/lib/src/winrt/itoastnotification3.dart
@@ -33,13 +33,11 @@ class IToastNotification3 extends IInspectable {
   // vtable begins at 6, is 4 entries long.
   IToastNotification3(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IToastNotification3);
-
   int get NotificationMirroring {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -47,7 +45,7 @@ class IToastNotification3 extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -59,11 +57,11 @@ class IToastNotification3 extends IInspectable {
   }
 
   set NotificationMirroring(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(7)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -72,15 +70,15 @@ class IToastNotification3 extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -96,11 +94,11 @@ class IToastNotification3 extends IInspectable {
     final hstr = convertToHString(value);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(9)
           .cast<Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr)>>>()
           .value
-          .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, hstr);
+          .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, hstr);
 
       if (FAILED(hr)) throw WindowsException(hr);
     } finally {

--- a/lib/src/winrt/itoastnotification4.dart
+++ b/lib/src/winrt/itoastnotification4.dart
@@ -33,12 +33,10 @@ class IToastNotification4 extends IInspectable {
   // vtable begins at 6, is 4 entries long.
   IToastNotification4(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IToastNotification4);
-
   Pointer<COMObject> get Data {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -46,7 +44,7 @@ class IToastNotification4 extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -54,7 +52,7 @@ class IToastNotification4 extends IInspectable {
   }
 
   set Data(Pointer<COMObject> value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(7)
             .cast<
                 Pointer<
@@ -62,7 +60,7 @@ class IToastNotification4 extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, value);
+        ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -71,7 +69,7 @@ class IToastNotification4 extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(8)
           .cast<
               Pointer<
@@ -79,7 +77,7 @@ class IToastNotification4 extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -91,11 +89,11 @@ class IToastNotification4 extends IInspectable {
   }
 
   set Priority(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(9)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/lib/src/winrt/itoastnotification6.dart
+++ b/lib/src/winrt/itoastnotification6.dart
@@ -33,13 +33,11 @@ class IToastNotification6 extends IInspectable {
   // vtable begins at 6, is 2 entries long.
   IToastNotification6(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IToastNotification6);
-
   bool get ExpiresOnReboot {
     final retValuePtr = calloc<Bool>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
@@ -47,7 +45,7 @@ class IToastNotification6 extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Bool>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Bool>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -59,11 +57,11 @@ class IToastNotification6 extends IInspectable {
   }
 
   set ExpiresOnReboot(bool value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(7)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Bool)>>>()
         .value
-        .asFunction<int Function(Pointer, bool)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, bool)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/lib/src/winrt/itoastnotificationfactory.dart
+++ b/lib/src/winrt/itoastnotificationfactory.dart
@@ -33,13 +33,10 @@ class IToastNotificationFactory extends IInspectable {
   // vtable begins at 6, is 1 entries long.
   IToastNotificationFactory(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr =
-      toInterface(IID_IToastNotificationFactory);
-
   Pointer<COMObject> CreateToastNotification(Pointer<COMObject> content) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -50,9 +47,7 @@ class IToastNotificationFactory extends IInspectable {
             .asFunction<
                 int Function(
                     Pointer, Pointer<COMObject> content, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl,
-        content.cast<Pointer<COMObject>>().value,
-        retValuePtr);
+        ptr.ref.lpVtbl, content.cast<Pointer<COMObject>>().value, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/itoastnotificationmanagerstatics.dart
+++ b/lib/src/winrt/itoastnotificationmanagerstatics.dart
@@ -34,13 +34,10 @@ class IToastNotificationManagerStatics extends IInspectable {
   // vtable begins at 6, is 3 entries long.
   IToastNotificationManagerStatics(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr =
-      toInterface(IID_IToastNotificationManagerStatics);
-
   Pointer<COMObject> CreateToastNotifier() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -48,7 +45,7 @@ class IToastNotificationManagerStatics extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -58,7 +55,7 @@ class IToastNotificationManagerStatics extends IInspectable {
   Pointer<COMObject> CreateToastNotifierWithId(String applicationId) {
     final retValuePtr = calloc<COMObject>();
     final applicationIdHstring = convertToHString(applicationId);
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(7)
             .cast<
                 Pointer<
@@ -68,7 +65,7 @@ class IToastNotificationManagerStatics extends IInspectable {
             .value
             .asFunction<
                 int Function(Pointer, int applicationId, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, applicationIdHstring, retValuePtr);
+        ptr.ref.lpVtbl, applicationIdHstring, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -79,7 +76,7 @@ class IToastNotificationManagerStatics extends IInspectable {
   Pointer<COMObject> GetTemplateContent(int type) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(8)
             .cast<
                 Pointer<
@@ -88,7 +85,7 @@ class IToastNotificationManagerStatics extends IInspectable {
                             Pointer, Int32 type, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, int type, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, type, retValuePtr);
+        ptr.ref.lpVtbl, type, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/iuserdatapathsstatics.dart
+++ b/lib/src/winrt/iuserdatapathsstatics.dart
@@ -33,13 +33,10 @@ class IUserDataPathsStatics extends IInspectable {
   // vtable begins at 6, is 2 entries long.
   IUserDataPathsStatics(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr =
-      toInterface(IID_IUserDataPathsStatics);
-
   Pointer<COMObject> GetForUser(Pointer<COMObject> user) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -50,9 +47,7 @@ class IUserDataPathsStatics extends IInspectable {
             .asFunction<
                 int Function(
                     Pointer, Pointer<COMObject> user, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl,
-        user.cast<Pointer<COMObject>>().value,
-        retValuePtr);
+        ptr.ref.lpVtbl, user.cast<Pointer<COMObject>>().value, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -62,7 +57,7 @@ class IUserDataPathsStatics extends IInspectable {
   Pointer<COMObject> GetDefault() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(7)
             .cast<
                 Pointer<
@@ -70,7 +65,7 @@ class IUserDataPathsStatics extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/phonenumberformatter.dart
+++ b/lib/src/winrt/phonenumberformatter.dart
@@ -26,10 +26,7 @@ import 'iphonenumberformatter.dart';
 import 'iphonenumberformatterstatics.dart';
 import '../com/iinspectable.dart';
 
-/// @nodoc
-const IID_PhoneNumberFormatter = 'null';
-
-/// {@category Interface}
+/// {@category Class}
 /// {@category winrt}
 class PhoneNumberFormatter extends IInspectable
     implements IPhoneNumberFormatter {

--- a/tool/generator/lib/src/projection/winrt_class.dart
+++ b/tool/generator/lib/src/projection/winrt_class.dart
@@ -138,7 +138,7 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
       $importHeader
       $rootHeader
 
-      /// {@category Interface}
+      /// {@category Class}
       /// {@category $category}
       class $shortName extends IInspectable implements $inheritsFrom {
         $shortName({Allocator allocator = calloc})

--- a/tool/generator/lib/src/projection/winrt_class.dart
+++ b/tool/generator/lib/src/projection/winrt_class.dart
@@ -47,6 +47,11 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
     return imports.map((import) => "import '$import';").join('\n');
   }
 
+  bool get hasDefaultConstructor => typeDef.customAttributes
+      .where((element) => element.name.endsWith('ActivatableAttribute'))
+      .where((element) => element.parameters.length == 2)
+      .isNotEmpty;
+
   List<String> get factoryInterfaces => typeDef.customAttributes
       .where((element) => element.name.endsWith('ActivatableAttribute'))
       .where((element) => element.parameters.length == 3)
@@ -130,6 +135,12 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
     return buffer.toString();
   }
 
+  String get defaultConstructor => hasDefaultConstructor
+      ? '''
+      $shortName({Allocator allocator = calloc})
+          : super(ActivateClass(_className, allocator: allocator));'''
+      : '';
+
   @override
   String toString() {
     return '''
@@ -141,8 +152,7 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
       /// {@category Class}
       /// {@category $category}
       class $shortName extends IInspectable implements $inheritsFrom {
-        $shortName({Allocator allocator = calloc})
-            : super(ActivateClass(_className, allocator: allocator));
+        $defaultConstructor
         $shortName.fromPointer(super.ptr);
 
         static const _className = '${typeDef.name}';

--- a/tool/generator/lib/src/projection/winrt_class.dart
+++ b/tool/generator/lib/src/projection/winrt_class.dart
@@ -137,7 +137,6 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
       $extraHeaders
       $importHeader
       $rootHeader
-      $guidConstants
 
       /// {@category Interface}
       /// {@category $category}

--- a/tool/generator/lib/src/projection/winrt_get_property.dart
+++ b/tool/generator/lib/src/projection/winrt_get_property.dart
@@ -17,11 +17,11 @@ class WinRTGetPropertyProjection extends WinRTPropertyProjection {
 
   @override
   String ffiCall([String params = '']) => '''
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
       .elementAt($vtableOffset)
       .cast<Pointer<NativeFunction<$nativePrototype>>>()
       .value
-      .asFunction<$dartPrototype>()(_thisPtr.ref.lpVtbl, retValuePtr);
+      .asFunction<$dartPrototype>()(ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 ''';

--- a/tool/generator/lib/src/projection/winrt_interface.dart
+++ b/tool/generator/lib/src/projection/winrt_interface.dart
@@ -128,8 +128,6 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
         // vtable begins at $vtableStart, is ${methodProjections.length} entries long.
         $shortName(super.ptr);
 
-        late final Pointer<COMObject> _thisPtr = toInterface(IID_$shortName);
-
         ${methodProjections.map((p) => p.toString()).join('\n')}
       }
     ''';

--- a/tool/generator/lib/src/projection/winrt_method.dart
+++ b/tool/generator/lib/src/projection/winrt_method.dart
@@ -44,7 +44,7 @@ class WinRTMethodProjection extends MethodProjection {
 
   @override
   String get identifiers => [
-        '_thisPtr.ref.lpVtbl',
+        'ptr.ref.lpVtbl',
         ...parameters.map(
             (param) => (param as WinRTParameterProjection).localIdentifier),
         if (!isVoidReturn) 'retValuePtr',
@@ -96,7 +96,7 @@ class WinRTMethodProjection extends MethodProjection {
   // Declaration String templates
 
   String ffiCall([String params = '']) => '''
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
       .elementAt($vtableOffset)
       .cast<Pointer<NativeFunction<$nativePrototype>>>()
       .value

--- a/tool/generator/lib/src/projection/winrt_set_property.dart
+++ b/tool/generator/lib/src/projection/winrt_set_property.dart
@@ -19,11 +19,11 @@ class WinRTSetPropertyProjection extends WinRTPropertyProjection {
 
   @override
   String ffiCall([String params = '']) => '''
-          final hr = _thisPtr.ref.vtable
+          final hr = ptr.ref.vtable
             .elementAt($vtableOffset)
             .cast<Pointer<NativeFunction<$nativePrototype>>>()
             .value
-            .asFunction<$dartPrototype>()(_thisPtr.ref.lpVtbl, $params);
+            .asFunction<$dartPrototype>()(ptr.ref.lpVtbl, $params);
 
           if (FAILED(hr)) throw WindowsException(hr);
   ''';

--- a/tool/generator/test/goldens/icalendar.golden
+++ b/tool/generator/test/goldens/icalendar.golden
@@ -33,12 +33,10 @@ class ICalendar extends IInspectable {
   // vtable begins at 6, is 98 entries long.
   ICalendar(super.ptr);
 
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_ICalendar);
-
   Pointer<COMObject> Clone() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
                 Pointer<
@@ -46,7 +44,7 @@ class ICalendar extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -54,21 +52,21 @@ class ICalendar extends IInspectable {
   }
 
   void SetToMin() {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(7)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
-        .asFunction<int Function(Pointer)>()(_thisPtr.ref.lpVtbl);
+        .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void SetToMax() {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(8)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
-        .asFunction<int Function(Pointer)>()(_thisPtr.ref.lpVtbl);
+        .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -76,7 +74,7 @@ class ICalendar extends IInspectable {
   List<String> get Languages {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(9)
             .cast<
                 Pointer<
@@ -84,7 +82,7 @@ class ICalendar extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -99,15 +97,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(10)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -123,11 +121,11 @@ class ICalendar extends IInspectable {
     final hstr = convertToHString(value);
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(11)
           .cast<Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr)>>>()
           .value
-          .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, hstr);
+          .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, hstr);
 
       if (FAILED(hr)) throw WindowsException(hr);
     } finally {
@@ -139,15 +137,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(12)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -161,14 +159,13 @@ class ICalendar extends IInspectable {
 
   void ChangeCalendarSystem(String value) {
     final valueHstring = convertToHString(value);
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(13)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr value)>>>()
         .value
         .asFunction<
-            int Function(
-                Pointer, int value)>()(_thisPtr.ref.lpVtbl, valueHstring);
+            int Function(Pointer, int value)>()(ptr.ref.lpVtbl, valueHstring);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -179,15 +176,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(14)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -201,14 +198,13 @@ class ICalendar extends IInspectable {
 
   void ChangeClock(String value) {
     final valueHstring = convertToHString(value);
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(15)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr value)>>>()
         .value
         .asFunction<
-            int Function(
-                Pointer, int value)>()(_thisPtr.ref.lpVtbl, valueHstring);
+            int Function(Pointer, int value)>()(ptr.ref.lpVtbl, valueHstring);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -219,15 +215,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Uint64>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(16)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<Uint64>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<Uint64>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<Uint64>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -241,24 +237,23 @@ class ICalendar extends IInspectable {
   void SetDateTime(DateTime value) {
     final valueDateTime =
         value.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(17)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, Uint64 value)>>>()
         .value
         .asFunction<
-            int Function(
-                Pointer, int value)>()(_thisPtr.ref.lpVtbl, valueDateTime);
+            int Function(Pointer, int value)>()(ptr.ref.lpVtbl, valueDateTime);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void SetToNow() {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(18)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
-        .asFunction<int Function(Pointer)>()(_thisPtr.ref.lpVtbl);
+        .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -267,7 +262,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(19)
           .cast<
               Pointer<
@@ -275,7 +270,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -290,7 +285,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(20)
           .cast<
               Pointer<
@@ -298,7 +293,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -313,7 +308,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(21)
           .cast<
               Pointer<
@@ -321,7 +316,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -336,7 +331,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(22)
           .cast<
               Pointer<
@@ -344,7 +339,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -356,22 +351,21 @@ class ICalendar extends IInspectable {
   }
 
   set Era(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(23)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddEras(int eras) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(24)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32 eras)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int eras)>()(_thisPtr.ref.lpVtbl, eras);
+        .asFunction<int Function(Pointer, int eras)>()(ptr.ref.lpVtbl, eras);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -380,15 +374,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(25)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -404,7 +398,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(26)
               .cast<
                   Pointer<
@@ -414,7 +408,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -430,7 +424,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(27)
           .cast<
               Pointer<
@@ -438,7 +432,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -453,7 +447,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(28)
           .cast<
               Pointer<
@@ -461,7 +455,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -476,7 +470,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(29)
           .cast<
               Pointer<
@@ -484,7 +478,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -499,7 +493,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(30)
           .cast<
               Pointer<
@@ -507,7 +501,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -519,22 +513,21 @@ class ICalendar extends IInspectable {
   }
 
   set Year(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(31)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddYears(int years) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(32)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32 years)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int years)>()(_thisPtr.ref.lpVtbl, years);
+        .asFunction<int Function(Pointer, int years)>()(ptr.ref.lpVtbl, years);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -543,15 +536,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(33)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -567,7 +560,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(34)
               .cast<
                   Pointer<
@@ -578,7 +571,7 @@ class ICalendar extends IInspectable {
               .asFunction<
                   int Function(
                       Pointer, int remainingDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, remainingDigits, retValuePtr);
+          ptr.ref.lpVtbl, remainingDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -594,7 +587,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(35)
               .cast<
                   Pointer<
@@ -604,7 +597,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -620,7 +613,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(36)
           .cast<
               Pointer<
@@ -628,7 +621,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -643,7 +636,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(37)
           .cast<
               Pointer<
@@ -651,7 +644,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -666,7 +659,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(38)
           .cast<
               Pointer<
@@ -674,7 +667,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -689,7 +682,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(39)
           .cast<
               Pointer<
@@ -697,7 +690,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -709,23 +702,23 @@ class ICalendar extends IInspectable {
   }
 
   set Month(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(40)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddMonths(int months) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(41)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, Int32 months)>>>()
         .value
         .asFunction<
-            int Function(Pointer, int months)>()(_thisPtr.ref.lpVtbl, months);
+            int Function(Pointer, int months)>()(ptr.ref.lpVtbl, months);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -734,15 +727,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(42)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -758,7 +751,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(43)
               .cast<
                   Pointer<
@@ -768,7 +761,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -784,15 +777,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(44)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -808,7 +801,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(45)
               .cast<
                   Pointer<
@@ -818,7 +811,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -834,15 +827,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(46)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -858,7 +851,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(47)
               .cast<
                   Pointer<
@@ -868,7 +861,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -881,12 +874,11 @@ class ICalendar extends IInspectable {
   }
 
   void AddWeeks(int weeks) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(48)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32 weeks)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int weeks)>()(_thisPtr.ref.lpVtbl, weeks);
+        .asFunction<int Function(Pointer, int weeks)>()(ptr.ref.lpVtbl, weeks);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -895,7 +887,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(49)
           .cast<
               Pointer<
@@ -903,7 +895,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -918,7 +910,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(50)
           .cast<
               Pointer<
@@ -926,7 +918,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -941,7 +933,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(51)
           .cast<
               Pointer<
@@ -949,7 +941,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -964,7 +956,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(52)
           .cast<
               Pointer<
@@ -972,7 +964,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -984,22 +976,21 @@ class ICalendar extends IInspectable {
   }
 
   set Day(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(53)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddDays(int days) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(54)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32 days)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int days)>()(_thisPtr.ref.lpVtbl, days);
+        .asFunction<int Function(Pointer, int days)>()(ptr.ref.lpVtbl, days);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1008,15 +999,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(55)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1032,7 +1023,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(56)
               .cast<
                   Pointer<
@@ -1042,7 +1033,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1058,7 +1049,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(57)
           .cast<
               Pointer<
@@ -1066,7 +1057,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1081,15 +1072,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(58)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1105,7 +1096,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(59)
               .cast<
                   Pointer<
@@ -1115,7 +1106,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1131,15 +1122,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(60)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1155,7 +1146,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(61)
               .cast<
                   Pointer<
@@ -1165,7 +1156,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1181,7 +1172,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(62)
           .cast<
               Pointer<
@@ -1189,7 +1180,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1204,7 +1195,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(63)
           .cast<
               Pointer<
@@ -1212,7 +1203,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1227,7 +1218,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(64)
           .cast<
               Pointer<
@@ -1235,7 +1226,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1250,7 +1241,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(65)
           .cast<
               Pointer<
@@ -1258,7 +1249,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1270,23 +1261,23 @@ class ICalendar extends IInspectable {
   }
 
   set Period(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(66)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddPeriods(int periods) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(67)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, Int32 periods)>>>()
         .value
         .asFunction<
-            int Function(Pointer, int periods)>()(_thisPtr.ref.lpVtbl, periods);
+            int Function(Pointer, int periods)>()(ptr.ref.lpVtbl, periods);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1295,15 +1286,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(68)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1319,7 +1310,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(69)
               .cast<
                   Pointer<
@@ -1329,7 +1320,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int idealLength, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, idealLength, retValuePtr);
+          ptr.ref.lpVtbl, idealLength, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1345,7 +1336,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(70)
           .cast<
               Pointer<
@@ -1353,7 +1344,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1368,7 +1359,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(71)
           .cast<
               Pointer<
@@ -1376,7 +1367,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1391,7 +1382,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(72)
           .cast<
               Pointer<
@@ -1399,7 +1390,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1414,7 +1405,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(73)
           .cast<
               Pointer<
@@ -1422,7 +1413,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1434,22 +1425,21 @@ class ICalendar extends IInspectable {
   }
 
   set Hour(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(74)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddHours(int hours) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(75)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32 hours)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int hours)>()(_thisPtr.ref.lpVtbl, hours);
+        .asFunction<int Function(Pointer, int hours)>()(ptr.ref.lpVtbl, hours);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1458,15 +1448,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(76)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1482,7 +1472,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(77)
               .cast<
                   Pointer<
@@ -1492,7 +1482,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1508,7 +1498,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(78)
           .cast<
               Pointer<
@@ -1516,7 +1506,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1528,23 +1518,23 @@ class ICalendar extends IInspectable {
   }
 
   set Minute(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(79)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddMinutes(int minutes) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(80)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, Int32 minutes)>>>()
         .value
         .asFunction<
-            int Function(Pointer, int minutes)>()(_thisPtr.ref.lpVtbl, minutes);
+            int Function(Pointer, int minutes)>()(ptr.ref.lpVtbl, minutes);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1553,15 +1543,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(81)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1577,7 +1567,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(82)
               .cast<
                   Pointer<
@@ -1587,7 +1577,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1603,7 +1593,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(83)
           .cast<
               Pointer<
@@ -1611,7 +1601,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1623,23 +1613,23 @@ class ICalendar extends IInspectable {
   }
 
   set Second(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(84)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddSeconds(int seconds) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(85)
         .cast<
             Pointer<NativeFunction<HRESULT Function(Pointer, Int32 seconds)>>>()
         .value
         .asFunction<
-            int Function(Pointer, int seconds)>()(_thisPtr.ref.lpVtbl, seconds);
+            int Function(Pointer, int seconds)>()(ptr.ref.lpVtbl, seconds);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1648,15 +1638,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(86)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1672,7 +1662,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(87)
               .cast<
                   Pointer<
@@ -1682,7 +1672,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1698,7 +1688,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(88)
           .cast<
               Pointer<
@@ -1706,7 +1696,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1718,17 +1708,17 @@ class ICalendar extends IInspectable {
   }
 
   set Nanosecond(int value) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(89)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer, Int32)>>>()
         .value
-        .asFunction<int Function(Pointer, int)>()(_thisPtr.ref.lpVtbl, value);
+        .asFunction<int Function(Pointer, int)>()(ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void AddNanoseconds(int nanoseconds) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(90)
         .cast<
             Pointer<
@@ -1736,7 +1726,7 @@ class ICalendar extends IInspectable {
         .value
         .asFunction<
             int Function(
-                Pointer, int nanoseconds)>()(_thisPtr.ref.lpVtbl, nanoseconds);
+                Pointer, int nanoseconds)>()(ptr.ref.lpVtbl, nanoseconds);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1745,15 +1735,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(91)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1769,7 +1759,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(92)
               .cast<
                   Pointer<
@@ -1779,7 +1769,7 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(Pointer, int minDigits, Pointer<IntPtr>)>()(
-          _thisPtr.ref.lpVtbl, minDigits, retValuePtr);
+          ptr.ref.lpVtbl, minDigits, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1795,7 +1785,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(93)
               .cast<
                   Pointer<
@@ -1806,9 +1796,7 @@ class ICalendar extends IInspectable {
               .asFunction<
                   int Function(
                       Pointer, Pointer<COMObject> other, Pointer<Int32>)>()(
-          _thisPtr.ref.lpVtbl,
-          other.cast<Pointer<COMObject>>().value,
-          retValuePtr);
+          ptr.ref.lpVtbl, other.cast<Pointer<COMObject>>().value, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1825,7 +1813,7 @@ class ICalendar extends IInspectable {
         other.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
               .elementAt(94)
               .cast<
                   Pointer<
@@ -1834,7 +1822,7 @@ class ICalendar extends IInspectable {
                               Pointer, Uint64 other, Pointer<Int32>)>>>()
               .value
               .asFunction<int Function(Pointer, int other, Pointer<Int32>)>()(
-          _thisPtr.ref.lpVtbl, otherDateTime, retValuePtr);
+          ptr.ref.lpVtbl, otherDateTime, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1846,7 +1834,7 @@ class ICalendar extends IInspectable {
   }
 
   void CopyTo(Pointer<COMObject> other) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(95)
             .cast<
                 Pointer<
@@ -1854,7 +1842,7 @@ class ICalendar extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject> other)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject> other)>()(
-        _thisPtr.ref.lpVtbl, other.cast<Pointer<COMObject>>().value);
+        ptr.ref.lpVtbl, other.cast<Pointer<COMObject>>().value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1863,7 +1851,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(96)
           .cast<
               Pointer<
@@ -1871,7 +1859,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1886,7 +1874,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(97)
           .cast<
               Pointer<
@@ -1894,7 +1882,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1909,7 +1897,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(98)
           .cast<
               Pointer<
@@ -1917,7 +1905,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1932,7 +1920,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(99)
           .cast<
               Pointer<
@@ -1940,7 +1928,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1955,7 +1943,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(100)
           .cast<
               Pointer<
@@ -1963,7 +1951,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1978,7 +1966,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(101)
           .cast<
               Pointer<
@@ -1986,7 +1974,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Int32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -2001,15 +1989,15 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<HSTRING>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(102)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<IntPtr>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<IntPtr>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<IntPtr>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -2025,7 +2013,7 @@ class ICalendar extends IInspectable {
     final retValuePtr = calloc<Bool>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(103)
           .cast<
               Pointer<
@@ -2033,7 +2021,7 @@ class ICalendar extends IInspectable {
           .value
           .asFunction<
               int Function(
-                  Pointer, Pointer<Bool>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+                  Pointer, Pointer<Bool>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/tool/generator/test/winrt_projection_test.dart
+++ b/tool/generator/test/winrt_projection_test.dart
@@ -331,4 +331,25 @@ void main() {
     expect(output, isNotEmpty);
     expect(output, contains('iinspectable.dart'));
   });
+
+  test('WinRT class successfully projects a default constructor', () {
+    final winTypeDef = MetadataStore.getMetadataForType(
+        'Windows.Storage.Pickers.FileOpenPicker');
+
+    final projection = WinRTClassProjection(winTypeDef!);
+    expect(projection.hasDefaultConstructor, true);
+    expect(
+        projection.defaultConstructor,
+        equalsIgnoringWhitespace(
+            'FileOpenPicker({Allocator allocator = calloc}) : super(ActivateClass(_className, allocator: allocator));'));
+  });
+
+  test('WinRT class does not project a default constructor', () {
+    final winTypeDef =
+        MetadataStore.getMetadataForType('Windows.Networking.HostName');
+
+    final projection = WinRTClassProjection(winTypeDef!);
+    expect(projection.hasDefaultConstructor, false);
+    expect(projection.defaultConstructor, isEmpty);
+  });
 }


### PR DESCRIPTION
- Create a default constructor for WinRT Class only if it supports it. (I do this by checking if the class has an `ActivatableAttribute` with `two` parameters. This is because if a class has a default constructor, it has this attribute: `[Activatable(65536u, "Windows.Foundation.UniversalApiContract")]`)
- Removed `guidConstants` as WinRT classes don't have any.
- Removed `_thisPtr` as it's redundant now.

Thank you for your work on the WinRT Class projection, it's great.

