### PR TITLE
Clean up WinRT struct generation script

### DIFF
--- a/tool/generator/bin/generate.dart
+++ b/tool/generator/bin/generate.dart
@@ -316,23 +316,20 @@ int generateWinRTStructs() {
   final file = File('../../lib/src/winrt/structs.g.dart');
   final structProjections = <StructProjection>[];
 
-  for (final typeName in structs.keys) {
-    final scope = MetadataStore.getScopeForType(typeName);
+  for (final type in structs.keys) {
+    final typeDef = MetadataStore.getMetadataForType(type);
+    if (typeDef == null) throw Exception("Can't find $type");
 
-    final typeDefs = scope.typeDefs
-        .where((typeDef) => typeName == typeDef.name)
-        .where((typeDef) => typeDef.supportedArchitectures.x64);
-
-    structProjections.addAll(typeDefs.map((struct) => StructProjection(
-        struct, stripAnsiUnicodeSuffix(lastComponent(struct.name)),
-        comment: structs[struct.name]!)));
+    final structProjection = StructProjection(
+        typeDef, stripAnsiUnicodeSuffix(lastComponent(typeDef.name)),
+        comment: structs[typeDef.name]!);
+    structProjections.add(structProjection);
   }
 
   structProjections.sort((a, b) =>
       lastComponent(a.structName).compareTo(lastComponent(b.structName)));
 
   final structsFile = [winrtStructFileHeader, ...structProjections].join();
-
   file.writeAsStringSync(DartFormatter().format(structsFile));
 
   return structProjections.length;


### PR DESCRIPTION
By using the `getMetadataForType()` method, I think the code is much cleaner now.