### PR TITLE
Fix WinRT Class projection

### DIFF
--- a/tool/generator/lib/src/projection/winrt_class.dart
+++ b/tool/generator/lib/src/projection/winrt_class.dart
@@ -135,6 +135,9 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
     return buffer.toString();
   }
 
+  String get classDeclaration =>
+      '''class $shortName extends IInspectable${inheritsFrom.isEmpty ? '' : ' implements $inheritsFrom'} {''';
+
   String get defaultConstructor => hasDefaultConstructor
       ? '''
       $shortName({Allocator allocator = calloc})
@@ -151,7 +154,7 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
 
       /// {@category Class}
       /// {@category $category}
-      class $shortName extends IInspectable implements $inheritsFrom {
+      $classDeclaration
         $defaultConstructor
         $shortName.fromPointer(super.ptr);
 

--- a/tool/generator/test/winrt_projection_test.dart
+++ b/tool/generator/test/winrt_projection_test.dart
@@ -352,4 +352,27 @@ void main() {
     expect(projection.hasDefaultConstructor, false);
     expect(projection.defaultConstructor, isEmpty);
   });
+
+  test('WinRT class includes implements keyword in class declaration', () {
+    final winTypeDef =
+        MetadataStore.getMetadataForType('Windows.Networking.HostName');
+
+    final projection = WinRTClassProjection(winTypeDef!);
+    expect(projection.inheritsFrom, isNotEmpty);
+    expect(
+        projection.classDeclaration,
+        equals(
+            'class HostName extends IInspectable implements IHostName, IStringable {'));
+  });
+
+  test('WinRT class does not include implements keyword in class declaration',
+      () {
+    final winTypeDef =
+        MetadataStore.getMetadataForType('Windows.System.Launcher');
+
+    final projection = WinRTClassProjection(winTypeDef!);
+    expect(projection.inheritsFrom, isEmpty);
+    expect(projection.classDeclaration,
+        equals('class Launcher extends IInspectable {'));
+  });
 }


### PR DESCRIPTION
There is a bug in the WinRT Class projection code. It doesn't check if the `Class` inherits from any interface before adding the `implements` keyword.

I also moved the class declaration to its own property to make testing easier.