### PR TITLE
Fix memleak in the `toMap` helper function

### DIFF
--- a/lib/src/winrt/foundation/collections/imap.dart
+++ b/lib/src/winrt/foundation/collections/imap.dart
@@ -758,8 +758,7 @@ class IMap<K, V> extends IInspectable
   /// Creates an unmodifiable [Map] from the current [IMap] instance.
   Map<K, V> toMap() => size == 0
       ? Map.unmodifiable(<K, V>{})
-      : MapHelper.toMap<K, V>(first().getMany,
-          length: size, creator: _iterableCreator);
+      : MapHelper.toMap<K, V>(first(), length: size, creator: _iterableCreator);
 
   late final _iIterable = IIterable<IKeyValuePair<K, V>>.fromRawPointer(
       toInterface(iterableIidFromIids(iids)),

--- a/lib/src/winrt/foundation/collections/imapview.dart
+++ b/lib/src/winrt/foundation/collections/imapview.dart
@@ -440,8 +440,7 @@ class IMapView<K, V> extends IInspectable
   /// Creates an unmodifiable [Map] from the current [IMapView] instance.
   Map<K, V> toMap() => size == 0
       ? Map.unmodifiable(<K, V>{})
-      : MapHelper.toMap<K, V>(first().getMany,
-          length: size, creator: _iterableCreator);
+      : MapHelper.toMap<K, V>(first(), length: size, creator: _iterableCreator);
 
   late final _iIterable = IIterable<IKeyValuePair<K, V>>.fromRawPointer(
       toInterface(iterableIidFromIids(iids)),

--- a/lib/src/winrt/internal/map_helpers.dart
+++ b/lib/src/winrt/internal/map_helpers.dart
@@ -35,6 +35,7 @@ class MapHelper {
       return Map.unmodifiable(map);
     } finally {
       free(pKeyValuePairArray);
+      free(iterator.ptr);
     }
   }
 }

--- a/lib/src/winrt/internal/map_helpers.dart
+++ b/lib/src/winrt/internal/map_helpers.dart
@@ -8,6 +8,7 @@ import 'package:ffi/ffi.dart';
 
 import '../../combase.dart';
 import '../../guid.dart';
+import '../../utils.dart';
 import '../../winrt_helpers.dart';
 import '../devices/sensors/enums.g.dart';
 import '../devices/sensors/pedometerreading.dart';
@@ -20,15 +21,20 @@ class MapHelper {
     IKeyValuePair<K, V> Function(Pointer<COMObject>)? creator,
     int length = 1,
   }) {
-    final pArray = calloc<COMObject>(length);
-    getManyCallback(length, pArray);
-    final keyValuePairs = pArray.toList<IKeyValuePair<K, V>>(
-        creator ?? IKeyValuePair.fromRawPointer,
-        length: length);
-    final map = Map.fromEntries(
-        keyValuePairs.map((kvp) => MapEntry(kvp.key, kvp.value)));
+    final pKeyValuePairArray = calloc<COMObject>(length);
 
-    return Map.unmodifiable(map);
+    try {
+      getManyCallback(length, pKeyValuePairArray);
+      final keyValuePairs = pKeyValuePairArray.toList<IKeyValuePair<K, V>>(
+          creator ?? IKeyValuePair.fromRawPointer,
+          length: length);
+      final map = Map.fromEntries(
+          keyValuePairs.map((kvp) => MapEntry(kvp.key, kvp.value)));
+
+      return Map.unmodifiable(map);
+    } finally {
+      free(pKeyValuePairArray);
+    }
   }
 }
 

--- a/lib/src/winrt/internal/map_helpers.dart
+++ b/lib/src/winrt/internal/map_helpers.dart
@@ -12,19 +12,20 @@ import '../../utils.dart';
 import '../../winrt_helpers.dart';
 import '../devices/sensors/enums.g.dart';
 import '../devices/sensors/pedometerreading.dart';
+import '../foundation/collections/iiterator.dart';
 import '../foundation/collections/ikeyvaluepair.dart';
 import 'comobject_pointer.dart';
 
 class MapHelper {
   static Map<K, V> toMap<K, V>(
-    int Function(int, Pointer<NativeType>) getManyCallback, {
+    IIterator<IKeyValuePair<K, V>> iterator, {
     IKeyValuePair<K, V> Function(Pointer<COMObject>)? creator,
     int length = 1,
   }) {
     final pKeyValuePairArray = calloc<COMObject>(length);
 
     try {
-      getManyCallback(length, pKeyValuePairArray);
+      iterator.getMany(length, pKeyValuePairArray);
       final keyValuePairs = pKeyValuePairArray.toList<IKeyValuePair<K, V>>(
           creator ?? IKeyValuePair.fromRawPointer,
           length: length);


### PR DESCRIPTION
https://github.com/timsneath/win32/blob/220c807d765518eb7d0216e59c9a13b0bebcfdce/lib/src/winrt/internal/map_helpers.dart#L23-L31

... we can also free the `pArray` pointer as it's only used when constructing a `Map` (Line 29, while iterating over to the `IKeyValuePair`'s `key` and `value` getters). After that, we don't need `pArray` at all. Therefore, we can safely free it in a `finally` block.

_Originally posted by @halildurmus in https://github.com/timsneath/win32/issues/563#issuecomment-1279341820_
      