### PR TITLE
Generate `implementsMappers` for WinRT Interfaces

### DIFF
--- a/example/storage.dart
+++ b/example/storage.dart
@@ -1,16 +1,15 @@
 import 'package:win32/win32.dart';
 
 void main() {
-  final hr = RoInitialize(RO_INIT_TYPE.RO_INIT_SINGLETHREADED);
-  if (FAILED(hr)) throw WindowsException(hr);
+  winrtInitialize();
 
   // Requires a package identity.
-  final currAppData = ApplicationData.Current();
+  final currAppData = ApplicationData.Current;
   print(currAppData.trustLevel);
   final localFolder = IStorageItem(currAppData.LocalFolder);
   final localPath = localFolder.Path;
 
   print('Local folder path: $localPath');
 
-  RoUninitialize();
+  winrtUninitialize();
 }

--- a/lib/src/winrt/applicationdata.dart
+++ b/lib/src/winrt/applicationdata.dart
@@ -1,32 +1,97 @@
-// ApplicationData.dart
+// applicationdata.dart
 
-// ignore_for_file: unused_import
-// ignore_for_file: directives_ordering, non_constant_identifier_names
+// THIS FILE IS GENERATED AUTOMATICALLY AND SHOULD NOT BE EDITED DIRECTLY.
+
+// ignore_for_file: unused_import, directives_ordering
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+// ignore_for_file: no_leading_underscores_for_local_identifiers
 
 import 'dart:ffi';
+
 import 'package:ffi/ffi.dart';
 
+import '../api_ms_win_core_winrt_string_l1_1_0.dart';
 import '../com/iinspectable.dart';
+import '../combase.dart';
+import '../exceptions.dart';
+import '../extensions/hstring_array.dart';
+import '../macros.dart';
+import '../types.dart';
 import '../utils.dart';
+import '../winrt_callbacks.dart';
 import '../winrt_helpers.dart';
-
 import 'iapplicationdata.dart';
 import 'iapplicationdatastatics.dart';
+import 'iasyncaction.dart';
+import 'iasyncoperation.dart';
+import 'user.dart';
 
+/// {@category Class}
 /// {@category winrt}
