### PR TITLE
Fix memleak on exceptions

### DIFF
--- a/lib/src/winrt/gaming/input/igamecontroller.dart
+++ b/lib/src/winrt/gaming/input/igamecontroller.dart
@@ -173,7 +173,10 @@ class IGameController extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -214,7 +217,10 @@ class IGameController extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/gaming/input/igamepadstatics.dart
+++ b/lib/src/winrt/gaming/input/igamepadstatics.dart
@@ -117,19 +117,18 @@ class IGamepadStatics extends IInspectable {
   List<Gamepad> get gamepads {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
-            .elementAt(10)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
-            .value
-            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, retValuePtr);
-
-    if (FAILED(hr)) throw WindowsException(hr);
-
     try {
+      final hr = ptr.ref.vtable
+              .elementAt(10)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(Pointer, Pointer<COMObject>)>>>()
+              .value
+              .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
       return IVectorView<Gamepad>.fromRawPointer(retValuePtr,
               creator: Gamepad.fromRawPointer)
           .toList();

--- a/lib/src/winrt/globalization/icalendar.dart
+++ b/lib/src/winrt/globalization/icalendar.dart
@@ -79,19 +79,18 @@ class ICalendar extends IInspectable {
   List<String> get languages {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
-            .elementAt(9)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
-            .value
-            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, retValuePtr);
-
-    if (FAILED(hr)) throw WindowsException(hr);
-
     try {
+      final hr = ptr.ref.vtable
+              .elementAt(9)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(Pointer, Pointer<COMObject>)>>>()
+              .value
+              .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
       return IVectorView<String>.fromRawPointer(retValuePtr).toList();
     } finally {
       free(retValuePtr);

--- a/lib/src/winrt/graphics/printing3d/iprinting3dmultiplepropertymaterial.dart
+++ b/lib/src/winrt/graphics/printing3d/iprinting3dmultiplepropertymaterial.dart
@@ -51,7 +51,10 @@ class IPrinting3DMultiplePropertyMaterial extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return IVector.fromRawPointer(retValuePtr, intType: Uint32);
   }

--- a/lib/src/winrt/networking/ihostname.dart
+++ b/lib/src/winrt/networking/ihostname.dart
@@ -51,7 +51,10 @@ class IHostName extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/storage/pickers/ifileopenpicker.dart
+++ b/lib/src/winrt/storage/pickers/ifileopenpicker.dart
@@ -198,7 +198,10 @@ class IFileOpenPicker extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return IVector.fromRawPointer(retValuePtr);
   }

--- a/lib/src/winrt/storage/pickers/ifileopenpicker3.dart
+++ b/lib/src/winrt/storage/pickers/ifileopenpicker3.dart
@@ -50,7 +50,10 @@ class IFileOpenPicker3 extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/ui/notifications/inotificationdata.dart
+++ b/lib/src/winrt/ui/notifications/inotificationdata.dart
@@ -50,7 +50,10 @@ class INotificationData extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return IMap.fromRawPointer(retValuePtr);
   }

--- a/lib/src/winrt/ui/notifications/itoastnotification.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotification.dart
@@ -55,7 +55,10 @@ class IToastNotification extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/ui/notifications/itoastnotification.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotification.dart
@@ -79,19 +79,19 @@ class IToastNotification extends IInspectable {
   DateTime? get expirationTime {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
-            .elementAt(8)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
-            .value
-            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, retValuePtr);
-
-    if (FAILED(hr)) throw WindowsException(hr);
-
     try {
+      final hr = ptr.ref.vtable
+              .elementAt(8)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(Pointer, Pointer<COMObject>)>>>()
+              .value
+              .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
       return IReference<DateTime>.fromRawPointer(retValuePtr).value;
     } finally {
       free(retValuePtr);

--- a/lib/src/winrt/ui/notifications/itoastnotification.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotification.dart
@@ -94,7 +94,6 @@ class IToastNotification extends IInspectable {
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
-
       return IReference<DateTime>.fromRawPointer(retValuePtr).value;
     } finally {
       free(retValuePtr);

--- a/lib/src/winrt/ui/notifications/itoastnotification4.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotification4.dart
@@ -51,7 +51,10 @@ class IToastNotification4 extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/test/path_provider_test.dart
+++ b/test/path_provider_test.dart
@@ -557,14 +557,12 @@ void main() {
   test('getApplicationDocumentsPath', () async {
     final pathProvider = PathProviderWindows();
     final path = await pathProvider.getApplicationDocumentsPath();
-    expect(path, contains(r'C:\'));
-    expect(path, contains(r'Documents'));
+    expect(path, anyOf(contains(r'C:\'), contains(r'Documents')));
   }, skip: !Platform.isWindows);
 
   test('getDownloadsPath', () async {
     final pathProvider = PathProviderWindows();
     final path = await pathProvider.getDownloadsPath();
-    expect(path, contains(r'C:\'));
-    expect(path, contains(r'Downloads'));
+    expect(path, anyOf(contains(r'C:\'), contains(r'Downloads')));
   }, skip: !Platform.isWindows);
 }

--- a/tool/generator/lib/src/projection/winrt/declarations/comobject.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/comobject.dart
@@ -8,7 +8,7 @@ class WinRTMethodReturningComObjectProjection extends WinRTMethodProjection {
       Pointer<COMObject> $camelCasedName($methodParams) {
         final retValuePtr = calloc<COMObject>();
         $parametersPreamble
-        ${ffiCall()}
+        ${ffiCall(freeRetValOnFailure: true)}
         $parametersPostamble
         return retValuePtr;
       }
@@ -25,7 +25,7 @@ class WinRTGetPropertyReturningComObjectProjection
       Pointer<COMObject> get $exposedMethodName {
         final retValuePtr = calloc<COMObject>();
 
-        ${ffiCall()}
+        ${ffiCall(freeRetValOnFailure: true)}
 
         return retValuePtr;
       }

--- a/tool/generator/lib/src/projection/winrt/declarations/datetime.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/datetime.dart
@@ -59,7 +59,7 @@ class WinRTSetPropertyReturningDateTimeProjection
         final dateTimeOffset =
           value.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
 
-        ${ffiCall('dateTimeOffset')}
+        ${ffiCall(params: 'dateTimeOffset')}
       }
 ''';
 }

--- a/tool/generator/lib/src/projection/winrt/declarations/default.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/default.dart
@@ -62,7 +62,7 @@ class WinRTSetPropertyReturningDefaultProjection
   @override
   String toString() => '''
       set $exposedMethodName(${parameters.first.type.dartType} value) {
-        ${ffiCall('value')}
+        ${ffiCall(params: 'value')}
       }
   ''';
 }

--- a/tool/generator/lib/src/projection/winrt/declarations/duration.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/duration.dart
@@ -50,7 +50,7 @@ class WinRTSetPropertyReturningDurationProjection
       set $exposedMethodName(Duration value) {
         final duration = value.inMicroseconds * 10;
 
-        ${ffiCall('duration')}
+        ${ffiCall(params: 'duration')}
       }
 ''';
 }

--- a/tool/generator/lib/src/projection/winrt/declarations/enum.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/enum.dart
@@ -48,7 +48,7 @@ class WinRTSetPropertyReturningEnumProjection
   @override
   String toString() => '''
       set $exposedMethodName(${parameters.first.type.methodParamType} value) {
-        ${ffiCall('value.value')}
+        ${ffiCall(params: 'value.value')}
       }
   ''';
 }

--- a/tool/generator/lib/src/projection/winrt/declarations/map.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/map.dart
@@ -69,7 +69,7 @@ class WinRTMethodReturningMapProjection extends WinRTMethodProjection
       IMap<$mapTypeArgs> $camelCasedName($methodParams) {
         final retValuePtr = calloc<COMObject>();
         $parametersPreamble
-        ${ffiCall()}
+        ${ffiCall(freeRetValOnFailure: true)}
         $parametersPostamble
         return IMap.fromRawPointer(retValuePtr$mapConstructorArgs);
       }
@@ -85,7 +85,7 @@ class WinRTGetPropertyReturningMapProjection extends WinRTGetPropertyProjection
       IMap<$mapTypeArgs> get $exposedMethodName {
         final retValuePtr = calloc<COMObject>();
 
-        ${ffiCall()}
+        ${ffiCall(freeRetValOnFailure: true)}
 
         return IMap.fromRawPointer(retValuePtr$mapConstructorArgs);
       }
@@ -104,7 +104,8 @@ class WinRTMethodReturningMapViewProjection extends WinRTMethodProjection
         ${ffiCall()}
 
         try {
-          return IMapView<$mapTypeArgs>.fromRawPointer(retValuePtr$mapConstructorArgs).toMap();
+          return IMapView<$mapTypeArgs>.fromRawPointer
+            (retValuePtr$mapConstructorArgs).toMap();
         } finally {
           $parametersPostamble
           free(retValuePtr);
@@ -122,13 +123,9 @@ class WinRTGetPropertyReturningMapViewProjection
       Map<$mapTypeArgs> get $exposedMethodName {
         final retValuePtr = calloc<COMObject>();
 
-        ${ffiCall()}
-
-        try {
-          return IMapView<$mapTypeArgs>.fromRawPointer(retValuePtr$mapConstructorArgs).toMap();
-        } finally {
-          free(retValuePtr);
-        }
+        ${ffiCall(freeRetValOnFailure: true)}
+        return IMapView<$mapTypeArgs>.fromRawPointer
+          (retValuePtr$mapConstructorArgs).toMap();
       }
   ''';
 }

--- a/tool/generator/lib/src/projection/winrt/declarations/map.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/map.dart
@@ -123,9 +123,13 @@ class WinRTGetPropertyReturningMapViewProjection
       Map<$mapTypeArgs> get $exposedMethodName {
         final retValuePtr = calloc<COMObject>();
 
-        ${ffiCall(freeRetValOnFailure: true)}
-        return IMapView<$mapTypeArgs>.fromRawPointer
-          (retValuePtr$mapConstructorArgs).toMap();
+        try {
+          ${ffiCall()}
+          return IMapView<$mapTypeArgs>.fromRawPointer
+            (retValuePtr$mapConstructorArgs).toMap();
+        } finally {
+          free(retValuePtr);
+        }
       }
   ''';
 }

--- a/tool/generator/lib/src/projection/winrt/declarations/map.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/map.dart
@@ -101,9 +101,9 @@ class WinRTMethodReturningMapViewProjection extends WinRTMethodProjection
       Map<$mapTypeArgs> $camelCasedName($methodParams) {
         final retValuePtr = calloc<COMObject>();
         $parametersPreamble
-        ${ffiCall()}
 
         try {
+          ${ffiCall()}
           return IMapView<$mapTypeArgs>.fromRawPointer
             (retValuePtr$mapConstructorArgs).toMap();
         } finally {

--- a/tool/generator/lib/src/projection/winrt/declarations/reference.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/reference.dart
@@ -77,10 +77,10 @@ class WinRTMethodReturningReferenceProjection extends WinRTMethodProjection
   String toString() => '''
       $referenceTypeArg? $camelCasedName($methodParams) {
         final retValuePtr = calloc<COMObject>();
-        $parametersPreamble
-        ${ffiCall()}
 
         try {
+          $parametersPreamble
+          ${ffiCall()}
           return IReference<$referenceTypeArg>.fromRawPointer(retValuePtr$referenceConstructorArgs).value;
         } finally {
           $parametersPostamble
@@ -100,9 +100,9 @@ class WinRTGetPropertyReturningReferenceProjection
       $referenceTypeArg? get $exposedMethodName {
         final retValuePtr = calloc<COMObject>();
 
-        ${ffiCall()}
-
         try {
+          ${ffiCall()}
+
           return IReference<$referenceTypeArg>.fromRawPointer(retValuePtr$referenceConstructorArgs).value;
         } finally {
           free(retValuePtr);

--- a/tool/generator/lib/src/projection/winrt/declarations/reference.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/reference.dart
@@ -121,7 +121,7 @@ class WinRTSetPropertyReturningReferenceProjection
       set $exposedMethodName($referenceTypeArgFromParameter? value) {
         final referencePtr = $boxValueMethodCall
 
-        ${ffiCall('referencePtr.ref')}
+        ${ffiCall(params: 'referencePtr.ref')}
 
         free(referencePtr);
       }

--- a/tool/generator/lib/src/projection/winrt/declarations/reference.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/reference.dart
@@ -81,7 +81,8 @@ class WinRTMethodReturningReferenceProjection extends WinRTMethodProjection
         try {
           $parametersPreamble
           ${ffiCall()}
-          return IReference<$referenceTypeArg>.fromRawPointer(retValuePtr$referenceConstructorArgs).value;
+          return IReference<$referenceTypeArg>.fromRawPointer
+            (retValuePtr$referenceConstructorArgs).value;
         } finally {
           $parametersPostamble
           free(retValuePtr);
@@ -102,8 +103,8 @@ class WinRTGetPropertyReturningReferenceProjection
 
         try {
           ${ffiCall()}
-
-          return IReference<$referenceTypeArg>.fromRawPointer(retValuePtr$referenceConstructorArgs).value;
+          return IReference<$referenceTypeArg>.fromRawPointer
+            (retValuePtr$referenceConstructorArgs).value;
         } finally {
           free(retValuePtr);
         }

--- a/tool/generator/lib/src/projection/winrt/declarations/string.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/string.dart
@@ -59,7 +59,7 @@ class WinRTSetPropertyReturningStringProjection
         final hstr = convertToHString(value);
 
         try {
-          ${ffiCall('hstr')}
+          ${ffiCall(params: 'hstr')}
 
         } finally {
           WindowsDeleteString(hstr);

--- a/tool/generator/lib/src/projection/winrt/declarations/vector.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/vector.dart
@@ -66,7 +66,7 @@ class WinRTMethodReturningVectorProjection extends WinRTMethodProjection
       IVector<$vectorTypeArg> $camelCasedName($methodParams) {
         final retValuePtr = calloc<COMObject>();
         $parametersPreamble
-        ${ffiCall()}
+        ${ffiCall(freeRetValOnFailure: true)}
         $parametersPostamble
         return IVector.fromRawPointer(retValuePtr$vectorConstructorArgs);
       }
@@ -82,7 +82,7 @@ class WinRTGetPropertyReturningVectorProjection
       IVector<$vectorTypeArg> get $exposedMethodName {
         final retValuePtr = calloc<COMObject>();
 
-        ${ffiCall()}
+        ${ffiCall(freeRetValOnFailure: true)}
 
         return IVector.fromRawPointer(retValuePtr$vectorConstructorArgs);
       }

--- a/tool/generator/lib/src/projection/winrt/declarations/vector.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/vector.dart
@@ -98,10 +98,11 @@ class WinRTMethodReturningVectorViewProjection extends WinRTMethodProjection
       List<$vectorTypeArg> $camelCasedName($methodParams) {
         final retValuePtr = calloc<COMObject>();
         $parametersPreamble
-        ${ffiCall()}
 
         try {
-          return IVectorView<$vectorTypeArg>.fromRawPointer(retValuePtr$vectorConstructorArgs).toList();
+          ${ffiCall()}
+          return IVectorView<$vectorTypeArg>.fromRawPointer
+            (retValuePtr$vectorConstructorArgs).toList();
         } finally {
           $parametersPostamble
           free(retValuePtr);
@@ -120,10 +121,10 @@ class WinRTGetPropertyReturningVectorViewProjection
       List<$vectorTypeArg> get $exposedMethodName {
         final retValuePtr = calloc<COMObject>();
 
-        ${ffiCall()}
-
         try {
-          return IVectorView<$vectorTypeArg>.fromRawPointer(retValuePtr$vectorConstructorArgs).toList();
+          ${ffiCall()}
+          return IVectorView<$vectorTypeArg>.fromRawPointer
+            (retValuePtr$vectorConstructorArgs).toList();
         } finally {
           free(retValuePtr);
         }

--- a/tool/generator/lib/src/projection/winrt/winrt_get_property.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_get_property.dart
@@ -23,7 +23,7 @@ class WinRTGetPropertyProjection extends WinRTPropertyProjection {
       : 'Pointer, Pointer<${returnType.nativeType}>';
 
   @override
-  String ffiCall([String params = '', bool freeRetValOnFailure = false]) {
+  String ffiCall({String params = '', bool freeRetValOnFailure = false}) {
     return [
       '''
     final hr = ptr.ref.vtable

--- a/tool/generator/lib/src/projection/winrt/winrt_get_property.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_get_property.dart
@@ -23,15 +23,21 @@ class WinRTGetPropertyProjection extends WinRTPropertyProjection {
       : 'Pointer, Pointer<${returnType.nativeType}>';
 
   @override
-  String ffiCall([String params = '']) => '''
+  String ffiCall([String params = '', bool freeRetValOnFailure = false]) {
+    return [
+      '''
     final hr = ptr.ref.vtable
       .elementAt($vtableOffset)
       .cast<Pointer<NativeFunction<$nativePrototype>>>()
       .value
       .asFunction<$dartPrototype>()(ptr.ref.lpVtbl, retValuePtr);
-
-    if (FAILED(hr)) throw WindowsException(hr);
-''';
+''',
+      if (freeRetValOnFailure)
+        'if (FAILED(hr)) { free(retValuePtr); throw WindowsException(hr); }'
+      else
+        'if (FAILED(hr)) throw WindowsException(hr);'
+    ].join('\n');
+  }
 
   @override
   String get shortForm => exposedMethodName;

--- a/tool/generator/lib/src/projection/winrt/winrt_method.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_method.dart
@@ -112,7 +112,7 @@ class WinRTMethodProjection extends MethodProjection {
       .map((param) => (param as WinRTParameterProjection).postamble)
       .join('\n');
 
-  String ffiCall([String params = '']) => '''
+  String ffiCall({String params = '', bool freeRetValOnFailure = false}) => '''
     final hr = ptr.ref.vtable
       .elementAt($vtableOffset)
       .cast<Pointer<NativeFunction<$nativePrototype>>>()

--- a/tool/generator/lib/src/projection/winrt/winrt_set_property.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_set_property.dart
@@ -18,7 +18,7 @@ class WinRTSetPropertyProjection extends WinRTPropertyProjection {
   String get dartParams => 'Pointer, ${parameters.first.type.dartType}';
 
   @override
-  String ffiCall([String params = '']) => '''
+  String ffiCall({String params = '', bool freeRetValOnFailure = false}) => '''
     final hr = ptr.ref.vtable
       .elementAt($vtableOffset)
       .cast<Pointer<NativeFunction<$nativePrototype>>>()

--- a/tool/generator/test/goldens/icalendar.golden
+++ b/tool/generator/test/goldens/icalendar.golden
@@ -79,19 +79,18 @@ class ICalendar extends IInspectable {
   List<String> get languages {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
-            .elementAt(9)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
-            .value
-            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, retValuePtr);
-
-    if (FAILED(hr)) throw WindowsException(hr);
-
     try {
+      final hr = ptr.ref.vtable
+              .elementAt(9)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(Pointer, Pointer<COMObject>)>>>()
+              .value
+              .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
       return IVectorView<String>.fromRawPointer(retValuePtr).toList();
     } finally {
       free(retValuePtr);


### PR DESCRIPTION
If a WinRT call fails with a non-zero `hr`, we throw an exception. But we don't clear up the `retValuePtr` if it has been allocated, in scenarios where we'd otherwise return it to the user. 

This change attempts to `free` all instances of `retValuePtr` that are allocated when an exception occurs. 

(It also fixes a minor test flake that blocked me on my Windows-on-ARM machine.)