### PR TITLE
Tweak generateWinRTApis()

### DIFF
--- a/tool/generator/bin/generate.dart
+++ b/tool/generator/bin/generate.dart
@@ -279,13 +279,13 @@ void generateWinRTApis() {
       ];
       typesToGenerate.addAll(factoryAndStaticInterfaces);
     }
-
-    typesToGenerate
-      // Remove generic interfaces. See https://github.com/timsneath/win32/issues/480
-      ..removeWhere((type) => type.isEmpty)
-      // Remove excluded WinRT types
-      ..removeWhere((type) => excludedWindowsRuntimeTypes.contains(type));
   }
+
+  typesToGenerate
+    // Remove generic interfaces. See https://github.com/timsneath/win32/issues/480
+    ..removeWhere((type) => type.isEmpty)
+    // Remove excluded WinRT types
+    ..removeWhere((type) => excludedWindowsRuntimeTypes.contains(type));
 
   for (final type in typesToGenerate) {
     final typeDef = MetadataStore.getMetadataForType(type);


### PR DESCRIPTION
Moved the code that removes generic interfaces and excluded types outside of the for loop since it was running after every iteration which was unnecessary (and inefficient). Instead, it should only run once after the for loop.