### PR TITLE
Convert WinRT Interface default constructors to named ones

### DIFF
--- a/doc/winrt.md
+++ b/doc/winrt.md
@@ -24,7 +24,7 @@ to the object type desired. For example:
 
 ```dart
 final comObject = CreateObject('Windows.Globalization.Calendar', IID_ICalendar);
-final calendar = ICalendar(comObject);
+final calendar = ICalendar.from(comObject);
 ```
 
 The object should be disposed of when it is no longer in use, for example:

--- a/example/appcontainer.dart
+++ b/example/appcontainer.dart
@@ -44,7 +44,7 @@ void main() {
 
   print('${!isAppContainer() ? '!' : ''}isAppContainer');
 
-  final userData = UserDataPaths.fromPointer(UserDataPaths.GetDefault());
+  final userData = UserDataPaths.from(UserDataPaths.GetDefault());
   final roamingAppData = userData.RoamingAppData;
   print('RoamingAppData: $roamingAppData');
 

--- a/example/calendar.dart
+++ b/example/calendar.dart
@@ -21,7 +21,7 @@ void main() {
     final calendar = Calendar();
     print(calendarData(calendar));
 
-    final clonedCalendar = Calendar.fromPointer(calendar.Clone());
+    final clonedCalendar = Calendar.from(calendar.Clone());
     final comparisonResult = clonedCalendar.Compare(calendar.ptr);
     print('Comparison result of calendar and its clone: $comparisonResult');
 

--- a/example/storage.dart
+++ b/example/storage.dart
@@ -6,7 +6,7 @@ void main() {
   // Requires a package identity.
   final currAppData = ApplicationData.Current;
   print(currAppData.trustLevel);
-  final localFolder = IStorageItem(currAppData.LocalFolder);
+  final localFolder = IStorageItem.from(currAppData.LocalFolder);
   final localPath = localFolder.Path;
 
   print('Local folder path: $localPath');

--- a/example/winrt_picker.dart
+++ b/example/winrt_picker.dart
@@ -16,7 +16,7 @@ void main() async {
   final object = CreateObject(
       'Windows.Storage.Pickers.FileOpenPicker', IID_IFileOpenPicker);
 
-  final picker = IFileOpenPicker(object)
+  final picker = IFileOpenPicker.from(object)
     ..SuggestedStartLocation = PickerLocationId.Desktop
     ..ViewMode = PickerViewMode.Thumbnail;
 

--- a/lib/src/extensions/comobject_pointer.dart
+++ b/lib/src/extensions/comobject_pointer.dart
@@ -16,15 +16,15 @@ extension COMObjectPointer on Pointer<COMObject> {
   ///
   /// `T` must be a `WinRT` type. e.g. `IHostName`, `IStorageFile` ...
   ///
-  /// `creator` must be specified for the given `T`. e.g. `IHostName.new`,
-  /// `IStorageFile.new`
+  /// `creator` must be specified for the given `T`. e.g. `IHostName.from`,
+  /// `IStorageFile.from`
   ///
   /// `length` must be equal to the number of elements stored inside the
   /// `Pointer<COMObject>`.
   ///
   /// ```dart
   /// ...
-  /// final list = pComObject.toList<IHostName>(IHostName.new, length: 4);
+  /// final list = pComObject.toList<IHostName>(IHostName.from, length: 4);
   /// ```
   ///
   /// {@category winrt}

--- a/lib/src/winrt/applicationdata.dart
+++ b/lib/src/winrt/applicationdata.dart
@@ -29,7 +29,7 @@ import 'user.dart';
 /// {@category Class}
 /// {@category winrt}
 class ApplicationData extends IInspectable implements IApplicationData {
-  ApplicationData.fromPointer(super.ptr);
+  ApplicationData.from(super.ptr);
 
   static const _className = 'Windows.Storage.ApplicationData';
 
@@ -39,8 +39,8 @@ class ApplicationData extends IInspectable implements IApplicationData {
         CreateActivationFactory(_className, IID_IApplicationDataStatics);
 
     try {
-      final result = ApplicationData.fromPointer(
-          IApplicationDataStatics(activationFactory).Current);
+      final result = ApplicationData.from(
+          IApplicationDataStatics.from(activationFactory).Current);
       return result;
     } finally {
       free(activationFactory);
@@ -49,7 +49,7 @@ class ApplicationData extends IInspectable implements IApplicationData {
 
   // IApplicationData methods
   late final _iApplicationData =
-      IApplicationData(toInterface(IID_IApplicationData));
+      IApplicationData.from(toInterface(IID_IApplicationData));
 
   @override
   int get Version => _iApplicationData.Version;

--- a/lib/src/winrt/calendar.dart
+++ b/lib/src/winrt/calendar.dart
@@ -34,7 +34,7 @@ import '../com/iinspectable.dart';
 class Calendar extends IInspectable implements ICalendar, ITimeZoneOnCalendar {
   Calendar({Allocator allocator = calloc})
       : super(ActivateClass(_className, allocator: allocator));
-  Calendar.fromPointer(super.ptr);
+  Calendar.from(super.ptr);
 
   static const _className = 'Windows.Globalization.Calendar';
 
@@ -45,9 +45,9 @@ class Calendar extends IInspectable implements ICalendar, ITimeZoneOnCalendar {
         CreateActivationFactory(_className, IID_ICalendarFactory);
 
     try {
-      final result = ICalendarFactory(activationFactory)
+      final result = ICalendarFactory.from(activationFactory)
           .CreateCalendarDefaultCalendarAndClock(languages);
-      return Calendar.fromPointer(result);
+      return Calendar.from(result);
     } finally {
       free(activationFactory);
     }
@@ -59,9 +59,9 @@ class Calendar extends IInspectable implements ICalendar, ITimeZoneOnCalendar {
         CreateActivationFactory(_className, IID_ICalendarFactory);
 
     try {
-      final result = ICalendarFactory(activationFactory)
+      final result = ICalendarFactory.from(activationFactory)
           .CreateCalendar(languages, calendar, clock);
-      return Calendar.fromPointer(result);
+      return Calendar.from(result);
     } finally {
       free(activationFactory);
     }
@@ -74,16 +74,16 @@ class Calendar extends IInspectable implements ICalendar, ITimeZoneOnCalendar {
         CreateActivationFactory(_className, IID_ICalendarFactory2);
 
     try {
-      final result = ICalendarFactory2(activationFactory)
+      final result = ICalendarFactory2.from(activationFactory)
           .CreateCalendarWithTimeZone(languages, calendar, clock, timeZoneId);
-      return Calendar.fromPointer(result);
+      return Calendar.from(result);
     } finally {
       free(activationFactory);
     }
   }
 
   // ICalendar methods
-  late final _iCalendar = ICalendar(toInterface(IID_ICalendar));
+  late final _iCalendar = ICalendar.from(toInterface(IID_ICalendar));
 
   @override
   Pointer<COMObject> Clone() => _iCalendar.Clone();
@@ -395,7 +395,7 @@ class Calendar extends IInspectable implements ICalendar, ITimeZoneOnCalendar {
   bool get IsDaylightSavingTime => _iCalendar.IsDaylightSavingTime;
   // ITimeZoneOnCalendar methods
   late final _iTimeZoneOnCalendar =
-      ITimeZoneOnCalendar(toInterface(IID_ITimeZoneOnCalendar));
+      ITimeZoneOnCalendar.from(toInterface(IID_ITimeZoneOnCalendar));
 
   @override
   String GetTimeZone() => _iTimeZoneOnCalendar.GetTimeZone();

--- a/lib/src/winrt/gamepad.dart
+++ b/lib/src/winrt/gamepad.dart
@@ -43,7 +43,7 @@ class Gamepad extends IInspectable
         IGameController,
         IGamepad2,
         IGameControllerBatteryInfo {
-  Gamepad.fromPointer(super.ptr);
+  Gamepad.from(super.ptr);
 
   static const _className = 'Windows.Gaming.Input.Gamepad';
 
@@ -53,7 +53,8 @@ class Gamepad extends IInspectable
         CreateActivationFactory(_className, IID_IGamepadStatics);
 
     try {
-      final result = IGamepadStatics(activationFactory).add_GamepadAdded(value);
+      final result =
+          IGamepadStatics.from(activationFactory).add_GamepadAdded(value);
       return result;
     } finally {
       free(activationFactory);
@@ -66,7 +67,7 @@ class Gamepad extends IInspectable
 
     try {
       final result =
-          IGamepadStatics(activationFactory).remove_GamepadAdded(token);
+          IGamepadStatics.from(activationFactory).remove_GamepadAdded(token);
       return result;
     } finally {
       free(activationFactory);
@@ -79,7 +80,7 @@ class Gamepad extends IInspectable
 
     try {
       final result =
-          IGamepadStatics(activationFactory).add_GamepadRemoved(value);
+          IGamepadStatics.from(activationFactory).add_GamepadRemoved(value);
       return result;
     } finally {
       free(activationFactory);
@@ -92,7 +93,7 @@ class Gamepad extends IInspectable
 
     try {
       final result =
-          IGamepadStatics(activationFactory).remove_GamepadRemoved(token);
+          IGamepadStatics.from(activationFactory).remove_GamepadRemoved(token);
       return result;
     } finally {
       free(activationFactory);
@@ -104,7 +105,7 @@ class Gamepad extends IInspectable
         CreateActivationFactory(_className, IID_IGamepadStatics);
 
     try {
-      final result = IGamepadStatics(activationFactory).Gamepads;
+      final result = IGamepadStatics.from(activationFactory).Gamepads;
       return result;
     } finally {
       free(activationFactory);
@@ -118,7 +119,7 @@ class Gamepad extends IInspectable
         CreateActivationFactory(_className, IID_IGamepadStatics2);
 
     try {
-      final result = IGamepadStatics2(activationFactory)
+      final result = IGamepadStatics2.from(activationFactory)
           .FromGameController(gameController);
       return result;
     } finally {
@@ -127,7 +128,7 @@ class Gamepad extends IInspectable
   }
 
   // IGamepad methods
-  late final _iGamepad = IGamepad(toInterface(IID_IGamepad));
+  late final _iGamepad = IGamepad.from(toInterface(IID_IGamepad));
 
   @override
   GamepadVibration get Vibration => _iGamepad.Vibration;
@@ -139,7 +140,7 @@ class Gamepad extends IInspectable
   GamepadReading GetCurrentReading() => _iGamepad.GetCurrentReading();
   // IGameController methods
   late final _iGameController =
-      IGameController(toInterface(IID_IGameController));
+      IGameController.from(toInterface(IID_IGameController));
 
   @override
   int add_HeadsetConnected(Pointer<NativeFunction<TypedEventHandler>> value) =>
@@ -175,13 +176,13 @@ class Gamepad extends IInspectable
   @override
   Pointer<COMObject> get User => _iGameController.User;
   // IGamepad2 methods
-  late final _iGamepad2 = IGamepad2(toInterface(IID_IGamepad2));
+  late final _iGamepad2 = IGamepad2.from(toInterface(IID_IGamepad2));
 
   @override
   int GetButtonLabel(int button) => _iGamepad2.GetButtonLabel(button);
   // IGameControllerBatteryInfo methods
-  late final _iGameControllerBatteryInfo =
-      IGameControllerBatteryInfo(toInterface(IID_IGameControllerBatteryInfo));
+  late final _iGameControllerBatteryInfo = IGameControllerBatteryInfo.from(
+      toInterface(IID_IGameControllerBatteryInfo));
 
   @override
   Pointer<COMObject> TryGetBatteryReport() =>

--- a/lib/src/winrt/iapplicationdata.dart
+++ b/lib/src/winrt/iapplicationdata.dart
@@ -30,7 +30,7 @@ const IID_IApplicationData = '{C3DA6FB7-B744-4B45-B0B8-223A0938D0DC}';
 /// {@category winrt}
 class IApplicationData extends IInspectable {
   // vtable begins at 6, is 13 entries long.
-  IApplicationData(super.ptr);
+  IApplicationData.from(super.ptr);
 
   int get Version {
     final retValuePtr = calloc<Uint32>();

--- a/lib/src/winrt/iapplicationdatastatics.dart
+++ b/lib/src/winrt/iapplicationdatastatics.dart
@@ -31,7 +31,7 @@ const IID_IApplicationDataStatics = '{5612147B-E843-45E3-94D8-06169E3C8E17}';
 /// {@category winrt}
 class IApplicationDataStatics extends IInspectable {
   // vtable begins at 6, is 1 entries long.
-  IApplicationDataStatics(super.ptr);
+  IApplicationDataStatics.from(super.ptr);
 
   Pointer<COMObject> get Current {
     final retValuePtr = calloc<COMObject>();

--- a/lib/src/winrt/iasyncinfo.dart
+++ b/lib/src/winrt/iasyncinfo.dart
@@ -30,7 +30,7 @@ const IID_IAsyncInfo = '{00000036-0000-0000-C000-000000000046}';
 /// {@category winrt}
 class IAsyncInfo extends IInspectable {
   // vtable begins at 6, is 5 entries long.
-  IAsyncInfo(super.ptr);
+  IAsyncInfo.from(super.ptr);
 
   int get Id {
     final retValuePtr = calloc<Uint32>();

--- a/lib/src/winrt/icalendar.dart
+++ b/lib/src/winrt/icalendar.dart
@@ -32,7 +32,7 @@ const IID_ICalendar = '{CA30221D-86D9-40FB-A26B-D44EB7CF08EA}';
 /// {@category winrt}
 class ICalendar extends IInspectable {
   // vtable begins at 6, is 98 entries long.
-  ICalendar(super.ptr);
+  ICalendar.from(super.ptr);
 
   Pointer<COMObject> Clone() {
     final retValuePtr = calloc<COMObject>();
@@ -88,7 +88,7 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
 
     try {
-      return IVectorView<String>(retValuePtr).toList();
+      return IVectorView<String>.from(retValuePtr).toList();
     } finally {
       free(retValuePtr);
     }

--- a/lib/src/winrt/icalendarfactory.dart
+++ b/lib/src/winrt/icalendarfactory.dart
@@ -32,7 +32,7 @@ const IID_ICalendarFactory = '{83F58412-E56B-4C75-A66E-0F63D57758A6}';
 /// {@category winrt}
 class ICalendarFactory extends IInspectable {
   // vtable begins at 6, is 2 entries long.
-  ICalendarFactory(super.ptr);
+  ICalendarFactory.from(super.ptr);
 
   Pointer<COMObject> CreateCalendarDefaultCalendarAndClock(
       Pointer<COMObject> languages) {

--- a/lib/src/winrt/icalendarfactory2.dart
+++ b/lib/src/winrt/icalendarfactory2.dart
@@ -32,7 +32,7 @@ const IID_ICalendarFactory2 = '{B44B378C-CA7E-4590-9E72-EA2BEC1A5115}';
 /// {@category winrt}
 class ICalendarFactory2 extends IInspectable {
   // vtable begins at 6, is 1 entries long.
-  ICalendarFactory2(super.ptr);
+  ICalendarFactory2.from(super.ptr);
 
   Pointer<COMObject> CreateCalendarWithTimeZone(Pointer<COMObject> languages,
       String calendar, String clock, String timeZoneId) {

--- a/lib/src/winrt/iclosable.dart
+++ b/lib/src/winrt/iclosable.dart
@@ -30,7 +30,7 @@ const IID_IClosable = '{30D5A829-7FA4-4026-83BB-D75BAE4EA99E}';
 /// {@category winrt}
 class IClosable extends IInspectable {
   // vtable begins at 6, is 1 entries long.
-  IClosable(super.ptr);
+  IClosable.from(super.ptr);
 
   void Close() {
     final hr = ptr.ref.vtable

--- a/lib/src/winrt/ifileopenpicker.dart
+++ b/lib/src/winrt/ifileopenpicker.dart
@@ -34,7 +34,7 @@ const IID_IFileOpenPicker = '{2CA8278A-12C5-4C5F-8977-94547793C241}';
 /// {@category winrt}
 class IFileOpenPicker extends IInspectable {
   // vtable begins at 6, is 11 entries long.
-  IFileOpenPicker(super.ptr);
+  IFileOpenPicker.from(super.ptr);
 
   int get ViewMode {
     final retValuePtr = calloc<Int32>();
@@ -197,7 +197,7 @@ class IFileOpenPicker extends IInspectable {
 
     if (FAILED(hr)) throw WindowsException(hr);
 
-    return IVector(retValuePtr);
+    return IVector.from(retValuePtr);
   }
 
   Pointer<COMObject> PickSingleFileAsync() {

--- a/lib/src/winrt/igamecontroller.dart
+++ b/lib/src/winrt/igamecontroller.dart
@@ -33,7 +33,7 @@ const IID_IGameController = '{1BAF6522-5F64-42C5-8267-B9FE2215BFBD}';
 /// {@category winrt}
 class IGameController extends IInspectable {
   // vtable begins at 6, is 9 entries long.
-  IGameController(super.ptr);
+  IGameController.from(super.ptr);
 
   int add_HeadsetConnected(Pointer<NativeFunction<TypedEventHandler>> value) {
     final retValuePtr = calloc<IntPtr>();

--- a/lib/src/winrt/igamecontrollerbatteryinfo.dart
+++ b/lib/src/winrt/igamecontrollerbatteryinfo.dart
@@ -31,7 +31,7 @@ const IID_IGameControllerBatteryInfo = '{DCECC681-3963-4DA6-955D-553F3B6F6161}';
 /// {@category winrt}
 class IGameControllerBatteryInfo extends IInspectable {
   // vtable begins at 6, is 1 entries long.
-  IGameControllerBatteryInfo(super.ptr);
+  IGameControllerBatteryInfo.from(super.ptr);
 
   Pointer<COMObject> TryGetBatteryReport() {
     final retValuePtr = calloc<COMObject>();

--- a/lib/src/winrt/igamepad.dart
+++ b/lib/src/winrt/igamepad.dart
@@ -35,7 +35,7 @@ const IID_IGamepad = '{BC7BB43C-0A69-3903-9E9D-A50F86A45DE5}';
 /// {@category winrt}
 class IGamepad extends IInspectable implements IGameController {
   // vtable begins at 6, is 3 entries long.
-  IGamepad(super.ptr);
+  IGamepad.from(super.ptr);
 
   GamepadVibration get Vibration {
     final retValuePtr = calloc<GamepadVibration>();
@@ -101,7 +101,7 @@ class IGamepad extends IInspectable implements IGameController {
 
   // IGameController methods
   late final _iGameController =
-      IGameController(toInterface(IID_IGameController));
+      IGameController.from(toInterface(IID_IGameController));
 
   @override
   int add_HeadsetConnected(Pointer<NativeFunction<TypedEventHandler>> value) =>

--- a/lib/src/winrt/igamepad2.dart
+++ b/lib/src/winrt/igamepad2.dart
@@ -36,7 +36,7 @@ const IID_IGamepad2 = '{3C1689BD-5915-4245-B0C0-C89FAE0308FF}';
 /// {@category winrt}
 class IGamepad2 extends IInspectable implements IGamepad, IGameController {
   // vtable begins at 6, is 1 entries long.
-  IGamepad2(super.ptr);
+  IGamepad2.from(super.ptr);
 
   int GetButtonLabel(int button) {
     final retValuePtr = calloc<Int32>();
@@ -63,7 +63,7 @@ class IGamepad2 extends IInspectable implements IGamepad, IGameController {
   }
 
   // IGamepad methods
-  late final _iGamepad = IGamepad(toInterface(IID_IGamepad));
+  late final _iGamepad = IGamepad.from(toInterface(IID_IGamepad));
 
   @override
   GamepadVibration get Vibration => _iGamepad.Vibration;
@@ -75,7 +75,7 @@ class IGamepad2 extends IInspectable implements IGamepad, IGameController {
   GamepadReading GetCurrentReading() => _iGamepad.GetCurrentReading();
   // IGameController methods
   late final _iGameController =
-      IGameController(toInterface(IID_IGameController));
+      IGameController.from(toInterface(IID_IGameController));
 
   @override
   int add_HeadsetConnected(Pointer<NativeFunction<TypedEventHandler>> value) =>

--- a/lib/src/winrt/igamepadstatics.dart
+++ b/lib/src/winrt/igamepadstatics.dart
@@ -32,7 +32,7 @@ const IID_IGamepadStatics = '{8BBCE529-D49C-39E9-9560-E47DDE96B7C8}';
 /// {@category winrt}
 class IGamepadStatics extends IInspectable {
   // vtable begins at 6, is 5 entries long.
-  IGamepadStatics(super.ptr);
+  IGamepadStatics.from(super.ptr);
 
   int add_GamepadAdded(Pointer<NativeFunction<EventHandler>> value) {
     final retValuePtr = calloc<IntPtr>();
@@ -126,7 +126,7 @@ class IGamepadStatics extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
 
     try {
-      return IVectorView<String>(retValuePtr).toList();
+      return IVectorView<String>.from(retValuePtr).toList();
     } finally {
       free(retValuePtr);
     }

--- a/lib/src/winrt/igamepadstatics2.dart
+++ b/lib/src/winrt/igamepadstatics2.dart
@@ -34,7 +34,7 @@ const IID_IGamepadStatics2 = '{42676DC5-0856-47C4-9213-B395504C3A3C}';
 /// {@category winrt}
 class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
   // vtable begins at 6, is 1 entries long.
-  IGamepadStatics2(super.ptr);
+  IGamepadStatics2.from(super.ptr);
 
   Pointer<COMObject> FromGameController(Pointer<COMObject> gameController) {
     final retValuePtr = calloc<COMObject>();
@@ -62,7 +62,7 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
 
   // IGamepadStatics methods
   late final _iGamepadStatics =
-      IGamepadStatics(toInterface(IID_IGamepadStatics));
+      IGamepadStatics.from(toInterface(IID_IGamepadStatics));
 
   @override
   int add_GamepadAdded(Pointer<NativeFunction<EventHandler>> value) =>

--- a/lib/src/winrt/ihostname.dart
+++ b/lib/src/winrt/ihostname.dart
@@ -32,7 +32,7 @@ const IID_IHostName = '{BF8ECAAD-ED96-49A7-9084-D416CAE88DCB}';
 /// {@category winrt}
 class IHostName extends IInspectable {
   // vtable begins at 6, is 6 entries long.
-  IHostName(super.ptr);
+  IHostName.from(super.ptr);
 
   Pointer<COMObject> get IPInformation {
     final retValuePtr = calloc<COMObject>();

--- a/lib/src/winrt/iiterable.dart
+++ b/lib/src/winrt/iiterable.dart
@@ -30,16 +30,16 @@ class IIterable<T> extends IInspectable {
   ///
   /// ```dart
   /// ...
-  /// final iterable = IIterable<String>(ptr);
+  /// final iterable = IIterable<String>.from(ptr);
   /// ```
   ///
   /// `creator` must be specified if the `T` is a `WinRT` type.
-  /// e.g. `IHostName.new`, `IStorageFile.new` etc.
+  /// e.g. `IHostName.from`, `IStorageFile.from` etc.
   ///
   /// ```dart
   /// ...
   /// final allocator = Arena();
-  /// final iterable = IIterable<IHostName>(ptr, creator: IHostName.new,
+  /// final iterable = IIterable<IHostName>.from(ptr, creator: IHostName.from,
   ///     allocator: allocator);
   /// ```
   ///
@@ -48,7 +48,7 @@ class IIterable<T> extends IInspectable {
   /// may be passed as a custom allocator for ease of memory management.
   ///
   /// {@category winrt}
-  IIterable(super.ptr,
+  IIterable.from(super.ptr,
       {T Function(Pointer<COMObject>)? creator, Allocator allocator = calloc})
       : _creator = creator,
         _allocator = allocator {
@@ -76,6 +76,7 @@ class IIterable<T> extends IInspectable {
 
     if (FAILED(hr)) throw WindowsException(hr);
 
-    return IIterator(retValuePtr, creator: _creator, allocator: _allocator);
+    return IIterator.from(retValuePtr,
+        creator: _creator, allocator: _allocator);
   }
 }

--- a/lib/src/winrt/iiterator.dart
+++ b/lib/src/winrt/iiterator.dart
@@ -32,16 +32,16 @@ class IIterator<T> extends IInspectable {
   ///
   /// ```dart
   /// ...
-  /// final iterator = IIterator<String>(ptr);
+  /// final iterator = IIterator<String>.from(ptr);
   /// ```
   ///
   /// `creator` must be specified if the `T` is a `WinRT` type.
-  /// e.g. `IHostName.new`, `IStorageFile.new` etc.
+  /// e.g. `IHostName.from`, `IStorageFile.from` etc.
   ///
   /// ```dart
   /// ...
   /// final allocator = Arena();
-  /// final iterator = IIterator<IHostName>(ptr, creator: IHostName.new,
+  /// final iterator = IIterator<IHostName>.from(ptr, creator: IHostName.from,
   ///     allocator: allocator);
   /// ```
   ///
@@ -50,7 +50,7 @@ class IIterator<T> extends IInspectable {
   /// may be passed as a custom allocator for ease of memory management.
   ///
   /// {@category winrt}
-  IIterator(super.ptr,
+  IIterator.from(super.ptr,
       {T Function(Pointer<COMObject>)? creator, Allocator allocator = calloc})
       : _creator = creator,
         _allocator = allocator {

--- a/lib/src/winrt/inetworkinformationstatics.dart
+++ b/lib/src/winrt/inetworkinformationstatics.dart
@@ -144,9 +144,9 @@ class INetworkInformationStatics extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
 
     try {
-      return IVectorView<IHostName>(
+      return IVectorView<IHostName>.from(
         retValuePtr,
-        creator: IHostName.new,
+        creator: IHostName.from,
         allocator: allocator,
       ).toList();
     } finally {

--- a/lib/src/winrt/iphonenumberformatter.dart
+++ b/lib/src/winrt/iphonenumberformatter.dart
@@ -31,7 +31,7 @@ const IID_IPhoneNumberFormatter = '{1556B49E-BAD4-4B4A-900D-4407ADB7C981}';
 /// {@category winrt}
 class IPhoneNumberFormatter extends IInspectable {
   // vtable begins at 6, is 5 entries long.
-  IPhoneNumberFormatter(super.ptr);
+  IPhoneNumberFormatter.from(super.ptr);
 
   String Format(Pointer<COMObject> number) {
     final retValuePtr = calloc<HSTRING>();

--- a/lib/src/winrt/iphonenumberformatterstatics.dart
+++ b/lib/src/winrt/iphonenumberformatterstatics.dart
@@ -31,7 +31,7 @@ const IID_IPhoneNumberFormatterStatics =
 /// {@category winrt}
 class IPhoneNumberFormatterStatics extends IInspectable {
   // vtable begins at 6, is 4 entries long.
-  IPhoneNumberFormatterStatics(super.ptr);
+  IPhoneNumberFormatterStatics.from(super.ptr);
 
   void TryCreate(String regionCode, Pointer<COMObject> phoneNumber) {
     final regionCodeHstring = convertToHString(regionCode);

--- a/lib/src/winrt/iphonenumberinfo.dart
+++ b/lib/src/winrt/iphonenumberinfo.dart
@@ -31,7 +31,7 @@ const IID_IPhoneNumberInfo = '{1C7CE4DD-C8B4-4EA3-9AEF-B342E2C5B417}';
 /// {@category winrt}
 class IPhoneNumberInfo extends IInspectable {
   // vtable begins at 6, is 8 entries long.
-  IPhoneNumberInfo(super.ptr);
+  IPhoneNumberInfo.from(super.ptr);
 
   int get CountryCode {
     final retValuePtr = calloc<Int32>();

--- a/lib/src/winrt/iphonenumberinfofactory.dart
+++ b/lib/src/winrt/iphonenumberinfofactory.dart
@@ -31,7 +31,7 @@ const IID_IPhoneNumberInfoFactory = '{8202B964-ADAA-4CFF-8FCF-17E7516A28FF}';
 /// {@category winrt}
 class IPhoneNumberInfoFactory extends IInspectable {
   // vtable begins at 6, is 1 entries long.
-  IPhoneNumberInfoFactory(super.ptr);
+  IPhoneNumberInfoFactory.from(super.ptr);
 
   Pointer<COMObject> Create(String number) {
     final retValuePtr = calloc<COMObject>();

--- a/lib/src/winrt/iphonenumberinfostatics.dart
+++ b/lib/src/winrt/iphonenumberinfostatics.dart
@@ -30,7 +30,7 @@ const IID_IPhoneNumberInfoStatics = '{5B3F4F6A-86A9-40E9-8649-6D61161928D4}';
 /// {@category winrt}
 class IPhoneNumberInfoStatics extends IInspectable {
   // vtable begins at 6, is 2 entries long.
-  IPhoneNumberInfoStatics(super.ptr);
+  IPhoneNumberInfoStatics.from(super.ptr);
 
   int TryParse(String input, Pointer<COMObject> phoneNumber) {
     final retValuePtr = calloc<Int32>();

--- a/lib/src/winrt/ipropertyvalue.dart
+++ b/lib/src/winrt/ipropertyvalue.dart
@@ -189,7 +189,7 @@ typedef _GetRectArray_Dart = int Function(
 class IPropertyValue extends IInspectable {
   // vtable begins at 6, ends at 44
 
-  IPropertyValue(super.ptr);
+  IPropertyValue.from(super.ptr);
 
   int get Type {
     final retValuePtr = calloc<Uint32>();

--- a/lib/src/winrt/istorageitem.dart
+++ b/lib/src/winrt/istorageitem.dart
@@ -38,7 +38,7 @@ const IID_IStorageItem = '{4207A996-CA2F-42F7-BDE8-8B10457A7F30}';
 /// {@category winrt}
 class IStorageItem extends IInspectable {
   // vtable begins at 6, is 10 entries long.
-  IStorageItem(super.ptr);
+  IStorageItem.from(super.ptr);
 
   Pointer<COMObject> RenameAsyncOverloadDefaultOptions(String desiredName) {
     final retValuePtr = calloc<COMObject>();

--- a/lib/src/winrt/istringable.dart
+++ b/lib/src/winrt/istringable.dart
@@ -30,7 +30,7 @@ const IID_IStringable = '{96369F54-8EB6-48F0-ABCE-C1B211E627C3}';
 /// {@category winrt}
 class IStringable extends IInspectable {
   // vtable begins at 6, is 1 entries long.
-  IStringable(super.ptr);
+  IStringable.from(super.ptr);
 
   String ToString() {
     final retValuePtr = calloc<HSTRING>();

--- a/lib/src/winrt/itimezoneoncalendar.dart
+++ b/lib/src/winrt/itimezoneoncalendar.dart
@@ -30,7 +30,7 @@ const IID_ITimeZoneOnCalendar = '{BB3C25E5-46CF-4317-A3F5-02621AD54478}';
 /// {@category winrt}
 class ITimeZoneOnCalendar extends IInspectable {
   // vtable begins at 6, is 4 entries long.
-  ITimeZoneOnCalendar(super.ptr);
+  ITimeZoneOnCalendar.from(super.ptr);
 
   String GetTimeZone() {
     final retValuePtr = calloc<HSTRING>();

--- a/lib/src/winrt/itoastnotification.dart
+++ b/lib/src/winrt/itoastnotification.dart
@@ -35,7 +35,7 @@ const IID_IToastNotification = '{997E2675-059E-4E60-8B06-1760917C8B80}';
 /// {@category winrt}
 class IToastNotification extends IInspectable {
   // vtable begins at 6, is 9 entries long.
-  IToastNotification(super.ptr);
+  IToastNotification.from(super.ptr);
 
   Pointer<COMObject> get Content {
     final retValuePtr = calloc<COMObject>();

--- a/lib/src/winrt/itoastnotification2.dart
+++ b/lib/src/winrt/itoastnotification2.dart
@@ -30,7 +30,7 @@ const IID_IToastNotification2 = '{9DFB9FD1-143A-490E-90BF-B9FBA7132DE7}';
 /// {@category winrt}
 class IToastNotification2 extends IInspectable {
   // vtable begins at 6, is 6 entries long.
-  IToastNotification2(super.ptr);
+  IToastNotification2.from(super.ptr);
 
   set Tag(String value) {
     final hstr = convertToHString(value);

--- a/lib/src/winrt/itoastnotification3.dart
+++ b/lib/src/winrt/itoastnotification3.dart
@@ -30,7 +30,7 @@ const IID_IToastNotification3 = '{31E8AED8-8141-4F99-BC0A-C4ED21297D77}';
 /// {@category winrt}
 class IToastNotification3 extends IInspectable {
   // vtable begins at 6, is 4 entries long.
-  IToastNotification3(super.ptr);
+  IToastNotification3.from(super.ptr);
 
   int get NotificationMirroring {
     final retValuePtr = calloc<Int32>();

--- a/lib/src/winrt/itoastnotification4.dart
+++ b/lib/src/winrt/itoastnotification4.dart
@@ -31,7 +31,7 @@ const IID_IToastNotification4 = '{15154935-28EA-4727-88E9-C58680E2D118}';
 /// {@category winrt}
 class IToastNotification4 extends IInspectable {
   // vtable begins at 6, is 4 entries long.
-  IToastNotification4(super.ptr);
+  IToastNotification4.from(super.ptr);
 
   Pointer<COMObject> get Data {
     final retValuePtr = calloc<COMObject>();

--- a/lib/src/winrt/itoastnotification6.dart
+++ b/lib/src/winrt/itoastnotification6.dart
@@ -30,7 +30,7 @@ const IID_IToastNotification6 = '{43EBFE53-89AE-5C1E-A279-3AECFE9B6F54}';
 /// {@category winrt}
 class IToastNotification6 extends IInspectable {
   // vtable begins at 6, is 2 entries long.
-  IToastNotification6(super.ptr);
+  IToastNotification6.from(super.ptr);
 
   bool get ExpiresOnReboot {
     final retValuePtr = calloc<Bool>();

--- a/lib/src/winrt/itoastnotificationfactory.dart
+++ b/lib/src/winrt/itoastnotificationfactory.dart
@@ -32,7 +32,7 @@ const IID_IToastNotificationFactory = '{04124B20-82C6-4229-B109-FD9ED4662B53}';
 /// {@category winrt}
 class IToastNotificationFactory extends IInspectable {
   // vtable begins at 6, is 1 entries long.
-  IToastNotificationFactory(super.ptr);
+  IToastNotificationFactory.from(super.ptr);
 
   Pointer<COMObject> CreateToastNotification(Pointer<COMObject> content) {
     final retValuePtr = calloc<COMObject>();

--- a/lib/src/winrt/itoastnotificationmanagerstatics.dart
+++ b/lib/src/winrt/itoastnotificationmanagerstatics.dart
@@ -33,7 +33,7 @@ const IID_IToastNotificationManagerStatics =
 /// {@category winrt}
 class IToastNotificationManagerStatics extends IInspectable {
   // vtable begins at 6, is 3 entries long.
-  IToastNotificationManagerStatics(super.ptr);
+  IToastNotificationManagerStatics.from(super.ptr);
 
   Pointer<COMObject> CreateToastNotifier() {
     final retValuePtr = calloc<COMObject>();

--- a/lib/src/winrt/iuserdatapaths.dart
+++ b/lib/src/winrt/iuserdatapaths.dart
@@ -30,7 +30,7 @@ const IID_IUserDataPaths = '{F9C53912-ABC4-46FF-8A2B-DC9D7FA6E52F}';
 /// {@category winrt}
 class IUserDataPaths extends IInspectable {
   // vtable begins at 6, is 19 entries long.
-  IUserDataPaths(super.ptr);
+  IUserDataPaths.from(super.ptr);
 
   String get CameraRoll {
     final retValuePtr = calloc<HSTRING>();

--- a/lib/src/winrt/iuserdatapathsstatics.dart
+++ b/lib/src/winrt/iuserdatapathsstatics.dart
@@ -32,7 +32,7 @@ const IID_IUserDataPathsStatics = '{01B29DEF-E062-48A1-8B0C-F2C7A9CA56C0}';
 /// {@category winrt}
 class IUserDataPathsStatics extends IInspectable {
   // vtable begins at 6, is 2 entries long.
-  IUserDataPathsStatics(super.ptr);
+  IUserDataPathsStatics.from(super.ptr);
 
   Pointer<COMObject> GetForUser(Pointer<COMObject> user) {
     final retValuePtr = calloc<COMObject>();

--- a/lib/src/winrt/ivector.dart
+++ b/lib/src/winrt/ivector.dart
@@ -38,17 +38,17 @@ class IVector<T> extends IInspectable implements IIterable<T> {
   ///
   /// ```dart
   /// ...
-  /// final vector = IVector<String>(ptr);
+  /// final vector = IVector<String>.from(ptr);
   /// ```
   ///
   /// `creator` must be specified if the `T` is a `WinRT` type.
-  /// e.g. `IHostName.new`, `IStorageFile.new` etc.
+  /// e.g. `IHostName.from`, `IStorageFile.from` etc.
   ///
   /// ```dart
   /// ...
   /// final allocator = Arena();
-  /// final vector =
-  ///     IVector<IHostName>(ptr, creator: IHostName.new, allocator: allocator);
+  /// final vector = IVector<IHostName>.from(ptr,
+  ///     creator: IHostName.from, allocator: allocator);
   /// ```
   ///
   /// It is the caller's responsibility to deallocate the returned pointers
@@ -57,7 +57,7 @@ class IVector<T> extends IInspectable implements IIterable<T> {
   /// memory management.
   ///
   /// {@category winrt}
-  IVector(super.ptr,
+  IVector.from(super.ptr,
       {T Function(Pointer<COMObject>)? creator, Allocator allocator = calloc})
       : _creator = creator,
         _allocator = allocator {
@@ -192,7 +192,8 @@ class IVector<T> extends IInspectable implements IIterable<T> {
 
     if (FAILED(hr)) throw WindowsException(hr);
 
-    return IVectorView(retValuePtr, creator: _creator, allocator: _allocator)
+    return IVectorView.from(retValuePtr,
+            creator: _creator, allocator: _allocator)
         .toList();
   }
 
@@ -677,7 +678,7 @@ class IVector<T> extends IInspectable implements IIterable<T> {
   }
 
   // IID_IIterable is always the second item on the iids list for IVector
-  late final _iIterable = IIterable<T>(toInterface(iids[1]),
+  late final _iIterable = IIterable<T>.from(toInterface(iids[1]),
       creator: _creator, allocator: _allocator);
 
   @override

--- a/lib/src/winrt/ivectorview.dart
+++ b/lib/src/winrt/ivectorview.dart
@@ -35,24 +35,24 @@ class IVectorView<T> extends IInspectable implements IIterable<T> {
   ///
   /// ```dart
   /// ...
-  /// final vectorView = IVectorView<String>(ptr);
+  /// final vectorView = IVectorView<String>.from(ptr);
   /// ```
   ///
   /// `creator` must be specified if the `T` is a `WinRT` type.
-  /// e.g. `IHostName.new`, `IStorageFile.new` etc.
+  /// e.g. `IHostName.from`, `IStorageFile.from` etc.
   ///
   /// ```dart
   /// ...
   /// final allocator = Arena();
-  /// final vectorView = IVectorView<IHostName>(ptr,
-  ///     creator: IHostName.new, allocator: allocator);
+  /// final vectorView = IVectorView<IHostName>.from(ptr,
+  ///     creator: IHostName.from, allocator: allocator);
   /// ```
   ///
   /// It is the caller's responsibility to deallocate the returned pointers
   /// from methods like `GetAt`, `GetView` and `toList` when they are finished
   /// with it. A FFI `Arena` may be passed as a custom allocator for ease of
   /// memory management.
-  IVectorView(super.ptr,
+  IVectorView.from(super.ptr,
       {T Function(Pointer<COMObject>)? creator, Allocator allocator = calloc})
       : _creator = creator,
         _allocator = allocator {
@@ -355,7 +355,7 @@ class IVectorView<T> extends IInspectable implements IIterable<T> {
   }
 
   // IID_IIterable is always the last item on the iids list for IVectorView
-  late final _iIterable = IIterable<T>(toInterface(iids.last),
+  late final _iIterable = IIterable<T>.from(toInterface(iids.last),
       creator: _creator, allocator: _allocator);
 
   @override

--- a/lib/src/winrt/ixmlnodelist.dart
+++ b/lib/src/winrt/ixmlnodelist.dart
@@ -32,7 +32,7 @@ const IID_IXmlNodeList = '{8C60AD77-83A4-4EC1-9C54-7BA429E13DA6}';
 /// {@category winrt}
 class IXmlNodeList extends IInspectable {
   // vtable begins at 6, is 2 entries long.
-  IXmlNodeList(super.ptr);
+  IXmlNodeList.from(super.ptr);
 
   int get Length {
     final retValuePtr = calloc<Uint32>();

--- a/lib/src/winrt/phonenumberformatter.dart
+++ b/lib/src/winrt/phonenumberformatter.dart
@@ -32,7 +32,7 @@ class PhoneNumberFormatter extends IInspectable
     implements IPhoneNumberFormatter {
   PhoneNumberFormatter({Allocator allocator = calloc})
       : super(ActivateClass(_className, allocator: allocator));
-  PhoneNumberFormatter.fromPointer(super.ptr);
+  PhoneNumberFormatter.from(super.ptr);
 
   static const _className =
       'Windows.Globalization.PhoneNumberFormatting.PhoneNumberFormatter';
@@ -43,7 +43,7 @@ class PhoneNumberFormatter extends IInspectable
         CreateActivationFactory(_className, IID_IPhoneNumberFormatterStatics);
 
     try {
-      final result = IPhoneNumberFormatterStatics(activationFactory)
+      final result = IPhoneNumberFormatterStatics.from(activationFactory)
           .TryCreate(regionCode, phoneNumber);
       return result;
     } finally {
@@ -56,7 +56,7 @@ class PhoneNumberFormatter extends IInspectable
         CreateActivationFactory(_className, IID_IPhoneNumberFormatterStatics);
 
     try {
-      final result = IPhoneNumberFormatterStatics(activationFactory)
+      final result = IPhoneNumberFormatterStatics.from(activationFactory)
           .GetCountryCodeForRegion(regionCode);
       return result;
     } finally {
@@ -70,7 +70,7 @@ class PhoneNumberFormatter extends IInspectable
         CreateActivationFactory(_className, IID_IPhoneNumberFormatterStatics);
 
     try {
-      final result = IPhoneNumberFormatterStatics(activationFactory)
+      final result = IPhoneNumberFormatterStatics.from(activationFactory)
           .GetNationalDirectDialingPrefixForRegion(regionCode, stripNonDigit);
       return result;
     } finally {
@@ -83,7 +83,7 @@ class PhoneNumberFormatter extends IInspectable
         CreateActivationFactory(_className, IID_IPhoneNumberFormatterStatics);
 
     try {
-      final result = IPhoneNumberFormatterStatics(activationFactory)
+      final result = IPhoneNumberFormatterStatics.from(activationFactory)
           .WrapWithLeftToRightMarkers(number);
       return result;
     } finally {
@@ -93,7 +93,7 @@ class PhoneNumberFormatter extends IInspectable
 
   // IPhoneNumberFormatter methods
   late final _iPhoneNumberFormatter =
-      IPhoneNumberFormatter(toInterface(IID_IPhoneNumberFormatter));
+      IPhoneNumberFormatter.from(toInterface(IID_IPhoneNumberFormatter));
 
   @override
   String Format(Pointer<COMObject> number) =>

--- a/lib/src/winrt/phonenumberinfo.dart
+++ b/lib/src/winrt/phonenumberinfo.dart
@@ -30,7 +30,7 @@ import '../com/iinspectable.dart';
 /// {@category Class}
 /// {@category winrt}
 class PhoneNumberInfo extends IInspectable implements IPhoneNumberInfo {
-  PhoneNumberInfo.fromPointer(super.ptr);
+  PhoneNumberInfo.from(super.ptr);
 
   static const _className =
       'Windows.Globalization.PhoneNumberFormatting.PhoneNumberInfo';
@@ -41,8 +41,9 @@ class PhoneNumberInfo extends IInspectable implements IPhoneNumberInfo {
         CreateActivationFactory(_className, IID_IPhoneNumberInfoFactory);
 
     try {
-      final result = IPhoneNumberInfoFactory(activationFactory).Create(number);
-      return PhoneNumberInfo.fromPointer(result);
+      final result =
+          IPhoneNumberInfoFactory.from(activationFactory).Create(number);
+      return PhoneNumberInfo.from(result);
     } finally {
       free(activationFactory);
     }
@@ -54,7 +55,7 @@ class PhoneNumberInfo extends IInspectable implements IPhoneNumberInfo {
         CreateActivationFactory(_className, IID_IPhoneNumberInfoStatics);
 
     try {
-      final result = IPhoneNumberInfoStatics(activationFactory)
+      final result = IPhoneNumberInfoStatics.from(activationFactory)
           .TryParse(input, phoneNumber);
       return result;
     } finally {
@@ -68,7 +69,7 @@ class PhoneNumberInfo extends IInspectable implements IPhoneNumberInfo {
         CreateActivationFactory(_className, IID_IPhoneNumberInfoStatics);
 
     try {
-      final result = IPhoneNumberInfoStatics(activationFactory)
+      final result = IPhoneNumberInfoStatics.from(activationFactory)
           .TryParseWithRegion(input, regionCode, phoneNumber);
       return result;
     } finally {
@@ -78,7 +79,7 @@ class PhoneNumberInfo extends IInspectable implements IPhoneNumberInfo {
 
   // IPhoneNumberInfo methods
   late final _iPhoneNumberInfo =
-      IPhoneNumberInfo(toInterface(IID_IPhoneNumberInfo));
+      IPhoneNumberInfo.from(toInterface(IID_IPhoneNumberInfo));
 
   @override
   int get CountryCode => _iPhoneNumberInfo.CountryCode;
@@ -110,7 +111,7 @@ class PhoneNumberInfo extends IInspectable implements IPhoneNumberInfo {
       _iPhoneNumberInfo.CheckNumberMatch(otherNumber);
 
   // IStringable methods
-  late final _iStringable = IStringable(toInterface(IID_IStringable));
+  late final _iStringable = IStringable.from(toInterface(IID_IStringable));
 
   @override
   String toString() => _iStringable.ToString();

--- a/lib/src/winrt/toastnotification.dart
+++ b/lib/src/winrt/toastnotification.dart
@@ -43,7 +43,7 @@ class ToastNotification extends IInspectable
         IToastNotification3,
         IToastNotification4,
         IToastNotification6 {
-  ToastNotification.fromPointer(super.ptr);
+  ToastNotification.from(super.ptr);
 
   static const _className = 'Windows.UI.Notifications.ToastNotification';
 
@@ -53,9 +53,9 @@ class ToastNotification extends IInspectable
         CreateActivationFactory(_className, IID_IToastNotificationFactory);
 
     try {
-      final result = IToastNotificationFactory(activationFactory)
+      final result = IToastNotificationFactory.from(activationFactory)
           .CreateToastNotification(content);
-      return ToastNotification.fromPointer(result);
+      return ToastNotification.from(result);
     } finally {
       free(activationFactory);
     }
@@ -63,7 +63,7 @@ class ToastNotification extends IInspectable
 
   // IToastNotification methods
   late final _iToastNotification =
-      IToastNotification(toInterface(IID_IToastNotification));
+      IToastNotification.from(toInterface(IID_IToastNotification));
 
   @override
   Pointer<COMObject> get Content => _iToastNotification.Content;
@@ -99,7 +99,7 @@ class ToastNotification extends IInspectable
   void remove_Failed(int token) => _iToastNotification.remove_Failed(token);
   // IToastNotification2 methods
   late final _iToastNotification2 =
-      IToastNotification2(toInterface(IID_IToastNotification2));
+      IToastNotification2.from(toInterface(IID_IToastNotification2));
 
   @override
   set Tag(String value) => _iToastNotification2.Tag = value;
@@ -120,7 +120,7 @@ class ToastNotification extends IInspectable
   bool get SuppressPopup => _iToastNotification2.SuppressPopup;
   // IToastNotification3 methods
   late final _iToastNotification3 =
-      IToastNotification3(toInterface(IID_IToastNotification3));
+      IToastNotification3.from(toInterface(IID_IToastNotification3));
 
   @override
   int get NotificationMirroring => _iToastNotification3.NotificationMirroring;
@@ -136,7 +136,7 @@ class ToastNotification extends IInspectable
   set RemoteId(String value) => _iToastNotification3.RemoteId = value;
   // IToastNotification4 methods
   late final _iToastNotification4 =
-      IToastNotification4(toInterface(IID_IToastNotification4));
+      IToastNotification4.from(toInterface(IID_IToastNotification4));
 
   @override
   Pointer<COMObject> get Data => _iToastNotification4.Data;
@@ -151,7 +151,7 @@ class ToastNotification extends IInspectable
   set Priority(int value) => _iToastNotification4.Priority = value;
   // IToastNotification6 methods
   late final _iToastNotification6 =
-      IToastNotification6(toInterface(IID_IToastNotification6));
+      IToastNotification6.from(toInterface(IID_IToastNotification6));
 
   @override
   bool get ExpiresOnReboot => _iToastNotification6.ExpiresOnReboot;

--- a/lib/src/winrt/userdatapaths.dart
+++ b/lib/src/winrt/userdatapaths.dart
@@ -29,7 +29,7 @@ import '../com/iinspectable.dart';
 /// {@category Class}
 /// {@category winrt}
 class UserDataPaths extends IInspectable implements IUserDataPaths {
-  UserDataPaths.fromPointer(super.ptr);
+  UserDataPaths.from(super.ptr);
 
   static const _className = 'Windows.Storage.UserDataPaths';
 
@@ -39,7 +39,8 @@ class UserDataPaths extends IInspectable implements IUserDataPaths {
         CreateActivationFactory(_className, IID_IUserDataPathsStatics);
 
     try {
-      final result = IUserDataPathsStatics(activationFactory).GetForUser(user);
+      final result =
+          IUserDataPathsStatics.from(activationFactory).GetForUser(user);
       return result;
     } finally {
       free(activationFactory);
@@ -51,7 +52,7 @@ class UserDataPaths extends IInspectable implements IUserDataPaths {
         CreateActivationFactory(_className, IID_IUserDataPathsStatics);
 
     try {
-      final result = IUserDataPathsStatics(activationFactory).GetDefault();
+      final result = IUserDataPathsStatics.from(activationFactory).GetDefault();
       return result;
     } finally {
       free(activationFactory);
@@ -59,7 +60,8 @@ class UserDataPaths extends IInspectable implements IUserDataPaths {
   }
 
   // IUserDataPaths methods
-  late final _iUserDataPaths = IUserDataPaths(toInterface(IID_IUserDataPaths));
+  late final _iUserDataPaths =
+      IUserDataPaths.from(toInterface(IID_IUserDataPaths));
 
   @override
   String get CameraRoll => _iUserDataPaths.CameraRoll;

--- a/lib/src/winrt_helpers.dart
+++ b/lib/src/winrt_helpers.dart
@@ -74,7 +74,7 @@ int convertToHString(String string) {
 ///
 /// ```dart
 /// final object = CreateObject('Windows.Globalization.Calendar', IID_ICalendar);
-/// final calendar = ICalendar(object);
+/// final calendar = ICalendar.from(object);
 /// ```
 ///
 /// {@category winrt}

--- a/test/winrt_calendar_test.dart
+++ b/test/winrt_calendar_test.dart
@@ -25,7 +25,7 @@ void main() {
     });
 
     test('Calendar.Clone', () {
-      final calendar2 = Calendar.fromPointer(calendar.Clone());
+      final calendar2 = Calendar.from(calendar.Clone());
 
       expect(
           calendar2.runtimeClassName, equals('Windows.Globalization.Calendar'));
@@ -456,7 +456,7 @@ void main() {
     // test('Calendar.CreateCalendarWithTimeZone constructor', () {
     //   final pickerPtr = CreateObject(
     //       'Windows.Storage.Pickers.FileOpenPicker', IID_IFileOpenPicker);
-    //   final picker = IFileOpenPicker(pickerPtr);
+    //   final picker = IFileOpenPicker.from(pickerPtr);
     //   final languages = picker.FileTypeFilter..ReplaceAll(['en-US', 'en-GB']);
 
     //   const IID_Iterable = '{E2FCC7C1-3BFC-5A0B-B2B0-72E769D1CB7E}';

--- a/test/winrt_collections_test.dart
+++ b/test/winrt_collections_test.dart
@@ -21,7 +21,7 @@ void main() {
 
         final object = CreateObject(
             'Windows.Storage.Pickers.FileOpenPicker', IID_IFileOpenPicker);
-        picker = IFileOpenPicker(object);
+        picker = IFileOpenPicker.from(object);
         allocator = Arena();
         vector = picker.FileTypeFilter;
       });
@@ -290,7 +290,7 @@ void main() {
 
         if (FAILED(hr)) throw WindowsException(hr);
 
-        return IVectorView(retValuePtr, allocator: allocator);
+        return IVectorView.from(retValuePtr, allocator: allocator);
       }
 
       setUp(() {
@@ -388,8 +388,8 @@ void main() {
 
         if (FAILED(hr)) throw WindowsException(hr);
 
-        return IVectorView(retValuePtr,
-            creator: IHostName.new, allocator: allocator);
+        return IVectorView.from(retValuePtr,
+            creator: IHostName.from, allocator: allocator);
       }
 
       setUp(() {
@@ -423,7 +423,7 @@ void main() {
       test('GetMany returns elements starting from index 0', () {
         final pCOMObject = allocator<COMObject>(vectorView.Size);
         expect(vectorView.GetMany(0, pCOMObject), greaterThanOrEqualTo(1));
-        final list = pCOMObject.toList<IHostName>(IHostName.new,
+        final list = pCOMObject.toList<IHostName>(IHostName.from,
             length: vectorView.Size);
         expect(list.length, greaterThanOrEqualTo(1));
       });

--- a/test/winrt_phonenumberformatter_test.dart
+++ b/test/winrt_phonenumberformatter_test.dart
@@ -36,7 +36,7 @@ void main() {
       // https://www.ofcom.org.uk/phones-telecoms-and-internet/information-for-industry/numbering/numbers-for-drama
       final formatterObject = calloc<COMObject>();
       PhoneNumberFormatter.TryCreate('GB', formatterObject);
-      final ukFormatter = IPhoneNumberFormatter(formatterObject);
+      final ukFormatter = IPhoneNumberFormatter.from(formatterObject);
       final london = ukFormatter.FormatString('02079460123');
       expect(london, equals('020 7946 0123'));
       final reading = ukFormatter.FormatString('01184960987');

--- a/tool/generator/lib/src/projection/winrt_class.dart
+++ b/tool/generator/lib/src/projection/winrt_class.dart
@@ -60,8 +60,8 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
             final activationFactory = CreateActivationFactory(_className, IID_$interfaceName);
 
             try {
-              final result = $interfaceName(activationFactory).${method.shortForm};
-              return $shortName.fromPointer(result);
+              final result = $interfaceName.from(activationFactory).${method.shortForm};
+              return $shortName.from(result);
             } finally {
               free(activationFactory);
             }
@@ -98,7 +98,7 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
             final activationFactory = CreateActivationFactory(_className, IID_$interfaceName);
 
             try {
-              final result = $interfaceName(activationFactory).${method.shortForm};
+              final result = $interfaceName.from(activationFactory).${method.shortForm};
               return result;
             } finally {
               free(activationFactory);
@@ -126,7 +126,7 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
   String get stringableMappers => isStringable
       ? '''
     // IStringable methods
-    late final _iStringable = IStringable(toInterface(IID_IStringable));
+    late final _iStringable = IStringable.from(toInterface(IID_IStringable));
 
     @override
     String toString() => _iStringable.ToString();
@@ -145,7 +145,7 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
       /// {@category $category}
       $classDeclaration
         $defaultConstructor
-        $shortName.fromPointer(super.ptr);
+        $shortName.from(super.ptr);
 
         $classNameDeclaration
 

--- a/tool/generator/lib/src/projection/winrt_get_property.dart
+++ b/tool/generator/lib/src/projection/winrt_get_property.dart
@@ -34,7 +34,7 @@ class WinRTGetPropertyProjection extends WinRTPropertyProjection {
     ${ffiCall()}
 
     try {
-      return IVectorView<String>(retValuePtr).toList();
+      return IVectorView<String>.from(retValuePtr).toList();
     } finally {
       free(retValuePtr);
     }
@@ -48,7 +48,7 @@ class WinRTGetPropertyProjection extends WinRTPropertyProjection {
 
     ${ffiCall()}
 
-    return IVector(retValuePtr);
+    return IVector.from(retValuePtr);
   }
 ''';
 

--- a/tool/generator/lib/src/projection/winrt_interface.dart
+++ b/tool/generator/lib/src/projection/winrt_interface.dart
@@ -152,7 +152,7 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
       final fieldIdentifier = '_i${interfaceName.substring(1)}';
       final iid = 'IID_$interfaceName';
       buffer.writeln(
-          'late final $fieldIdentifier = $interfaceName(toInterface($iid));');
+          'late final $fieldIdentifier = $interfaceName.from(toInterface($iid));');
 
       final projection = WinRTInterfaceProjection(interface);
       for (final method in projection.methodProjections) {
@@ -179,7 +179,7 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
       /// {@category $category}
       $classDeclaration
         // vtable begins at $vtableStart, is ${methodProjections.length} entries long.
-        $shortName(super.ptr);
+        $shortName.from(super.ptr);
 
         ${methodProjections.map((p) => p.toString()).join('\n')}
 

--- a/tool/generator/lib/src/projection/winrt_method.dart
+++ b/tool/generator/lib/src/projection/winrt_method.dart
@@ -123,7 +123,7 @@ class WinRTMethodProjection extends MethodProjection {
     ${ffiCall()}
 
     try {
-      return IVectorView<String>(retValuePtr).toList();
+      return IVectorView<String>.from(retValuePtr).toList();
     } finally {
       $parametersPostamble
       free(retValuePtr);

--- a/tool/generator/test/goldens/icalendar.golden
+++ b/tool/generator/test/goldens/icalendar.golden
@@ -32,7 +32,7 @@ const IID_ICalendar = '{CA30221D-86D9-40FB-A26B-D44EB7CF08EA}';
 /// {@category winrt}
 class ICalendar extends IInspectable {
   // vtable begins at 6, is 98 entries long.
-  ICalendar(super.ptr);
+  ICalendar.from(super.ptr);
 
   Pointer<COMObject> Clone() {
     final retValuePtr = calloc<COMObject>();
@@ -88,7 +88,7 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
 
     try {
-      return IVectorView<String>(retValuePtr).toList();
+      return IVectorView<String>.from(retValuePtr).toList();
     } finally {
       free(retValuePtr);
     }


### PR DESCRIPTION
Partially fixes #464 (I'll have to think about how to apply this to COM later)