### PR TITLE
Remove overrides of operators `[]` and `[]=`

### DIFF
--- a/lib/src/extensions/comobject_pointer.dart
+++ b/lib/src/extensions/comobject_pointer.dart
@@ -7,11 +7,6 @@ import 'dart:ffi';
 import '../combase.dart';
 
 extension COMObjectPointer on Pointer<COMObject> {
-  Pointer<COMObject> operator [](int index) => this.elementAt(index);
-
-  void operator []=(int index, Pointer<Pointer<IntPtr>> value) =>
-      this[index].ref.lpVtbl = value;
-
   /// Creates a `List<T>` from the `Pointer<COMObject>`.
   ///
   /// `T` must be a `WinRT` type. e.g. `IHostName`, `IStorageFile` ...
@@ -31,7 +26,7 @@ extension COMObjectPointer on Pointer<COMObject> {
   List<T> toList<T>(T Function(Pointer<COMObject>) creator, {int length = 1}) {
     final list = <T>[];
     for (var i = 0; i < length; i++) {
-      final element = this[i];
+      final element = this.elementAt(i);
       if (element.ref.lpVtbl == nullptr) {
         break;
       }

--- a/lib/src/winrt/ivector.dart
+++ b/lib/src/winrt/ivector.dart
@@ -605,8 +605,7 @@ class IVector<T> extends IInspectable implements IIterable<T> {
   void _ReplaceAll_COMObject(List<IInspectable> items) {
     final pArray = calloc<COMObject>(items.length);
     for (var i = 0; i < items.length; i++) {
-      final pElement = items.elementAt(i).ptr;
-      pArray[i] = pElement.ref.lpVtbl;
+      pArray[i] = items.elementAt(i).ptr.ref;
     }
 
     try {


### PR DESCRIPTION
I previously added these operators because I thought they weren't exposed for `Pointer<T extends Struct>` (e.g. `Pointer<COMObject>`) types. Looks like, I was wrong :) as they are defined [here](https://github.com/dart-lang/sdk/blob/5263e15e99d967bd9cec5f8b05fac95224bd768e/sdk/lib/ffi/ffi.dart#L682-L697).