### PR TITLE
Fix projection of static setters

### DIFF
--- a/lib/src/winrt/gamepad.dart
+++ b/lib/src/winrt/gamepad.dart
@@ -53,9 +53,7 @@ class Gamepad extends IInspectable
         CreateActivationFactory(_className, IID_IGamepadStatics);
 
     try {
-      final result =
-          IGamepadStatics.from(activationFactory).add_GamepadAdded(value);
-      return result;
+      return IGamepadStatics.from(activationFactory).add_GamepadAdded(value);
     } finally {
       free(activationFactory);
     }
@@ -66,9 +64,7 @@ class Gamepad extends IInspectable
         CreateActivationFactory(_className, IID_IGamepadStatics);
 
     try {
-      final result =
-          IGamepadStatics.from(activationFactory).remove_GamepadAdded(token);
-      return result;
+      return IGamepadStatics.from(activationFactory).remove_GamepadAdded(token);
     } finally {
       free(activationFactory);
     }
@@ -79,9 +75,7 @@ class Gamepad extends IInspectable
         CreateActivationFactory(_className, IID_IGamepadStatics);
 
     try {
-      final result =
-          IGamepadStatics.from(activationFactory).add_GamepadRemoved(value);
-      return result;
+      return IGamepadStatics.from(activationFactory).add_GamepadRemoved(value);
     } finally {
       free(activationFactory);
     }
@@ -92,9 +86,8 @@ class Gamepad extends IInspectable
         CreateActivationFactory(_className, IID_IGamepadStatics);
 
     try {
-      final result =
-          IGamepadStatics.from(activationFactory).remove_GamepadRemoved(token);
-      return result;
+      return IGamepadStatics.from(activationFactory)
+          .remove_GamepadRemoved(token);
     } finally {
       free(activationFactory);
     }
@@ -105,8 +98,7 @@ class Gamepad extends IInspectable
         CreateActivationFactory(_className, IID_IGamepadStatics);
 
     try {
-      final result = IGamepadStatics.from(activationFactory).Gamepads;
-      return result;
+      return IGamepadStatics.from(activationFactory).Gamepads;
     } finally {
       free(activationFactory);
     }
@@ -119,9 +111,8 @@ class Gamepad extends IInspectable
         CreateActivationFactory(_className, IID_IGamepadStatics2);
 
     try {
-      final result = IGamepadStatics2.from(activationFactory)
+      return IGamepadStatics2.from(activationFactory)
           .FromGameController(gameController);
-      return result;
     } finally {
       free(activationFactory);
     }

--- a/lib/src/winrt/phonenumberformatter.dart
+++ b/lib/src/winrt/phonenumberformatter.dart
@@ -43,9 +43,8 @@ class PhoneNumberFormatter extends IInspectable
         CreateActivationFactory(_className, IID_IPhoneNumberFormatterStatics);
 
     try {
-      final result = IPhoneNumberFormatterStatics.from(activationFactory)
+      return IPhoneNumberFormatterStatics.from(activationFactory)
           .TryCreate(regionCode, phoneNumber);
-      return result;
     } finally {
       free(activationFactory);
     }
@@ -56,9 +55,8 @@ class PhoneNumberFormatter extends IInspectable
         CreateActivationFactory(_className, IID_IPhoneNumberFormatterStatics);
 
     try {
-      final result = IPhoneNumberFormatterStatics.from(activationFactory)
+      return IPhoneNumberFormatterStatics.from(activationFactory)
           .GetCountryCodeForRegion(regionCode);
-      return result;
     } finally {
       free(activationFactory);
     }
@@ -70,9 +68,8 @@ class PhoneNumberFormatter extends IInspectable
         CreateActivationFactory(_className, IID_IPhoneNumberFormatterStatics);
 
     try {
-      final result = IPhoneNumberFormatterStatics.from(activationFactory)
+      return IPhoneNumberFormatterStatics.from(activationFactory)
           .GetNationalDirectDialingPrefixForRegion(regionCode, stripNonDigit);
-      return result;
     } finally {
       free(activationFactory);
     }
@@ -83,9 +80,8 @@ class PhoneNumberFormatter extends IInspectable
         CreateActivationFactory(_className, IID_IPhoneNumberFormatterStatics);
 
     try {
-      final result = IPhoneNumberFormatterStatics.from(activationFactory)
+      return IPhoneNumberFormatterStatics.from(activationFactory)
           .WrapWithLeftToRightMarkers(number);
-      return result;
     } finally {
       free(activationFactory);
     }

