### PR TITLE
Update pubspec to support reftypes in winmd

### DIFF
--- a/tool/generator/pubspec.yaml
+++ b/tool/generator/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   # relationship between these two packages is tightly coupled, since this
   # package includes a specific version of the Win32 metadata, so we pin the
   # dependency by version to avoid surprising conflicts.
-  winmd: 2.2.0
+  winmd: 2.2.1
 
   # Win32 itself
   win32:


### PR DESCRIPTION
This version of winmd should be neutral to the generator, but will solve the problem where reference types weren't projected properly. 