### PR TITLE
Fix 'Format a US number' test

### DIFF
--- a/test/winrt_phonenumberformatter_test.dart
+++ b/test/winrt_phonenumberformatter_test.dart
@@ -27,7 +27,10 @@ void main() {
     });
 
     test('Format a US number', () {
-      final phone = formatter.formatString('4255550123');
+      final formatterObject = calloc<COMObject>();
+      PhoneNumberFormatter.tryCreate('US', formatterObject);
+      final usFormatter = IPhoneNumberFormatter.fromRawPointer(formatterObject);
+      final phone = usFormatter.formatString('4255550123');
       expect(phone, equals('(425) 555-0123'));
     });
 


### PR DESCRIPTION
https://github.com/timsneath/win32/blob/f8705863fd288983ce0891d1c019ac64e8942dea/test/winrt_phonenumberformatter_test.dart#L18

The default constructor of `PhoneNumberFormatter` uses the current default region. Since this test is dependent on the current default region being `US` (which is not the case for me), the test fails on my machine as follows:

![format](https://user-images.githubusercontent.com/45524029/189640021-d76e44f2-18d6-4ca2-870b-36e2342802fe.png)

This PR fixes it by using a `US` PhoneNumberFormatter to format the number.