--- a/lib/src/winrt/phonenumberinfo.dart
+++ b/lib/src/winrt/phonenumberinfo.dart
@@ -55,9 +55,8 @@ class PhoneNumberInfo extends IInspectable implements IPhoneNumberInfo {
         CreateActivationFactory(_className, IID_IPhoneNumberInfoStatics);
 
     try {
-      final result = IPhoneNumberInfoStatics.from(activationFactory)
+      return IPhoneNumberInfoStatics.from(activationFactory)
           .TryParse(input, phoneNumber);
-      return result;
     } finally {
       free(activationFactory);
     }
@@ -69,9 +68,8 @@ class PhoneNumberInfo extends IInspectable implements IPhoneNumberInfo {
         CreateActivationFactory(_className, IID_IPhoneNumberInfoStatics);
 
     try {
-      final result = IPhoneNumberInfoStatics.from(activationFactory)
+      return IPhoneNumberInfoStatics.from(activationFactory)
           .TryParseWithRegion(input, regionCode, phoneNumber);
-      return result;
     } finally {
       free(activationFactory);
     }

--- a/lib/src/winrt/userdatapaths.dart
+++ b/lib/src/winrt/userdatapaths.dart
@@ -39,9 +39,7 @@ class UserDataPaths extends IInspectable implements IUserDataPaths {
         CreateActivationFactory(_className, IID_IUserDataPathsStatics);
 
     try {
-      final result =
-          IUserDataPathsStatics.from(activationFactory).GetForUser(user);
-      return result;
+      return IUserDataPathsStatics.from(activationFactory).GetForUser(user);
     } finally {
       free(activationFactory);
     }
@@ -52,8 +50,7 @@ class UserDataPaths extends IInspectable implements IUserDataPaths {
         CreateActivationFactory(_className, IID_IUserDataPathsStatics);
 
     try {
-      final result = IUserDataPathsStatics.from(activationFactory).GetDefault();
-      return result;
+      return IUserDataPathsStatics.from(activationFactory).GetDefault();
     } finally {
       free(activationFactory);
     }

--- a/tool/generator/lib/src/projection/winrt_class.dart
+++ b/tool/generator/lib/src/projection/winrt_class.dart
@@ -91,15 +91,19 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
       }
 
       final interfaceProjection = WinRTInterfaceProjection(staticTypeDef);
-      for (final method in interfaceProjection.methodProjections) {
-        final declaration = method.shortDeclaration;
+      for (final methodProjection in interfaceProjection.methodProjections) {
+        final declaration = methodProjection.shortDeclaration;
+        final statement =
+            '$interfaceName.from(activationFactory).${methodProjection.shortForm}';
+        final returnStatement = methodProjection.method.isSetProperty
+            ? statement
+            : 'return $statement;';
         buffer.writeln('''
           static $declaration {
             final activationFactory = CreateActivationFactory(_className, IID_$interfaceName);
 
             try {
-              final result = $interfaceName.from(activationFactory).${method.shortForm};
-              return result;
+              $returnStatement
             } finally {
               free(activationFactory);
             }

--- a/tool/generator/lib/src/projection/winrt_class.dart
+++ b/tool/generator/lib/src/projection/winrt_class.dart
@@ -94,10 +94,10 @@ class WinRTClassProjection extends WinRTInterfaceProjection {
       for (final methodProjection in interfaceProjection.methodProjections) {
         final declaration = methodProjection.shortDeclaration;
         final statement =
-            '$interfaceName.from(activationFactory).${methodProjection.shortForm}';
+            '$interfaceName.from(activationFactory).${methodProjection.shortForm};';
         final returnStatement = methodProjection.method.isSetProperty
             ? statement
-            : 'return $statement;';
+            : 'return $statement';
         buffer.writeln('''
           static $declaration {
             final activationFactory = CreateActivationFactory(_className, IID_$interfaceName);


### PR DESCRIPTION
Static setters should not return anything since their return types are void.

For example, prior to this change, Geolocator's DefaultGeoposition setter was incorrectly generated as:
```dart
  static set DefaultGeoposition(Pointer<COMObject> value) {
    final activationFactory =
        CreateActivationFactory(_className, IID_IGeolocatorStatics2);

    try {
      final result = IGeolocatorStatics2.from(activationFactory).DefaultGeoposition = value;
      return result;
    } finally {
      free(activationFactory);
    }
  }
```

With this change, it will be generated as:
```dart
  static set DefaultGeoposition(Pointer<COMObject> value) {
    final activationFactory =
        CreateActivationFactory(_className, IID_IGeolocatorStatics2);

    try {
      IGeolocatorStatics2.from(activationFactory).DefaultGeoposition = value;
    } finally {
      free(activationFactory);
    }
  }
```
