### PR TITLE
Fix memleak on exceptions (in WinRT methods)

### DIFF
--- a/lib/src/winrt/foundation/ipropertyvaluestatics.dart
+++ b/lib/src/winrt/foundation/ipropertyvaluestatics.dart
@@ -51,7 +51,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -70,7 +73,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -89,7 +95,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -108,7 +117,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -127,7 +139,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -146,7 +161,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -165,7 +183,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -184,7 +205,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -204,7 +228,10 @@ class IPropertyValueStatics extends IInspectable {
                 int Function(Pointer, double value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -224,7 +251,10 @@ class IPropertyValueStatics extends IInspectable {
                 int Function(Pointer, double value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -243,7 +273,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -263,7 +296,10 @@ class IPropertyValueStatics extends IInspectable {
                 int Function(Pointer, bool value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -282,8 +318,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueHstring, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
-
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
     WindowsDeleteString(valueHstring);
     return retValuePtr;
   }
@@ -304,7 +342,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer, Pointer<COMObject> value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value.cast<Pointer<COMObject>>().value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -324,7 +365,10 @@ class IPropertyValueStatics extends IInspectable {
                 int Function(Pointer, GUID value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -344,7 +388,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueDateTime, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -363,7 +410,10 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<int Function(Pointer, int value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueDuration, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -383,7 +433,10 @@ class IPropertyValueStatics extends IInspectable {
                 int Function(Pointer, Point value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -403,7 +456,10 @@ class IPropertyValueStatics extends IInspectable {
                 int Function(Pointer, Size value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -423,7 +479,10 @@ class IPropertyValueStatics extends IInspectable {
                 int Function(Pointer, Rect value, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -444,7 +503,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -465,7 +527,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -486,7 +551,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -507,7 +575,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -528,7 +599,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -549,7 +623,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -570,7 +647,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -591,7 +671,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -612,7 +695,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -633,7 +719,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -654,7 +743,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -675,7 +767,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -697,7 +792,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -718,7 +816,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -739,7 +840,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -760,7 +864,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -781,7 +888,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -802,7 +912,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -823,7 +936,10 @@ class IPropertyValueStatics extends IInspectable {
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, valueSize, value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/gaming/input/igamecontrollerbatteryinfo.dart
+++ b/lib/src/winrt/gaming/input/igamecontrollerbatteryinfo.dart
@@ -50,7 +50,10 @@ class IGameControllerBatteryInfo extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/gaming/input/igamepadstatics2.dart
+++ b/lib/src/winrt/gaming/input/igamepadstatics2.dart
@@ -59,7 +59,10 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
                         Pointer<COMObject>)>()(ptr.ref.lpVtbl,
             gameController.cast<Pointer<COMObject>>().value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/globalization/icalendar.dart
+++ b/lib/src/winrt/globalization/icalendar.dart
@@ -51,7 +51,10 @@ class ICalendar extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -172,7 +175,6 @@ class ICalendar extends IInspectable {
             int Function(Pointer, int value)>()(ptr.ref.lpVtbl, valueHstring);
 
     if (FAILED(hr)) throw WindowsException(hr);
-
     WindowsDeleteString(valueHstring);
   }
 
@@ -211,7 +213,6 @@ class ICalendar extends IInspectable {
             int Function(Pointer, int value)>()(ptr.ref.lpVtbl, valueHstring);
 
     if (FAILED(hr)) throw WindowsException(hr);
-
     WindowsDeleteString(valueHstring);
   }
 

--- a/lib/src/winrt/globalization/icalendarfactory.dart
+++ b/lib/src/winrt/globalization/icalendarfactory.dart
@@ -55,7 +55,10 @@ class ICalendarFactory extends IInspectable {
                     Pointer<COMObject>)>()(ptr.ref.lpVtbl,
         languages.cast<Pointer<COMObject>>().value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -88,7 +91,10 @@ class ICalendarFactory extends IInspectable {
             clockHstring,
             retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     WindowsDeleteString(calendarHstring);
     WindowsDeleteString(clockHstring);

--- a/lib/src/winrt/globalization/icalendarfactory2.dart
+++ b/lib/src/winrt/globalization/icalendarfactory2.dart
@@ -73,7 +73,10 @@ class ICalendarFactory2 extends IInspectable {
         timeZoneIdHstring,
         retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     WindowsDeleteString(calendarHstring);
     WindowsDeleteString(clockHstring);

--- a/lib/src/winrt/globalization/itimezoneoncalendar.dart
+++ b/lib/src/winrt/globalization/itimezoneoncalendar.dart
@@ -73,7 +73,6 @@ class ITimeZoneOnCalendar extends IInspectable {
                 Pointer, int timeZoneId)>()(ptr.ref.lpVtbl, timeZoneIdHstring);
 
     if (FAILED(hr)) throw WindowsException(hr);
-
     WindowsDeleteString(timeZoneIdHstring);
   }
 

--- a/lib/src/winrt/globalization/phonenumberformatting/iphonenumberformatterstatics.dart
+++ b/lib/src/winrt/globalization/phonenumberformatting/iphonenumberformatterstatics.dart
@@ -55,7 +55,6 @@ class IPhoneNumberFormatterStatics extends IInspectable {
         ptr.ref.lpVtbl, regionCodeHstring, phoneNumber);
 
     if (FAILED(hr)) throw WindowsException(hr);
-
     WindowsDeleteString(regionCodeHstring);
   }
 

--- a/lib/src/winrt/globalization/phonenumberformatting/iphonenumberinfofactory.dart
+++ b/lib/src/winrt/globalization/phonenumberformatting/iphonenumberinfofactory.dart
@@ -52,8 +52,10 @@ class IPhoneNumberInfoFactory extends IInspectable {
                 int Function(Pointer, int number, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, numberHstring, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
-
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
     WindowsDeleteString(numberHstring);
     return retValuePtr;
   }

--- a/lib/src/winrt/storage/istorageitem.dart
+++ b/lib/src/winrt/storage/istorageitem.dart
@@ -54,8 +54,10 @@ class IStorageItem extends IInspectable {
                 int Function(Pointer, int desiredName, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, desiredNameHstring, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
-
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
     WindowsDeleteString(desiredNameHstring);
     return retValuePtr;
   }
@@ -79,8 +81,10 @@ class IStorageItem extends IInspectable {
                         Pointer<COMObject>)>()(
             ptr.ref.lpVtbl, desiredNameHstring, option.value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
-
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
     WindowsDeleteString(desiredNameHstring);
 
     return retValuePtr;
@@ -99,7 +103,10 @@ class IStorageItem extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -119,7 +126,10 @@ class IStorageItem extends IInspectable {
                 int Function(Pointer, int option, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, option.value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -137,7 +147,10 @@ class IStorageItem extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/storage/iuserdatapathsstatics.dart
+++ b/lib/src/winrt/storage/iuserdatapathsstatics.dart
@@ -54,7 +54,10 @@ class IUserDataPathsStatics extends IInspectable {
                     Pointer, Pointer<COMObject> user, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, user.cast<Pointer<COMObject>>().value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -72,7 +75,10 @@ class IUserDataPathsStatics extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/storage/pickers/ifileopenpicker.dart
+++ b/lib/src/winrt/storage/pickers/ifileopenpicker.dart
@@ -219,7 +219,10 @@ class IFileOpenPicker extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -237,7 +240,10 @@ class IFileOpenPicker extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/storage/pickers/ifileopenpickerstatics2.dart
+++ b/lib/src/winrt/storage/pickers/ifileopenpickerstatics2.dart
@@ -54,7 +54,10 @@ class IFileOpenPickerStatics2 extends IInspectable {
                     Pointer, Pointer<COMObject> user, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, user.cast<Pointer<COMObject>>().value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/ui/notifications/inotificationdatafactory.dart
+++ b/lib/src/winrt/ui/notifications/inotificationdatafactory.dart
@@ -63,7 +63,10 @@ class INotificationDataFactory extends IInspectable {
             sequenceNumber,
             retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -88,7 +91,10 @@ class INotificationDataFactory extends IInspectable {
                         Pointer<COMObject>)>()(ptr.ref.lpVtbl,
             initialValues.cast<Pointer<COMObject>>().value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/ui/notifications/itoastnotificationfactory.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotificationfactory.dart
@@ -54,7 +54,10 @@ class IToastNotificationFactory extends IInspectable {
                     Pointer, Pointer<COMObject> content, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, content.cast<Pointer<COMObject>>().value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/lib/src/winrt/ui/notifications/itoastnotificationmanagerstatics.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotificationmanagerstatics.dart
@@ -53,7 +53,10 @@ class IToastNotificationManagerStatics extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -73,8 +76,10 @@ class IToastNotificationManagerStatics extends IInspectable {
                 int Function(Pointer, int applicationId, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, applicationIdHstring, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
-
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
     WindowsDeleteString(applicationIdHstring);
     return retValuePtr;
   }
@@ -93,7 +98,10 @@ class IToastNotificationManagerStatics extends IInspectable {
             .asFunction<int Function(Pointer, int type, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, type.value, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }

--- a/tool/generator/lib/src/projection/winrt/winrt_method.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_method.dart
@@ -112,15 +112,21 @@ class WinRTMethodProjection extends MethodProjection {
       .map((param) => (param as WinRTParameterProjection).postamble)
       .join('\n');
 
-  String ffiCall({String params = '', bool freeRetValOnFailure = false}) => '''
+  String ffiCall({String params = '', bool freeRetValOnFailure = false}) {
+    return [
+      '''
     final hr = ptr.ref.vtable
       .elementAt($vtableOffset)
       .cast<Pointer<NativeFunction<$nativePrototype>>>()
       .value
       .asFunction<$dartPrototype>()($identifiers);
-
-    if (FAILED(hr)) throw WindowsException(hr);
-  ''';
+''',
+      if (freeRetValOnFailure)
+        'if (FAILED(hr)) { free(retValuePtr); throw WindowsException(hr); }'
+      else
+        'if (FAILED(hr)) throw WindowsException(hr);'
+    ].join('\n');
+  }
 
   /// Returns the method declaration for a method or property declaration class
   /// specified in [creator].

--- a/tool/generator/test/goldens/icalendar.golden
+++ b/tool/generator/test/goldens/icalendar.golden
@@ -51,7 +51,10 @@ class ICalendar extends IInspectable {
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) throw WindowsException(hr);
+    if (FAILED(hr)) {
+      free(retValuePtr);
+      throw WindowsException(hr);
+    }
 
     return retValuePtr;
   }
@@ -172,7 +175,6 @@ class ICalendar extends IInspectable {
             int Function(Pointer, int value)>()(ptr.ref.lpVtbl, valueHstring);
 
     if (FAILED(hr)) throw WindowsException(hr);
-
     WindowsDeleteString(valueHstring);
   }
 
@@ -211,7 +213,6 @@ class ICalendar extends IInspectable {
             int Function(Pointer, int value)>()(ptr.ref.lpVtbl, valueHstring);
 
     if (FAILED(hr)) throw WindowsException(hr);
-
     WindowsDeleteString(valueHstring);
   }
 


### PR DESCRIPTION
It looks like we forgot to update the `ffiCall` method in the `WinRTMethodProjection` to handle `freeRetValOnFailure` flag in #564 (Oops! 😅).