### PR TITLE
Clean up `specialTypes`

### DIFF
--- a/lib/src/winrt/iphonenumberformatterstatics.dart
+++ b/lib/src/winrt/iphonenumberformatterstatics.dart
@@ -21,6 +21,7 @@ import '../winrt_helpers.dart';
 
 import '../extensions/hstring_array.dart';
 
+import 'phonenumberformatter.dart';
 import '../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/iphonenumberinfostatics.dart
+++ b/lib/src/winrt/iphonenumberinfostatics.dart
@@ -21,6 +21,7 @@ import '../winrt_helpers.dart';
 
 import '../extensions/hstring_array.dart';
 
+import 'phonenumberinfo.dart';
 import '../com/iinspectable.dart';
 
 /// @nodoc

--- a/tool/generator/lib/src/projection/type.dart
+++ b/tool/generator/lib/src/projection/type.dart
@@ -49,12 +49,6 @@ const Map<String, TypeTuple> specialTypes = {
   'Windows.Win32.Foundation.ULARGE_INTEGER':
       TypeTuple('Uint64', 'int', attribute: '@Uint64()'),
   'System.Guid': TypeTuple('GUID', 'GUID'),
-  'Windows.Foundation.IAsyncOperation`1':
-      TypeTuple('Pointer<COMObject>', 'Pointer<COMObject>'),
-  'Windows.Foundation.Collections.IVector`1':
-      TypeTuple('Pointer<COMObject>', 'Pointer<COMObject>'),
-  'Windows.Foundation.Collections.IVectorView`1':
-      TypeTuple('Pointer<COMObject>', 'Pointer<COMObject>'),
   'Windows.Foundation.DateTime': TypeTuple('Uint64', 'int',
       attribute: '@Uint64()', methodParamType: 'DateTime'),
   'Windows.Foundation.HResult':


### PR DESCRIPTION
I've added these before with #405 and #406. It was necessary at the time because the `isInterface` property was returning false for these generic interfaces which were preventing the projection of these types: https://github.com/timsneath/win32/blob/05df9384ad9c4c51a59d3f3d4701ac38494a9494/tool/generator/lib/src/projection/type.dart#L275-L285

I don't know when this was fixed but it seems to be working properly now. Therefore, we can remove them from the `specialTypes` map.