-class ApplicationData extends IInspectable with IApplicationData {
-  ApplicationData(super.ptr);
+class ApplicationData extends IInspectable implements IApplicationData {
+  ApplicationData.fromPointer(super.ptr);
 
   static const _className = 'Windows.Storage.ApplicationData';
 
-  static ApplicationData Current() {
+  // IApplicationDataStatics methods
+  static ApplicationData get Current {
     final activationFactory =
         CreateActivationFactory(_className, IID_IApplicationDataStatics);
+
     try {
-      return ApplicationData(
+      final result = ApplicationData.fromPointer(
           IApplicationDataStatics(activationFactory).Current);
+      return result;
     } finally {
       free(activationFactory);
     }
   }
+
+  // IApplicationData methods
+  late final _iApplicationData =
+      IApplicationData(toInterface(IID_IApplicationData));
+
+  @override
+  int get Version => _iApplicationData.Version;
+
+  @override
+  Pointer<COMObject> SetVersionAsync(int desiredVersion,
+          Pointer<NativeFunction<ApplicationDataSetVersionHandler>> handler) =>
+      _iApplicationData.SetVersionAsync(desiredVersion, handler);
+
+  @override
+  Pointer<COMObject> ClearAllAsync() => _iApplicationData.ClearAllAsync();
+
+  @override
+  Pointer<COMObject> ClearAsync(int locality) =>
+      _iApplicationData.ClearAsync(locality);
+
+  @override
+  Pointer<COMObject> get LocalSettings => _iApplicationData.LocalSettings;
+
+  @override
+  Pointer<COMObject> get RoamingSettings => _iApplicationData.RoamingSettings;
+
+  @override
+  Pointer<COMObject> get LocalFolder => _iApplicationData.LocalFolder;
+
+  @override
+  Pointer<COMObject> get RoamingFolder => _iApplicationData.RoamingFolder;
+
+  @override
+  Pointer<COMObject> get TemporaryFolder => _iApplicationData.TemporaryFolder;
+
+  @override
+  int add_DataChanged(Pointer<NativeFunction<TypedEventHandler>> handler) =>
+      _iApplicationData.add_DataChanged(handler);
+
+  @override
+  void remove_DataChanged(int token) =>
+      _iApplicationData.remove_DataChanged(token);
+
+  @override
+  void SignalDataChanged() => _iApplicationData.SignalDataChanged();
+
+  @override
+  int get RoamingStorageQuota => _iApplicationData.RoamingStorageQuota;
 }

--- a/lib/src/winrt/iapplicationdata.dart
+++ b/lib/src/winrt/iapplicationdata.dart
@@ -1,4 +1,6 @@
-// IApplicationData.dart
+// iapplicationdata.dart
+
+// THIS FILE IS GENERATED AUTOMATICALLY AND SHOULD NOT BE EDITED DIRECTLY.
 
 // ignore_for_file: unused_import, directives_ordering
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
@@ -8,49 +10,41 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 
-import '../callbacks.dart';
-import '../combase.dart';
-import '../constants.dart';
-import '../exceptions.dart';
-import '../guid.dart';
-import '../macros.dart';
-import '../ole32.dart';
-import '../structs.dart';
-import '../structs.g.dart';
-import '../utils.dart';
-
 import '../api_ms_win_core_winrt_string_l1_1_0.dart';
-import '../winrt_helpers.dart';
-import '../types.dart';
-
-import '../extensions/hstring_array.dart';
-import 'ivector.dart';
-import 'ivectorview.dart';
-
 import '../com/iinspectable.dart';
+import '../combase.dart';
+import '../exceptions.dart';
+import '../extensions/hstring_array.dart';
+import '../macros.dart';
+import '../types.dart';
+import '../utils.dart';
+import '../winrt_callbacks.dart';
+import '../winrt_helpers.dart';
+import 'applicationdata.dart';
+import 'iasyncaction.dart';
 
 /// @nodoc
 const IID_IApplicationData = '{C3DA6FB7-B744-4B45-B0B8-223A0938D0DC}';
 
 /// {@category Interface}
 /// {@category winrt}
-mixin IApplicationData on IInspectable {
+class IApplicationData extends IInspectable {
   // vtable begins at 6, is 13 entries long.
-  late final Pointer<COMObject> _thisPtr = toInterface(IID_IApplicationData);
+  IApplicationData(super.ptr);
 
   int get Version {
     final retValuePtr = calloc<Uint32>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(6)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<Uint32>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<Uint32>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<Uint32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -61,22 +55,32 @@ mixin IApplicationData on IInspectable {
     }
   }
 
-  Pointer<COMObject> SetVersionAsync(
-      int desiredVersion, Pointer<NativeFunction> handler) {
+  Pointer<COMObject> SetVersionAsync(int desiredVersion,
+      Pointer<NativeFunction<ApplicationDataSetVersionHandler>> handler) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(7)
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(Pointer, Uint32 desiredVersion,
-                            Pointer handler, Pointer<COMObject>)>>>()
+                        HRESULT Function(
+                            Pointer,
+                            Uint32 desiredVersion,
+                            Pointer<
+                                    NativeFunction<
+                                        ApplicationDataSetVersionHandler>>
+                                handler,
+                            Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(Pointer, int desiredVersion, Pointer handler,
+                int Function(
+                    Pointer,
+                    int desiredVersion,
+                    Pointer<NativeFunction<ApplicationDataSetVersionHandler>>
+                        handler,
                     Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, desiredVersion, handler, retValuePtr);
+        ptr.ref.lpVtbl, desiredVersion, handler, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -86,7 +90,7 @@ mixin IApplicationData on IInspectable {
   Pointer<COMObject> ClearAllAsync() {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(8)
             .cast<
                 Pointer<
@@ -94,7 +98,7 @@ mixin IApplicationData on IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -104,7 +108,7 @@ mixin IApplicationData on IInspectable {
   Pointer<COMObject> ClearAsync(int locality) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(9)
             .cast<
                 Pointer<
@@ -114,7 +118,7 @@ mixin IApplicationData on IInspectable {
             .value
             .asFunction<
                 int Function(Pointer, int locality, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, locality, retValuePtr);
+        ptr.ref.lpVtbl, locality, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -124,7 +128,7 @@ mixin IApplicationData on IInspectable {
   Pointer<COMObject> get LocalSettings {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(10)
             .cast<
                 Pointer<
@@ -132,7 +136,7 @@ mixin IApplicationData on IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -142,7 +146,7 @@ mixin IApplicationData on IInspectable {
   Pointer<COMObject> get RoamingSettings {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(11)
             .cast<
                 Pointer<
@@ -150,7 +154,7 @@ mixin IApplicationData on IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -160,7 +164,7 @@ mixin IApplicationData on IInspectable {
   Pointer<COMObject> get LocalFolder {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(12)
             .cast<
                 Pointer<
@@ -168,7 +172,7 @@ mixin IApplicationData on IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -178,7 +182,7 @@ mixin IApplicationData on IInspectable {
   Pointer<COMObject> get RoamingFolder {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(13)
             .cast<
                 Pointer<
@@ -186,7 +190,7 @@ mixin IApplicationData on IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -196,7 +200,7 @@ mixin IApplicationData on IInspectable {
   Pointer<COMObject> get TemporaryFolder {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
             .elementAt(14)
             .cast<
                 Pointer<
@@ -204,31 +208,59 @@ mixin IApplicationData on IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        _thisPtr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
     return retValuePtr;
   }
 
+  int add_DataChanged(Pointer<NativeFunction<TypedEventHandler>> handler) {
+    final retValuePtr = calloc<IntPtr>();
+
+    try {
+      final hr = ptr.ref.vtable
+          .elementAt(15)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      HRESULT Function(
+                          Pointer,
+                          Pointer<NativeFunction<TypedEventHandler>> handler,
+                          Pointer<IntPtr>)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer,
+                  Pointer<NativeFunction<TypedEventHandler>> handler,
+                  Pointer<IntPtr>)>()(ptr.ref.lpVtbl, handler, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      final retValue = retValuePtr.value;
+      return retValue;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
   void remove_DataChanged(int token) {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(16)
         .cast<
-            Pointer<NativeFunction<HRESULT Function(Pointer, Uint64 token)>>>()
+            Pointer<NativeFunction<HRESULT Function(Pointer, IntPtr token)>>>()
         .value
-        .asFunction<
-            int Function(Pointer, int token)>()(_thisPtr.ref.lpVtbl, token);
+        .asFunction<int Function(Pointer, int token)>()(ptr.ref.lpVtbl, token);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void SignalDataChanged() {
-    final hr = _thisPtr.ref.vtable
+    final hr = ptr.ref.vtable
         .elementAt(17)
         .cast<Pointer<NativeFunction<HRESULT Function(Pointer)>>>()
         .value
-        .asFunction<int Function(Pointer)>()(_thisPtr.ref.lpVtbl);
+        .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -237,15 +269,15 @@ mixin IApplicationData on IInspectable {
     final retValuePtr = calloc<Uint64>();
 
     try {
-      final hr = _thisPtr.ref.vtable
+      final hr = ptr.ref.vtable
           .elementAt(18)
           .cast<
               Pointer<
                   NativeFunction<HRESULT Function(Pointer, Pointer<Uint64>)>>>()
           .value
           .asFunction<
-              int Function(Pointer,
-                  Pointer<Uint64>)>()(_thisPtr.ref.lpVtbl, retValuePtr);
+              int Function(
+                  Pointer, Pointer<Uint64>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/lib/src/winrt/igamepad.dart
+++ b/lib/src/winrt/igamepad.dart
@@ -23,6 +23,9 @@ import '../extensions/hstring_array.dart';
 
 import 'igamecontroller.dart';
 import 'structs.g.dart';
+import 'headset.dart';
+import 'userchangedeventargs.dart';
+import 'user.dart';
 import '../com/iinspectable.dart';
 
 /// @nodoc
@@ -30,7 +33,7 @@ const IID_IGamepad = '{BC7BB43C-0A69-3903-9E9D-A50F86A45DE5}';
 
 /// {@category Interface}
 /// {@category winrt}
-class IGamepad extends IGameController {
+class IGamepad extends IInspectable implements IGameController {
   // vtable begins at 6, is 3 entries long.
   IGamepad(super.ptr);
 
@@ -95,4 +98,42 @@ class IGamepad extends IGameController {
       free(retValuePtr);
     }
   }
+
+  // IGameController methods
+  late final _iGameController =
+      IGameController(toInterface(IID_IGameController));
+
+  @override
+  int add_HeadsetConnected(Pointer<NativeFunction<TypedEventHandler>> value) =>
+      _iGameController.add_HeadsetConnected(value);
+
+  @override
+  void remove_HeadsetConnected(int token) =>
+      _iGameController.remove_HeadsetConnected(token);
+
+  @override
+  int add_HeadsetDisconnected(
+          Pointer<NativeFunction<TypedEventHandler>> value) =>
+      _iGameController.add_HeadsetDisconnected(value);
+
+  @override
+  void remove_HeadsetDisconnected(int token) =>
+      _iGameController.remove_HeadsetDisconnected(token);
+
+  @override
+  int add_UserChanged(Pointer<NativeFunction<TypedEventHandler>> value) =>
+      _iGameController.add_UserChanged(value);
+
+  @override
+  void remove_UserChanged(int token) =>
+      _iGameController.remove_UserChanged(token);
+
+  @override
+  Pointer<COMObject> get Headset => _iGameController.Headset;
+
+  @override
+  bool get IsWireless => _iGameController.IsWireless;
+
+  @override
+  Pointer<COMObject> get User => _iGameController.User;
 }

--- a/lib/src/winrt/igamepad2.dart
+++ b/lib/src/winrt/igamepad2.dart
@@ -23,6 +23,10 @@ import '../extensions/hstring_array.dart';
 
 import 'igamepad.dart';
 import 'igamecontroller.dart';
+import 'structs.g.dart';
+import 'headset.dart';
+import 'userchangedeventargs.dart';
+import 'user.dart';
 import '../com/iinspectable.dart';
 
 /// @nodoc
@@ -30,7 +34,7 @@ const IID_IGamepad2 = '{3C1689BD-5915-4245-B0C0-C89FAE0308FF}';
 
 /// {@category Interface}
 /// {@category winrt}
-class IGamepad2 extends IGamepad {
+class IGamepad2 extends IInspectable implements IGamepad, IGameController {
   // vtable begins at 6, is 1 entries long.
   IGamepad2(super.ptr);
 
@@ -57,4 +61,53 @@ class IGamepad2 extends IGamepad {
       free(retValuePtr);
     }
   }
+
+  // IGamepad methods
+  late final _iGamepad = IGamepad(toInterface(IID_IGamepad));
+
+  @override
+  GamepadVibration get Vibration => _iGamepad.Vibration;
+
+  @override
+  set Vibration(GamepadVibration value) => _iGamepad.Vibration = value;
+
+  @override
+  GamepadReading GetCurrentReading() => _iGamepad.GetCurrentReading();
+  // IGameController methods
+  late final _iGameController =
+      IGameController(toInterface(IID_IGameController));
+
+  @override
+  int add_HeadsetConnected(Pointer<NativeFunction<TypedEventHandler>> value) =>
+      _iGameController.add_HeadsetConnected(value);
+
+  @override
+  void remove_HeadsetConnected(int token) =>
+      _iGameController.remove_HeadsetConnected(token);
+
+  @override
+  int add_HeadsetDisconnected(
+          Pointer<NativeFunction<TypedEventHandler>> value) =>
+      _iGameController.add_HeadsetDisconnected(value);
+
+  @override
+  void remove_HeadsetDisconnected(int token) =>
+      _iGameController.remove_HeadsetDisconnected(token);
+
+  @override
+  int add_UserChanged(Pointer<NativeFunction<TypedEventHandler>> value) =>
+      _iGameController.add_UserChanged(value);
+
+  @override
+  void remove_UserChanged(int token) =>
+      _iGameController.remove_UserChanged(token);
+
+  @override
+  Pointer<COMObject> get Headset => _iGameController.Headset;
+
+  @override
+  bool get IsWireless => _iGameController.IsWireless;
+
+  @override
+  Pointer<COMObject> get User => _iGameController.User;
 }

--- a/lib/src/winrt/igamepadstatics2.dart
+++ b/lib/src/winrt/igamepadstatics2.dart
@@ -24,6 +24,7 @@ import '../extensions/hstring_array.dart';
 import 'igamepadstatics.dart';
 import 'igamecontroller.dart';
 import 'gamepad.dart';
+import 'ivectorview.dart';
 import '../com/iinspectable.dart';
 
 /// @nodoc
@@ -31,7 +32,7 @@ const IID_IGamepadStatics2 = '{42676DC5-0856-47C4-9213-B395504C3A3C}';
 
 /// {@category Interface}
 /// {@category winrt}
-class IGamepadStatics2 extends IGamepadStatics {
+class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
   // vtable begins at 6, is 1 entries long.
   IGamepadStatics2(super.ptr);
 
@@ -58,4 +59,27 @@ class IGamepadStatics2 extends IGamepadStatics {
 
     return retValuePtr;
   }
+
+  // IGamepadStatics methods
+  late final _iGamepadStatics =
+      IGamepadStatics(toInterface(IID_IGamepadStatics));
+
+  @override
+  int add_GamepadAdded(Pointer<NativeFunction<EventHandler>> value) =>
+      _iGamepadStatics.add_GamepadAdded(value);
+
+  @override
+  void remove_GamepadAdded(int token) =>
+      _iGamepadStatics.remove_GamepadAdded(token);
+
+  @override
+  int add_GamepadRemoved(Pointer<NativeFunction<EventHandler>> value) =>
+      _iGamepadStatics.add_GamepadRemoved(value);
+
+  @override
+  void remove_GamepadRemoved(int token) =>
+      _iGamepadStatics.remove_GamepadRemoved(token);
+
+  @override
+  List<String> get Gamepads => _iGamepadStatics.Gamepads;
 }

--- a/lib/src/winrt/ixmlnodelist.dart
+++ b/lib/src/winrt/ixmlnodelist.dart
@@ -22,6 +22,7 @@ import '../winrt_helpers.dart';
 import '../extensions/hstring_array.dart';
 
 import 'ixmlnode.dart';
+import 'jsonarray.dart';
 import '../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/jsonarray.dart
+++ b/lib/src/winrt/jsonarray.dart
@@ -1,0 +1,1 @@
+// TODO Implement this library.

--- a/lib/src/winrt/jsonarray.dart
+++ b/lib/src/winrt/jsonarray.dart
@@ -1,1 +1,1 @@
-// TODO Implement this library.
+

--- a/lib/src/winrt_callbacks.dart
+++ b/lib/src/winrt_callbacks.dart
@@ -10,6 +10,8 @@ import 'dart:ffi';
 
 import 'combase.dart';
 
+typedef ApplicationDataSetVersionHandler = Void Function(
+    Pointer<COMObject> setVersionRequest);
 typedef AsyncActionCompletedHandler = Void Function(
     Pointer<COMObject> asyncInfo, Int32 asyncStatus);
 typedef EventHandler = Void Function(

--- a/tool/generator/lib/src/projection/com_interface.dart
+++ b/tool/generator/lib/src/projection/com_interface.dart
@@ -99,8 +99,13 @@ class ComInterfaceProjection {
   // TODO: Find duplicates. This is the "correct" one.
   Set<String> importsForClass() {
     final importList = <String>{};
+    final methods = {
+      ...typeDef.methods,
+      // Also add the methods in typeDef's interfaces
+      ...[for (var typeDef in typeDef.interfaces) ...typeDef.methods]
+    };
 
-    for (final method in typeDef.methods) {
+    for (final method in methods) {
       final paramsAndReturnType = [...method.parameters, method.returnType];
       for (final param in paramsAndReturnType) {
         // Add imports for a parameter itself (e.g. VARIANT)

--- a/tool/generator/lib/src/projection/winrt_class.dart
+++ b/tool/generator/lib/src/projection/winrt_class.dart
@@ -115,7 +115,7 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
   List<TypeDef> get implementsInterfaces => [...typeDef.interfaces]
     ..removeWhere(
         (interface) => interface.name == 'Windows.Foundation.IStringable')
-    // Generic collections' interface name returns empty and that breaks lots
+    // Generic collections' typeDef returns an empty name and that breaks lots
     // of things. We need to ignore them for now
     ..removeWhere((interface) => interface.name.isEmpty);
 

--- a/tool/generator/lib/src/projection/winrt_class.dart
+++ b/tool/generator/lib/src/projection/winrt_class.dart
@@ -112,9 +112,12 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
 
   // Clone the list, otherwise isStringable will give unpredictable results.
   @override
-  List<TypeDef> get implementsInterfaces =>
-      [...typeDef.interfaces]..removeWhere(
-          (interface) => interface.name == 'Windows.Foundation.IStringable');
+  List<TypeDef> get implementsInterfaces => [...typeDef.interfaces]
+    ..removeWhere(
+        (interface) => interface.name == 'Windows.Foundation.IStringable')
+    // Generic collections' interface name returns empty and that breaks lots
+    // of things. We need to ignore them for now
+    ..removeWhere((interface) => interface.name.isEmpty);
 
   bool get isStringable => typeDef.interfaces
       .map((i) => i.name)

--- a/tool/generator/lib/src/projection/winrt_interface.dart
+++ b/tool/generator/lib/src/projection/winrt_interface.dart
@@ -137,8 +137,10 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
   String get classDeclaration => 'class $shortName extends IInspectable'
       '${inheritsFrom.isNotEmpty ? ' implements $inheritsFrom {' : ' {'}';
 
-  List<TypeDef> get implementsInterfaces =>
-      typeDef.interfaces..removeWhere((interface) => interface.name.isEmpty);
+  List<TypeDef> get implementsInterfaces => typeDef.interfaces
+    // Generic collections' interface name returns empty and that breaks lots
+    // of things. We need to ignore them for now
+    ..removeWhere((interface) => interface.name.isEmpty);
 
   String get implementsMappers {
     final buffer = StringBuffer();

--- a/tool/generator/lib/src/projection/winrt_interface.dart
+++ b/tool/generator/lib/src/projection/winrt_interface.dart
@@ -138,7 +138,7 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
       '${inheritsFrom.isNotEmpty ? ' implements $inheritsFrom {' : ' {'}';
 
   List<TypeDef> get implementsInterfaces => typeDef.interfaces
-    // Generic collections' interface name returns empty and that breaks lots
+    // Generic collections' typeDef returns an empty name and that breaks lots
     // of things. We need to ignore them for now
     ..removeWhere((interface) => interface.name.isEmpty);
 

--- a/tool/generator/test/winrt_projection_test.dart
+++ b/tool/generator/test/winrt_projection_test.dart
@@ -67,7 +67,7 @@ void main() {
         MetadataStore.getMetadataForType('Windows.Foundation.IPropertyValue');
 
     final projection = WinRTInterfaceProjection(winTypeDef!);
-    expect(projection.inheritsFrom, equals('IInspectable'));
+    expect(projection.inheritsFrom, equals(''));
   });
 
   test('WinRT interface has right short name', () {

--- a/tool/generator/test/winrt_projection_test.dart
+++ b/tool/generator/test/winrt_projection_test.dart
@@ -147,6 +147,7 @@ void main() {
     final projection = WinRTClassProjection(winTypeDef!);
     expect(projection.importHeader, contains("import 'structs.g.dart'"));
   });
+
   test('WinRT interface includes correct import file for structs', () {
     final winTypeDef =
         MetadataStore.getMetadataForType('Windows.Gaming.Input.IGamepad');
@@ -389,6 +390,31 @@ void main() {
         equals('class Launcher extends IInspectable {'));
   });
 
+  test('WinRT interface that includes implements keyword in class declaration',
+      () {
+    final winTypeDef =
+        MetadataStore.getMetadataForType('Windows.Gaming.Input.IGamepad');
+
+    final projection = WinRTInterfaceProjection(winTypeDef!);
+    expect(projection.inheritsFrom, isNotEmpty);
+    expect(
+        projection.classDeclaration,
+        equals(
+            'class IGamepad extends IInspectable implements IGameController {'));
+  });
+
+  test(
+      'WinRT interface that does not include implements keyword in class declaration',
+      () {
+    final winTypeDef =
+        MetadataStore.getMetadataForType('Windows.Globalization.ICalendar');
+
+    final projection = WinRTInterfaceProjection(winTypeDef!);
+    expect(projection.inheritsFrom, isEmpty);
+    expect(projection.classDeclaration,
+        equals('class ICalendar extends IInspectable {'));
+  });
+
   test('WinRT class that inherits IStringable has Dart toString()', () {
     //
     final winTypeDef = MetadataStore.getMetadataForType(
@@ -434,5 +460,17 @@ void main() {
     expect(projection.factoryMappers, isEmpty);
     expect(projection.staticMappers, isEmpty);
     expect(projection.classNameDeclaration, isEmpty);
+  });
+
+  test('WinRT interface includes imports for methods in implemented interfaces',
+      () {
+    final winTypeDef =
+        MetadataStore.getMetadataForType('Windows.Gaming.Input.IGamepad');
+
+    final projection = WinRTClassProjection(winTypeDef!);
+    expect(projection.importHeader, contains("import 'headset.dart'"));
+    expect(projection.importHeader, contains("import 'user.dart'"));
+    expect(projection.importHeader,
+        contains("import 'userchangedeventargs.dart'"));
   });
 }


### PR DESCRIPTION
Closes #473

Also, I regenerated `ApplicationData` class and `IApplicationData` interface as they were a bit outdated.