### PR TITLE
Convert `getView` getter to a method

### DIFF
--- a/example/winrt_picker.dart
+++ b/example/winrt_picker.dart
@@ -28,7 +28,7 @@ void main() async {
   filters.append('.jpeg');
   print('Vector\'s second element is ${filters.getAt(1)}.');
 
-  final vectorView = filters.getView;
+  final vectorView = filters.getView();
   print('VectorView has ${vectorView.length} elements.');
 
   var containsElement = filters.indexOf('.jpeg', pIndex);
@@ -55,13 +55,13 @@ void main() async {
   print('Vector has ${filters.size} elements.');
   print('Vector\'s last element is ${filters.getAt(filters.size - 1)}.');
 
-  var list = filters.getView;
+  var list = filters.getView();
   print(list.isNotEmpty ? 'Vector elements: $list' : 'Vector is empty!');
 
   print('Replacing vector\'s elements with [".jpg", ".jpeg", ".png"]...');
   filters.replaceAll(['.jpg', '.jpeg', '.png']);
 
-  list = filters.getView;
+  list = filters.getView();
   print(list.isNotEmpty ? 'Vector elements: $list' : 'Vector is empty!');
 
   print('Clearing the vector...');

--- a/lib/src/winrt/data/json/jsonarray.dart
+++ b/lib/src/winrt/data/json/jsonarray.dart
@@ -115,7 +115,7 @@ class JsonArray extends IInspectable
       _iVector.getMany(startIndex, capacity, value);
 
   @override
-  List<IJsonValue> get getView => _iVector.getView;
+  List<IJsonValue> getView() => _iVector.getView();
 
   @override
   bool indexOf(IJsonValue value, Pointer<Uint32> index) =>

--- a/lib/src/winrt/foundation/collections/ivector.dart
+++ b/lib/src/winrt/foundation/collections/ivector.dart
@@ -350,7 +350,7 @@ class IVector<T> extends IInspectable implements IIterable<T> {
   }
 
   /// Returns an immutable view of the vector.
-  List<T> get getView {
+  List<T> getView() {
     final retValuePtr = _allocator<COMObject>();
 
     final hr = ptr.ref.vtable

--- a/test/winrt_collections_test.dart
+++ b/test/winrt_collections_test.dart
@@ -1278,7 +1278,7 @@ void main() {
         vector
           ..append(DeviceClass.audioCapture)
           ..append(DeviceClass.audioRender);
-        final list = vector.getView;
+        final list = vector.getView();
         expect(list.length, equals(2));
         expect(() => list..clear(), throwsUnsupportedError);
       });
@@ -1534,7 +1534,7 @@ void main() {
         vector
           ..append(5)
           ..append(259);
-        final list = vector.getView;
+        final list = vector.getView();
         expect(list.length, equals(2));
         expect(() => list..clear(), throwsUnsupportedError);
       });
@@ -1787,7 +1787,7 @@ void main() {
         vector
           ..append('.jpg')
           ..append('.jpeg');
-        final list = vector.getView;
+        final list = vector.getView();
         expect(list.length, equals(2));
         expect(() => list..clear(), throwsUnsupportedError);
       });


### PR DESCRIPTION
I accidentally made [GetView()](https://docs.microsoft.com/en-us/uwp/api/windows.foundation.collections.ivector-1.getview?view=winrt-22621#windows-foundation-collections-ivector-1-getview) method a getter while manually projecting the `IVector` interface a few months ago. This PR converts it into a method.