### PR TITLE
Support creating `null` HSTRING

### DIFF
--- a/lib/src/winrt/foundation/collections/imap.dart
+++ b/lib/src/winrt/foundation/collections/imap.dart
@@ -661,7 +661,7 @@ class IMap<K, V> extends IInspectable
   bool _insert_String_String(String key, String? value) {
     final retValuePtr = calloc<Bool>();
     final hKey = convertToHString(key);
-    final hValue = value != null ? convertToHString(value) : 0;
+    final hValue = convertToHString(value);
 
     try {
       final hr = ptr.ref.lpVtbl.value

--- a/lib/src/winrt_helpers.dart
+++ b/lib/src/winrt_helpers.dart
@@ -56,12 +56,12 @@ String convertFromHString(int hstring) =>
 /// reaches 0, the Windows Runtime deallocates the buffer.
 ///
 /// {@category winrt}
-int convertToHString(String string) {
+int convertToHString(String? string) {
   final hString = calloc<HSTRING>();
-  final stringPtr = string.toNativeUtf16();
+  final stringPtr = string?.toNativeUtf16() ?? nullptr;
   // Create a HSTRING representing the object
   try {
-    final hr = WindowsCreateString(stringPtr, string.length, hString);
+    final hr = WindowsCreateString(stringPtr, string?.length ?? 0, hString);
     if (FAILED(hr)) {
       throw WindowsException(hr);
     } else {

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -94,9 +94,10 @@ void main() {
       test('String to HSTRING conversion (null string)', () {
         for (var i = 0; i < testRuns; i++) {
           final hstring = convertToHString(null);
+          expect(hstring, equals(0));
 
           final string2 = convertFromHString(hstring);
-          expect('', equals(string2));
+          expect(string2, isEmpty);
 
           WindowsDeleteString(hstring);
         }

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -90,6 +90,18 @@ void main() {
           WindowsDeleteString(hstring);
         }
       });
+
+      test('String to HSTRING conversion (null string)', () {
+        for (var i = 0; i < testRuns; i++) {
+          final hstring = convertToHString(null);
+
+          final string2 = convertFromHString(hstring);
+          expect('', equals(string2));
+
+          WindowsDeleteString(hstring);
+        }
+      });
+
       test('String to HSTRING conversion -- more complex', () {
         for (var i = 0; i < testRuns; i++) {
           const string = '''


### PR DESCRIPTION
[WindowsCreateString function (winstring.h)](https://docs.microsoft.com/en-us/windows/win32/api/winstring/nf-winstring-windowscreatestring#parameters)
> ... To create a new, empty, or NULL string, pass NULL for sourceString and 0 for length.

EDIT: The failed check for formatting in [build(windows-latest, main)](https://github.com/timsneath/win32/runs/7784240786?check_suite_focus=true) might be related to changes made to the `dart format` command in the latest Dart SDK version.