### PR TITLE
Use the relative path from the current folder while generating imports

### DIFF
--- a/lib/src/winrt/data/json/enums.g.dart
+++ b/lib/src/winrt/data/json/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../../winrt/foundation/winrt_enum.dart';
+import '../../foundation/winrt_enum.dart';
 
 /// Defines errors encountered while parsing JSON data.
 ///

--- a/lib/src/winrt/data/json/ijsonarray.dart
+++ b/lib/src/winrt/data/json/ijsonarray.dart
@@ -19,12 +19,12 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/json/ijsonvalue.dart';
-import '../../../winrt/data/json/jsonobject.dart';
-import '../../../winrt/data/json/jsonarray.dart';
-import '../../../winrt/data/json/enums.g.dart';
+import 'ijsonvalue.dart';
+import 'jsonobject.dart';
+import 'jsonarray.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/data/json/ijsonarraystatics.dart
+++ b/lib/src/winrt/data/json/ijsonarraystatics.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/json/jsonarray.dart';
+import 'jsonarray.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/data/json/ijsonobject.dart
+++ b/lib/src/winrt/data/json/ijsonobject.dart
@@ -19,13 +19,13 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/json/ijsonvalue.dart';
-import '../../../winrt/data/json/jsonvalue.dart';
-import '../../../winrt/data/json/jsonobject.dart';
-import '../../../winrt/data/json/jsonarray.dart';
-import '../../../winrt/data/json/enums.g.dart';
+import 'ijsonvalue.dart';
+import 'jsonvalue.dart';
+import 'jsonobject.dart';
+import 'jsonarray.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/data/json/ijsonobjectstatics.dart
+++ b/lib/src/winrt/data/json/ijsonobjectstatics.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/json/jsonobject.dart';
+import 'jsonobject.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/data/json/ijsonobjectwithdefaultvalues.dart
+++ b/lib/src/winrt/data/json/ijsonobjectwithdefaultvalues.dart
@@ -19,14 +19,14 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/json/ijsonobject.dart';
-import '../../../winrt/data/json/ijsonvalue.dart';
-import '../../../winrt/data/json/jsonvalue.dart';
-import '../../../winrt/data/json/jsonobject.dart';
-import '../../../winrt/data/json/jsonarray.dart';
-import '../../../winrt/data/json/enums.g.dart';
+import 'ijsonobject.dart';
+import 'ijsonvalue.dart';
+import 'jsonvalue.dart';
+import 'jsonobject.dart';
+import 'jsonarray.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/data/json/ijsonvalue.dart
+++ b/lib/src/winrt/data/json/ijsonvalue.dart
@@ -19,11 +19,11 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/json/enums.g.dart';
-import '../../../winrt/data/json/jsonarray.dart';
-import '../../../winrt/data/json/jsonobject.dart';
+import 'enums.g.dart';
+import 'jsonarray.dart';
+import 'jsonobject.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/data/json/ijsonvaluestatics.dart
+++ b/lib/src/winrt/data/json/ijsonvaluestatics.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/json/jsonvalue.dart';
+import 'jsonvalue.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/data/json/ijsonvaluestatics2.dart
+++ b/lib/src/winrt/data/json/ijsonvaluestatics2.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/json/jsonvalue.dart';
+import 'jsonvalue.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/data/json/jsonvalue.dart
+++ b/lib/src/winrt/data/json/jsonvalue.dart
@@ -19,15 +19,15 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/json/ijsonvalue.dart';
-import '../../../winrt/foundation/istringable.dart';
+import 'ijsonvalue.dart';
+import '../../foundation/istringable.dart';
 import 'ijsonvaluestatics.dart';
 import 'ijsonvaluestatics2.dart';
-import '../../../winrt/data/json/enums.g.dart';
-import '../../../winrt/data/json/jsonarray.dart';
-import '../../../winrt/data/json/jsonobject.dart';
+import 'enums.g.dart';
+import 'jsonarray.dart';
+import 'jsonobject.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/devices/enumeration/enums.g.dart
+++ b/lib/src/winrt/devices/enumeration/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../../winrt/foundation/winrt_enum.dart';
+import '../../foundation/winrt_enum.dart';
 
 /// Indicates the type of devices that the user wants to enumerate.
 ///

--- a/lib/src/winrt/devices/power/batteryreport.dart
+++ b/lib/src/winrt/devices/power/batteryreport.dart
@@ -19,11 +19,11 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/devices/power/ibatteryreport.dart';
-import '../../../winrt/foundation/ireference.dart';
-import '../../../winrt/system/power/enums.g.dart';
+import 'ibatteryreport.dart';
+import '../../foundation/ireference.dart';
+import '../../system/power/enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/devices/power/ibatteryreport.dart
+++ b/lib/src/winrt/devices/power/ibatteryreport.dart
@@ -19,11 +19,11 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/foundation/ireference.dart';
-import '../../../winrt/system/power/enums.g.dart';
-import '../../../winrt/internal/ipropertyvalue_helpers.dart';
+import '../../foundation/ireference.dart';
+import '../../system/power/enums.g.dart';
+import '../../internal/ipropertyvalue_helpers.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/devices/sensors/enums.g.dart
+++ b/lib/src/winrt/devices/sensors/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../../winrt/foundation/winrt_enum.dart';
+import '../../foundation/winrt_enum.dart';
 
 /// The type of step taken according to the pedometer.
 ///

--- a/lib/src/winrt/devices/sensors/ipedometerreading.dart
+++ b/lib/src/winrt/devices/sensors/ipedometerreading.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/devices/sensors/enums.g.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/devices/sensors/pedometerreading.dart
+++ b/lib/src/winrt/devices/sensors/pedometerreading.dart
@@ -19,10 +19,10 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/devices/sensors/ipedometerreading.dart';
-import '../../../winrt/devices/sensors/enums.g.dart';
+import 'ipedometerreading.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/foundation/enums.g.dart
+++ b/lib/src/winrt/foundation/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../winrt/foundation/winrt_enum.dart';
+import 'winrt_enum.dart';
 
 /// Specifies the status of an asynchronous operation.
 ///

--- a/lib/src/winrt/foundation/iasyncinfo.dart
+++ b/lib/src/winrt/foundation/iasyncinfo.dart
@@ -19,9 +19,9 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/foundation/enums.g.dart';
+import 'enums.g.dart';
 import '../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/foundation/iclosable.dart
+++ b/lib/src/winrt/foundation/iclosable.dart
@@ -19,7 +19,7 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
 import '../../com/iinspectable.dart';
 

--- a/lib/src/winrt/foundation/ipropertyvalue.dart
+++ b/lib/src/winrt/foundation/ipropertyvalue.dart
@@ -19,11 +19,11 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/foundation/enums.g.dart';
+import 'enums.g.dart';
 import '../../guid.dart';
-import '../../winrt/foundation/structs.g.dart';
+import 'structs.g.dart';
 import '../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/foundation/ipropertyvaluestatics.dart
+++ b/lib/src/winrt/foundation/ipropertyvaluestatics.dart
@@ -19,10 +19,10 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
 import '../../guid.dart';
-import '../../winrt/foundation/structs.g.dart';
+import 'structs.g.dart';
 import 'ipropertyvalue.dart';
 import '../../com/iinspectable.dart';
 

--- a/lib/src/winrt/foundation/istringable.dart
+++ b/lib/src/winrt/foundation/istringable.dart
@@ -19,7 +19,7 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
 import '../../com/iinspectable.dart';
 

--- a/lib/src/winrt/foundation/propertyvalue.dart
+++ b/lib/src/winrt/foundation/propertyvalue.dart
@@ -19,11 +19,11 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
 import 'ipropertyvaluestatics.dart';
 import '../../guid.dart';
-import '../../winrt/foundation/structs.g.dart';
+import 'structs.g.dart';
 import 'ipropertyvalue.dart';
 import '../../com/iinspectable.dart';
 

--- a/lib/src/winrt/gaming/input/enums.g.dart
+++ b/lib/src/winrt/gaming/input/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../../winrt/foundation/winrt_enum.dart';
+import '../../foundation/winrt_enum.dart';
 
 /// Label that appears on the physical controller button.
 ///

--- a/lib/src/winrt/gaming/input/gamepad.dart
+++ b/lib/src/winrt/gaming/input/gamepad.dart
@@ -19,21 +19,21 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/gaming/input/igamepad.dart';
-import '../../../winrt/gaming/input/igamecontroller.dart';
-import '../../../winrt/gaming/input/igamepad2.dart';
-import '../../../winrt/gaming/input/igamecontrollerbatteryinfo.dart';
+import 'igamepad.dart';
+import 'igamecontroller.dart';
+import 'igamepad2.dart';
+import 'igamecontrollerbatteryinfo.dart';
 import 'igamepadstatics.dart';
 import 'igamepadstatics2.dart';
-import '../../../winrt/gaming/input/structs.g.dart';
-import '../../../winrt/gaming/input/headset.dart';
-import '../../../winrt/system/userchangedeventargs.dart';
-import '../../../winrt/system/user.dart';
-import '../../../winrt/gaming/input/enums.g.dart';
-import '../../../winrt/devices/power/batteryreport.dart';
-import '../../../winrt/foundation/collections/ivectorview.dart';
+import 'structs.g.dart';
+import 'headset.dart';
+import '../../system/userchangedeventargs.dart';
+import '../../system/user.dart';
+import 'enums.g.dart';
+import '../../devices/power/batteryreport.dart';
+import '../../foundation/collections/ivectorview.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/gaming/input/headset.dart
+++ b/lib/src/winrt/gaming/input/headset.dart
@@ -19,11 +19,11 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/gaming/input/iheadset.dart';
-import '../../../winrt/gaming/input/igamecontrollerbatteryinfo.dart';
-import '../../../winrt/devices/power/batteryreport.dart';
+import 'iheadset.dart';
+import 'igamecontrollerbatteryinfo.dart';
+import '../../devices/power/batteryreport.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/gaming/input/igamecontroller.dart
+++ b/lib/src/winrt/gaming/input/igamecontroller.dart
@@ -19,11 +19,11 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/gaming/input/headset.dart';
-import '../../../winrt/system/userchangedeventargs.dart';
-import '../../../winrt/system/user.dart';
+import 'headset.dart';
+import '../../system/userchangedeventargs.dart';
+import '../../system/user.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/gaming/input/igamecontrollerbatteryinfo.dart
+++ b/lib/src/winrt/gaming/input/igamecontrollerbatteryinfo.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/devices/power/batteryreport.dart';
+import '../../devices/power/batteryreport.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/gaming/input/igamepad.dart
+++ b/lib/src/winrt/gaming/input/igamepad.dart
@@ -19,13 +19,13 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/gaming/input/igamecontroller.dart';
-import '../../../winrt/gaming/input/structs.g.dart';
-import '../../../winrt/gaming/input/headset.dart';
-import '../../../winrt/system/userchangedeventargs.dart';
-import '../../../winrt/system/user.dart';
+import 'igamecontroller.dart';
+import 'structs.g.dart';
+import 'headset.dart';
+import '../../system/userchangedeventargs.dart';
+import '../../system/user.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/gaming/input/igamepad2.dart
+++ b/lib/src/winrt/gaming/input/igamepad2.dart
@@ -19,15 +19,15 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/gaming/input/igamepad.dart';
-import '../../../winrt/gaming/input/igamecontroller.dart';
-import '../../../winrt/gaming/input/enums.g.dart';
-import '../../../winrt/gaming/input/structs.g.dart';
-import '../../../winrt/gaming/input/headset.dart';
-import '../../../winrt/system/userchangedeventargs.dart';
-import '../../../winrt/system/user.dart';
+import 'igamepad.dart';
+import 'igamecontroller.dart';
+import 'enums.g.dart';
+import 'structs.g.dart';
+import 'headset.dart';
+import '../../system/userchangedeventargs.dart';
+import '../../system/user.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/gaming/input/igamepadstatics.dart
+++ b/lib/src/winrt/gaming/input/igamepadstatics.dart
@@ -19,10 +19,10 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/gaming/input/gamepad.dart';
-import '../../../winrt/foundation/collections/ivectorview.dart';
+import 'gamepad.dart';
+import '../../foundation/collections/ivectorview.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/gaming/input/igamepadstatics2.dart
+++ b/lib/src/winrt/gaming/input/igamepadstatics2.dart
@@ -19,12 +19,12 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/gaming/input/igamepadstatics.dart';
-import '../../../winrt/gaming/input/igamecontroller.dart';
-import '../../../winrt/gaming/input/gamepad.dart';
-import '../../../winrt/foundation/collections/ivectorview.dart';
+import 'igamepadstatics.dart';
+import 'igamecontroller.dart';
+import 'gamepad.dart';
+import '../../foundation/collections/ivectorview.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/gaming/input/iheadset.dart
+++ b/lib/src/winrt/gaming/input/iheadset.dart
@@ -19,7 +19,7 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
 import '../../../com/iinspectable.dart';
 

--- a/lib/src/winrt/globalization/calendar.dart
+++ b/lib/src/winrt/globalization/calendar.dart
@@ -19,15 +19,15 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/globalization/icalendar.dart';
-import '../../winrt/globalization/itimezoneoncalendar.dart';
+import 'icalendar.dart';
+import 'itimezoneoncalendar.dart';
 import 'icalendarfactory.dart';
 import 'icalendarfactory2.dart';
-import '../../winrt/foundation/collections/iiterable.dart';
-import '../../winrt/foundation/collections/ivectorview.dart';
-import '../../winrt/globalization/enums.g.dart';
+import '../foundation/collections/iiterable.dart';
+import '../foundation/collections/ivectorview.dart';
+import 'enums.g.dart';
 import '../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/globalization/enums.g.dart
+++ b/lib/src/winrt/globalization/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../winrt/foundation/winrt_enum.dart';
+import '../foundation/winrt_enum.dart';
 
 /// Identifies the day of the week.
 ///

--- a/lib/src/winrt/globalization/icalendar.dart
+++ b/lib/src/winrt/globalization/icalendar.dart
@@ -19,11 +19,11 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/globalization/calendar.dart';
-import '../../winrt/foundation/collections/ivectorview.dart';
-import '../../winrt/globalization/enums.g.dart';
+import 'calendar.dart';
+import '../foundation/collections/ivectorview.dart';
+import 'enums.g.dart';
 import '../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/globalization/icalendarfactory.dart
+++ b/lib/src/winrt/globalization/icalendarfactory.dart
@@ -19,10 +19,10 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/foundation/collections/iiterable.dart';
-import '../../winrt/globalization/calendar.dart';
+import '../foundation/collections/iiterable.dart';
+import 'calendar.dart';
 import '../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/globalization/icalendarfactory2.dart
+++ b/lib/src/winrt/globalization/icalendarfactory2.dart
@@ -19,10 +19,10 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/foundation/collections/iiterable.dart';
-import '../../winrt/globalization/calendar.dart';
+import '../foundation/collections/iiterable.dart';
+import 'calendar.dart';
 import '../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/globalization/itimezoneoncalendar.dart
+++ b/lib/src/winrt/globalization/itimezoneoncalendar.dart
@@ -19,7 +19,7 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
 import '../../com/iinspectable.dart';
 

--- a/lib/src/winrt/globalization/phonenumberformatting/enums.g.dart
+++ b/lib/src/winrt/globalization/phonenumberformatting/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../../winrt/foundation/winrt_enum.dart';
+import '../../foundation/winrt_enum.dart';
 
 /// Lists phone number formats supported by this API.
 ///

--- a/lib/src/winrt/globalization/phonenumberformatting/iphonenumberformatter.dart
+++ b/lib/src/winrt/globalization/phonenumberformatting/iphonenumberformatter.dart
@@ -19,10 +19,10 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/globalization/phonenumberformatting/phonenumberinfo.dart';
-import '../../../winrt/globalization/phonenumberformatting/enums.g.dart';
+import 'phonenumberinfo.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/globalization/phonenumberformatting/iphonenumberformatterstatics.dart
+++ b/lib/src/winrt/globalization/phonenumberformatting/iphonenumberformatterstatics.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/globalization/phonenumberformatting/phonenumberformatter.dart';
+import 'phonenumberformatter.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/globalization/phonenumberformatting/iphonenumberinfo.dart
+++ b/lib/src/winrt/globalization/phonenumberformatting/iphonenumberinfo.dart
@@ -19,10 +19,10 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/globalization/phonenumberformatting/enums.g.dart';
-import '../../../winrt/globalization/phonenumberformatting/phonenumberinfo.dart';
+import 'enums.g.dart';
+import 'phonenumberinfo.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/globalization/phonenumberformatting/iphonenumberinfofactory.dart
+++ b/lib/src/winrt/globalization/phonenumberformatting/iphonenumberinfofactory.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/globalization/phonenumberformatting/phonenumberinfo.dart';
+import 'phonenumberinfo.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/globalization/phonenumberformatting/iphonenumberinfostatics.dart
+++ b/lib/src/winrt/globalization/phonenumberformatting/iphonenumberinfostatics.dart
@@ -19,10 +19,10 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/globalization/phonenumberformatting/phonenumberinfo.dart';
-import '../../../winrt/globalization/phonenumberformatting/enums.g.dart';
+import 'phonenumberinfo.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/globalization/phonenumberformatting/phonenumberformatter.dart
+++ b/lib/src/winrt/globalization/phonenumberformatting/phonenumberformatter.dart
@@ -19,12 +19,12 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/globalization/phonenumberformatting/iphonenumberformatter.dart';
+import 'iphonenumberformatter.dart';
 import 'iphonenumberformatterstatics.dart';
-import '../../../winrt/globalization/phonenumberformatting/phonenumberinfo.dart';
-import '../../../winrt/globalization/phonenumberformatting/enums.g.dart';
+import 'phonenumberinfo.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/globalization/phonenumberformatting/phonenumberinfo.dart
+++ b/lib/src/winrt/globalization/phonenumberformatting/phonenumberinfo.dart
@@ -19,13 +19,13 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/globalization/phonenumberformatting/iphonenumberinfo.dart';
-import '../../../winrt/foundation/istringable.dart';
+import 'iphonenumberinfo.dart';
+import '../../foundation/istringable.dart';
 import 'iphonenumberinfofactory.dart';
 import 'iphonenumberinfostatics.dart';
-import '../../../winrt/globalization/phonenumberformatting/enums.g.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/graphics/printing3d/iprinting3dmultiplepropertymaterial.dart
+++ b/lib/src/winrt/graphics/printing3d/iprinting3dmultiplepropertymaterial.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/foundation/collections/ivector.dart';
+import '../../foundation/collections/ivector.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/graphics/printing3d/printing3dmultiplepropertymaterial.dart
+++ b/lib/src/winrt/graphics/printing3d/printing3dmultiplepropertymaterial.dart
@@ -19,10 +19,10 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/graphics/printing3d/iprinting3dmultiplepropertymaterial.dart';
-import '../../../winrt/foundation/collections/ivector.dart';
+import 'iprinting3dmultiplepropertymaterial.dart';
+import '../../foundation/collections/ivector.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/networking/connectivity/enums.g.dart
+++ b/lib/src/winrt/networking/connectivity/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../../winrt/foundation/winrt_enum.dart';
+import '../../foundation/winrt_enum.dart';
 
 /// Defines the network connection types.
 ///

--- a/lib/src/winrt/networking/connectivity/iipinformation.dart
+++ b/lib/src/winrt/networking/connectivity/iipinformation.dart
@@ -19,11 +19,11 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/networking/connectivity/networkadapter.dart';
-import '../../../winrt/foundation/ireference.dart';
-import '../../../winrt/internal/ipropertyvalue_helpers.dart';
+import 'networkadapter.dart';
+import '../../foundation/ireference.dart';
+import '../../internal/ipropertyvalue_helpers.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/networking/connectivity/inetworkadapter.dart
+++ b/lib/src/winrt/networking/connectivity/inetworkadapter.dart
@@ -19,12 +19,12 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/networking/connectivity/networkitem.dart';
+import 'networkitem.dart';
 import '../../../guid.dart';
-import '../../../winrt/foundation/iasyncoperation.dart';
-import '../../../winrt/networking/connectivity/connectionprofile.dart';
+import '../../foundation/iasyncoperation.dart';
+import 'connectionprofile.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/networking/connectivity/inetworkitem.dart
+++ b/lib/src/winrt/networking/connectivity/inetworkitem.dart
@@ -19,10 +19,10 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
 import '../../../guid.dart';
-import '../../../winrt/networking/connectivity/enums.g.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/networking/connectivity/ipinformation.dart
+++ b/lib/src/winrt/networking/connectivity/ipinformation.dart
@@ -19,11 +19,11 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/networking/connectivity/iipinformation.dart';
-import '../../../winrt/networking/connectivity/networkadapter.dart';
-import '../../../winrt/foundation/ireference.dart';
+import 'iipinformation.dart';
+import 'networkadapter.dart';
+import '../../foundation/ireference.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/networking/connectivity/networkadapter.dart
+++ b/lib/src/winrt/networking/connectivity/networkadapter.dart
@@ -19,13 +19,13 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/networking/connectivity/inetworkadapter.dart';
-import '../../../winrt/networking/connectivity/networkitem.dart';
+import 'inetworkadapter.dart';
+import 'networkitem.dart';
 import '../../../guid.dart';
-import '../../../winrt/foundation/iasyncoperation.dart';
-import '../../../winrt/networking/connectivity/connectionprofile.dart';
+import '../../foundation/iasyncoperation.dart';
+import 'connectionprofile.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/networking/connectivity/networkitem.dart
+++ b/lib/src/winrt/networking/connectivity/networkitem.dart
@@ -19,11 +19,11 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/networking/connectivity/inetworkitem.dart';
+import 'inetworkitem.dart';
 import '../../../guid.dart';
-import '../../../winrt/networking/connectivity/enums.g.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/networking/enums.g.dart
+++ b/lib/src/winrt/networking/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../winrt/foundation/winrt_enum.dart';
+import '../foundation/winrt_enum.dart';
 
 /// The type of a HostName object.
 ///

--- a/lib/src/winrt/networking/hostname.dart
+++ b/lib/src/winrt/networking/hostname.dart
@@ -19,14 +19,14 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/networking/ihostname.dart';
-import '../../winrt/foundation/istringable.dart';
+import 'ihostname.dart';
+import '../foundation/istringable.dart';
 import 'ihostnamefactory.dart';
 import 'ihostnamestatics.dart';
-import '../../winrt/networking/connectivity/ipinformation.dart';
-import '../../winrt/networking/enums.g.dart';
+import 'connectivity/ipinformation.dart';
+import 'enums.g.dart';
 import '../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/networking/ihostname.dart
+++ b/lib/src/winrt/networking/ihostname.dart
@@ -19,11 +19,11 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/networking/connectivity/ipinformation.dart';
-import '../../winrt/networking/enums.g.dart';
-import '../../winrt/networking/hostname.dart';
+import 'connectivity/ipinformation.dart';
+import 'enums.g.dart';
+import 'hostname.dart';
 import '../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/networking/ihostnamefactory.dart
+++ b/lib/src/winrt/networking/ihostnamefactory.dart
@@ -19,9 +19,9 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/networking/hostname.dart';
+import 'hostname.dart';
 import '../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/networking/ihostnamestatics.dart
+++ b/lib/src/winrt/networking/ihostnamestatics.dart
@@ -19,7 +19,7 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
 import '../../com/iinspectable.dart';
 

--- a/lib/src/winrt/storage/enums.g.dart
+++ b/lib/src/winrt/storage/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../winrt/foundation/winrt_enum.dart';
+import '../foundation/winrt_enum.dart';
 
 /// Describes the attributes of a file or folder.
 ///

--- a/lib/src/winrt/storage/istorageitem.dart
+++ b/lib/src/winrt/storage/istorageitem.dart
@@ -19,12 +19,12 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/foundation/iasyncaction.dart';
-import '../../winrt/storage/enums.g.dart';
-import '../../winrt/foundation/iasyncoperation.dart';
-import '../../winrt/storage/fileproperties/basicproperties.dart';
+import '../foundation/iasyncaction.dart';
+import 'enums.g.dart';
+import '../foundation/iasyncoperation.dart';
+import 'fileproperties/basicproperties.dart';
 import '../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/storage/iuserdatapaths.dart
+++ b/lib/src/winrt/storage/iuserdatapaths.dart
@@ -19,7 +19,7 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
 import '../../com/iinspectable.dart';
 

--- a/lib/src/winrt/storage/iuserdatapathsstatics.dart
+++ b/lib/src/winrt/storage/iuserdatapathsstatics.dart
@@ -19,10 +19,10 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/system/user.dart';
-import '../../winrt/storage/userdatapaths.dart';
+import '../system/user.dart';
+import 'userdatapaths.dart';
 import '../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/storage/pickers/enums.g.dart
+++ b/lib/src/winrt/storage/pickers/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../../winrt/foundation/winrt_enum.dart';
+import '../../foundation/winrt_enum.dart';
 
 /// Identifies the storage location that the file picker presents to the
 /// user.

--- a/lib/src/winrt/storage/pickers/fileopenpicker.dart
+++ b/lib/src/winrt/storage/pickers/fileopenpicker.dart
@@ -19,18 +19,18 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/storage/pickers/ifileopenpicker.dart';
-import '../../../winrt/storage/pickers/ifileopenpicker3.dart';
+import 'ifileopenpicker.dart';
+import 'ifileopenpicker3.dart';
 import 'ifileopenpickerstatics2.dart';
-import '../../../winrt/foundation/collections/valueset.dart';
-import '../../../winrt/foundation/iasyncoperation.dart';
-import '../../../winrt/storage/storagefile.dart';
-import '../../../winrt/storage/pickers/enums.g.dart';
-import '../../../winrt/foundation/collections/ivector.dart';
-import '../../../winrt/foundation/collections/ivectorview.dart';
-import '../../../winrt/system/user.dart';
+import '../../foundation/collections/valueset.dart';
+import '../../foundation/iasyncoperation.dart';
+import '../storagefile.dart';
+import 'enums.g.dart';
+import '../../foundation/collections/ivector.dart';
+import '../../foundation/collections/ivectorview.dart';
+import '../../system/user.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/storage/pickers/ifileopenpicker.dart
+++ b/lib/src/winrt/storage/pickers/ifileopenpicker.dart
@@ -19,13 +19,13 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/storage/pickers/enums.g.dart';
-import '../../../winrt/foundation/collections/ivector.dart';
-import '../../../winrt/foundation/iasyncoperation.dart';
-import '../../../winrt/storage/storagefile.dart';
-import '../../../winrt/foundation/collections/ivectorview.dart';
+import 'enums.g.dart';
+import '../../foundation/collections/ivector.dart';
+import '../../foundation/iasyncoperation.dart';
+import '../storagefile.dart';
+import '../../foundation/collections/ivectorview.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/storage/pickers/ifileopenpicker3.dart
+++ b/lib/src/winrt/storage/pickers/ifileopenpicker3.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/system/user.dart';
+import '../../system/user.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/storage/pickers/ifileopenpickerstatics2.dart
+++ b/lib/src/winrt/storage/pickers/ifileopenpickerstatics2.dart
@@ -19,10 +19,10 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/system/user.dart';
-import '../../../winrt/storage/pickers/fileopenpicker.dart';
+import '../../system/user.dart';
+import 'fileopenpicker.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/storage/userdatapaths.dart
+++ b/lib/src/winrt/storage/userdatapaths.dart
@@ -19,11 +19,11 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/storage/iuserdatapaths.dart';
+import 'iuserdatapaths.dart';
 import 'iuserdatapathsstatics.dart';
-import '../../winrt/system/user.dart';
+import '../system/user.dart';
 import '../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/system/power/enums.g.dart
+++ b/lib/src/winrt/system/power/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../../winrt/foundation/winrt_enum.dart';
+import '../../foundation/winrt_enum.dart';
 
 /// Indicates the status of the battery.
 ///

--- a/lib/src/winrt/ui/notifications/enums.g.dart
+++ b/lib/src/winrt/ui/notifications/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../../winrt/foundation/winrt_enum.dart';
+import '../../foundation/winrt_enum.dart';
 
 /// Specifies whether notification mirroring is allowed. Mirroring enables a
 /// notification to be displayed on multiple devices.

--- a/lib/src/winrt/ui/notifications/inotificationdata.dart
+++ b/lib/src/winrt/ui/notifications/inotificationdata.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/foundation/collections/imap.dart';
+import '../../foundation/collections/imap.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/ui/notifications/inotificationdatafactory.dart
+++ b/lib/src/winrt/ui/notifications/inotificationdatafactory.dart
@@ -19,11 +19,11 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/foundation/collections/iiterable.dart';
-import '../../../winrt/foundation/collections/ikeyvaluepair.dart';
-import '../../../winrt/ui/notifications/notificationdata.dart';
+import '../../foundation/collections/iiterable.dart';
+import '../../foundation/collections/ikeyvaluepair.dart';
+import 'notificationdata.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/ui/notifications/itoastnotification.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotification.dart
@@ -19,14 +19,14 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/xml/dom/xmldocument.dart';
-import '../../../winrt/foundation/ireference.dart';
-import '../../../winrt/ui/notifications/toastnotification.dart';
-import '../../../winrt/ui/notifications/toastdismissedeventargs.dart';
-import '../../../winrt/ui/notifications/toastfailedeventargs.dart';
-import '../../../winrt/internal/ipropertyvalue_helpers.dart';
+import '../../data/xml/dom/xmldocument.dart';
+import '../../foundation/ireference.dart';
+import 'toastnotification.dart';
+import 'toastdismissedeventargs.dart';
+import 'toastfailedeventargs.dart';
+import '../../internal/ipropertyvalue_helpers.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/ui/notifications/itoastnotification2.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotification2.dart
@@ -19,7 +19,7 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
 import '../../../com/iinspectable.dart';
 

--- a/lib/src/winrt/ui/notifications/itoastnotification3.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotification3.dart
@@ -19,9 +19,9 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/ui/notifications/enums.g.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/ui/notifications/itoastnotification4.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotification4.dart
@@ -19,10 +19,10 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/ui/notifications/notificationdata.dart';
-import '../../../winrt/ui/notifications/enums.g.dart';
+import 'notificationdata.dart';
+import 'enums.g.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/ui/notifications/itoastnotification6.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotification6.dart
@@ -19,7 +19,7 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
 import '../../../com/iinspectable.dart';
 

--- a/lib/src/winrt/ui/notifications/itoastnotificationfactory.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotificationfactory.dart
@@ -19,10 +19,10 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/data/xml/dom/xmldocument.dart';
-import '../../../winrt/ui/notifications/toastnotification.dart';
+import '../../data/xml/dom/xmldocument.dart';
+import 'toastnotification.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/ui/notifications/itoastnotificationmanagerstatics.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotificationmanagerstatics.dart
@@ -19,11 +19,11 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/ui/notifications/toastnotifier.dart';
-import '../../../winrt/ui/notifications/enums.g.dart';
-import '../../../winrt/data/xml/dom/xmldocument.dart';
+import 'toastnotifier.dart';
+import 'enums.g.dart';
+import '../../data/xml/dom/xmldocument.dart';
 import '../../../com/iinspectable.dart';
 
 /// @nodoc

--- a/lib/src/winrt/ui/notifications/notificationdata.dart
+++ b/lib/src/winrt/ui/notifications/notificationdata.dart
@@ -19,13 +19,13 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/ui/notifications/inotificationdata.dart';
+import 'inotificationdata.dart';
 import 'inotificationdatafactory.dart';
-import '../../../winrt/foundation/collections/iiterable.dart';
-import '../../../winrt/foundation/collections/ikeyvaluepair.dart';
-import '../../../winrt/foundation/collections/imap.dart';
+import '../../foundation/collections/iiterable.dart';
+import '../../foundation/collections/ikeyvaluepair.dart';
+import '../../foundation/collections/imap.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/ui/notifications/toastnotification.dart
+++ b/lib/src/winrt/ui/notifications/toastnotification.dart
@@ -19,20 +19,20 @@ import '../../../types.dart';
 import '../../../winrt_callbacks.dart';
 import '../../../winrt_helpers.dart';
 
-import '../../../winrt/internal/hstring_array.dart';
+import '../../internal/hstring_array.dart';
 
-import '../../../winrt/ui/notifications/itoastnotification.dart';
-import '../../../winrt/ui/notifications/itoastnotification2.dart';
-import '../../../winrt/ui/notifications/itoastnotification3.dart';
-import '../../../winrt/ui/notifications/itoastnotification4.dart';
-import '../../../winrt/ui/notifications/itoastnotification6.dart';
+import 'itoastnotification.dart';
+import 'itoastnotification2.dart';
+import 'itoastnotification3.dart';
+import 'itoastnotification4.dart';
+import 'itoastnotification6.dart';
 import 'itoastnotificationfactory.dart';
-import '../../../winrt/data/xml/dom/xmldocument.dart';
-import '../../../winrt/foundation/ireference.dart';
-import '../../../winrt/ui/notifications/toastdismissedeventargs.dart';
-import '../../../winrt/ui/notifications/toastfailedeventargs.dart';
-import '../../../winrt/ui/notifications/enums.g.dart';
-import '../../../winrt/ui/notifications/notificationdata.dart';
+import '../../data/xml/dom/xmldocument.dart';
+import '../../foundation/ireference.dart';
+import 'toastdismissedeventargs.dart';
+import 'toastfailedeventargs.dart';
+import 'enums.g.dart';
+import 'notificationdata.dart';
 import '../../../com/iinspectable.dart';
 
 /// {@category Class}

--- a/lib/src/winrt/ui/popups/enums.g.dart
+++ b/lib/src/winrt/ui/popups/enums.g.dart
@@ -8,7 +8,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-import '../../../winrt/foundation/winrt_enum.dart';
+import '../../foundation/winrt_enum.dart';
 
 /// Specifies where the context menu should be positioned relative to the
 /// selection rectangle.

--- a/tool/generator/bin/generate.dart
+++ b/tool/generator/bin/generate.dart
@@ -340,9 +340,10 @@ void generateWinRTEnumerations() {
     enumProjections.sort((a, b) =>
         lastComponent(a.enumName).compareTo(lastComponent(b.enumName)));
 
-    final import =
-        "import '${relativePathToSrcDirectory(file)}winrt/foundation/winrt_enum.dart';";
-    final enumsFile = [winrtEnumFileHeader, import, ...enumProjections].join();
+    final winrtEnumFileImport =
+        "import '${relativePath('winrt/foundation/winrt_enum.dart', start: 'winrt/$folderPath')}';";
+    final enumsFile =
+        [winrtEnumFileHeader, winrtEnumFileImport, ...enumProjections].join();
     file.writeAsStringSync(DartFormatter().format(enumsFile));
   }
 }

--- a/tool/generator/lib/src/projection/utils.dart
+++ b/tool/generator/lib/src/projection/utils.dart
@@ -1,6 +1,6 @@
 // Useful utilities
 
-import 'package:path/path.dart' as p;
+import 'package:path/path.dart' as path;
 import 'package:winmd/winmd.dart';
 
 import '../shared/exclusions.dart';
@@ -132,9 +132,9 @@ extension CamelCaseConversion on String {
       length >= 2 ? substring(0, 1).toLowerCase() + substring(1) : this;
 }
 
-/// Converts [path] to an equivalent relative path from the [start] directory.
-String relativePath(String path, {required String start}) =>
-    p.relative(path, from: start).replaceAll(r'\', '/');
+/// Converts [targetPath] to an equivalent relative path from the [start] directory.
+String relativePath(String targetPath, {required String start}) =>
+    path.relative(targetPath, from: start).replaceAll(r'\', '/');
 
 String importForWin32Type(TypeIdentifier identifier) {
   if (excludedWin32Structs.contains(identifier.name)) {

--- a/tool/generator/lib/src/projection/utils.dart
+++ b/tool/generator/lib/src/projection/utils.dart
@@ -1,7 +1,6 @@
 // Useful utilities
 
-import 'dart:io';
-
+import 'package:path/path.dart' as p;
 import 'package:winmd/winmd.dart';
 
 import '../shared/exclusions.dart';
@@ -133,13 +132,9 @@ extension CamelCaseConversion on String {
       length >= 2 ? substring(0, 1).toLowerCase() + substring(1) : this;
 }
 
-/// Given a known file of arbitrary depth in the lib/src hierarchy, return the
-/// relative path to the src parent directory.
-String relativePathToSrcDirectory(File file) {
-  // Find out how many parents there are to the lib/src directory
-  final pathDepth = file.path.split('/').reversed.toList().indexOf('src') - 1;
-  return '../' * pathDepth;
-}
+/// Converts [path] to an equivalent relative path from the [start] directory.
+String relativePath(String path, {required String start}) =>
+    p.relative(path, from: start).replaceAll(r'\', '/');
 
 String importForWin32Type(TypeIdentifier identifier) {
   if (excludedWin32Structs.contains(identifier.name)) {

--- a/tool/generator/lib/src/projection/winrt/winrt_interface.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_interface.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:winmd/winmd.dart';
 
 import '../../shared/exclusions.dart';
@@ -19,8 +17,12 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
       .toList()
       .join(', ');
 
-  String get relativePathToSrcDir => relativePathToSrcDirectory(File(
-      '../../lib/src/winrt/${folderFromWinRTType(typeDef.name)}/$shortName.dart'));
+  /// Returns the path to the directory where the current interface is located.
+  String get _currentDirectory => 'winrt/${folderFromWinRTType(typeDef.name)}';
+
+  /// Converts [path] to an equivalent relative path from the [_currentDirectory].
+  String _relativePathTo(String path) =>
+      relativePath(path, start: _currentDirectory);
 
   /// The WinRT types to ignore when generating the imports.
   static const ignoredWindowsRuntimeTypes = <String>{
@@ -50,11 +52,13 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
       // folders e.g. Windows.Foundation.AsyncActionCompletedHandler -> foundation/delegates.g.dart
       return '';
     } else if (typeDef.isEnum) {
-      return '${relativePathToSrcDir}winrt/${folderFromWinRTType(typeDef.name)}/enums.g.dart';
+      return _relativePathTo(
+          'winrt/${folderFromWinRTType(typeDef.name)}/enums.g.dart');
     } else if (typeDef.isClass || typeDef.isInterface) {
-      return '${relativePathToSrcDir}winrt/${filePathFromWinRTType(typeDef.name)}';
+      return _relativePathTo('winrt/${filePathFromWinRTType(typeDef.name)}');
     } else if (typeDef.isStruct) {
-      return '${relativePathToSrcDir}winrt/${folderFromWinRTType(typeDef.name)}/structs.g.dart';
+      return _relativePathTo(
+          'winrt/${folderFromWinRTType(typeDef.name)}/structs.g.dart');
     } else {
       // TODO: Add support for these as they occur.
       print('Unable to get import for typeDef: $typeDef');
@@ -65,7 +69,7 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
   @override
   String? getImportForTypeIdentifier(TypeIdentifier typeIdentifier) {
     if (typeIdentifier.name == 'System.Guid') {
-      return '${relativePathToSrcDir}guid.dart';
+      return _relativePathTo('guid.dart');
     }
 
     if (typeIdentifier.name.startsWith('Windows')) {
@@ -102,8 +106,8 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
     final containsIReferenceImport =
         imports.where((i) => i.endsWith('ireference.dart')).isNotEmpty;
     if (containsIReferenceImport) {
-      imports.add(
-          '${relativePathToSrcDir}winrt/internal/ipropertyvalue_helpers.dart');
+      imports
+          .add(_relativePathTo('winrt/internal/ipropertyvalue_helpers.dart'));
     }
 
     return imports.map((import) => "import '$import';").join('\n');
@@ -151,20 +155,20 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
 
   @override
   String get rootHeader =>
-      "import '${relativePathToSrcDir}com/iinspectable.dart';";
+      "import '${_relativePathTo('com/iinspectable.dart')}';";
 
   @override
   String get extraHeaders => """
-    import '${relativePathToSrcDir}api_ms_win_core_winrt_string_l1_1_0.dart';
-    import '${relativePathToSrcDir}combase.dart';
-    import '${relativePathToSrcDir}exceptions.dart';
-    import '${relativePathToSrcDir}macros.dart';
-    import '${relativePathToSrcDir}utils.dart';
-    import '${relativePathToSrcDir}types.dart';
-    import '${relativePathToSrcDir}winrt_callbacks.dart';
-    import '${relativePathToSrcDir}winrt_helpers.dart';
+    import '${_relativePathTo('api_ms_win_core_winrt_string_l1_1_0.dart')}';
+    import '${_relativePathTo('combase.dart')}';
+    import '${_relativePathTo('exceptions.dart')}';
+    import '${_relativePathTo('macros.dart')}';
+    import '${_relativePathTo('utils.dart')}';
+    import '${_relativePathTo('types.dart')}';
+    import '${_relativePathTo('winrt_callbacks.dart')}';
+    import '${_relativePathTo('winrt_helpers.dart')}';
 
-    import '${relativePathToSrcDir}winrt/internal/hstring_array.dart';
+    import '${_relativePathTo('winrt/internal/hstring_array.dart')}';
   """;
 
   @override

--- a/tool/generator/lib/src/projection/winrt/winrt_interface.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_interface.dart
@@ -17,14 +17,13 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
       .toList()
       .join(', ');
 
-  /// Returns the path to the folder where the current interface is located.
-  ///
-  /// e.g. `winrt/storage/pickers`
-  String get _currentFolderPath => 'winrt/${folderFromWinRTType(typeDef.name)}';
+  /// Returns the path to the folder where the current interface is located
+  /// (e.g. `winrt/storage/pickers` for `Windows.Storage.Pickers.IFileOpenPicker`).
+  String get currentFolderPath => 'winrt/${folderFromWinRTType(typeDef.name)}';
 
-  /// Converts [path] to an equivalent relative path from the [_currentFolderPath].
-  String _relativePathTo(String path) =>
-      relativePath(path, start: _currentFolderPath);
+  /// Converts [path] to an equivalent relative path from the [currentFolderPath].
+  String relativePathTo(String path) =>
+      relativePath(path, start: currentFolderPath);
 
   /// The WinRT types to ignore when generating the imports.
   static const ignoredWindowsRuntimeTypes = <String>{
@@ -54,12 +53,12 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
       // folders e.g. Windows.Foundation.AsyncActionCompletedHandler -> foundation/delegates.g.dart
       return '';
     } else if (typeDef.isEnum) {
-      return _relativePathTo(
+      return relativePathTo(
           'winrt/${folderFromWinRTType(typeDef.name)}/enums.g.dart');
     } else if (typeDef.isClass || typeDef.isInterface) {
-      return _relativePathTo('winrt/${filePathFromWinRTType(typeDef.name)}');
+      return relativePathTo('winrt/${filePathFromWinRTType(typeDef.name)}');
     } else if (typeDef.isStruct) {
-      return _relativePathTo(
+      return relativePathTo(
           'winrt/${folderFromWinRTType(typeDef.name)}/structs.g.dart');
     } else {
       // TODO: Add support for these as they occur.
@@ -71,7 +70,7 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
   @override
   String? getImportForTypeIdentifier(TypeIdentifier typeIdentifier) {
     if (typeIdentifier.name == 'System.Guid') {
-      return _relativePathTo('guid.dart');
+      return relativePathTo('guid.dart');
     }
 
     if (typeIdentifier.name.startsWith('Windows')) {
@@ -108,8 +107,7 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
     final containsIReferenceImport =
         imports.where((i) => i.endsWith('ireference.dart')).isNotEmpty;
     if (containsIReferenceImport) {
-      imports
-          .add(_relativePathTo('winrt/internal/ipropertyvalue_helpers.dart'));
+      imports.add(relativePathTo('winrt/internal/ipropertyvalue_helpers.dart'));
     }
 
     return imports.map((import) => "import '$import';").join('\n');
@@ -157,20 +155,20 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
 
   @override
   String get rootHeader =>
-      "import '${_relativePathTo('com/iinspectable.dart')}';";
+      "import '${relativePathTo('com/iinspectable.dart')}';";
 
   @override
   String get extraHeaders => """
-    import '${_relativePathTo('api_ms_win_core_winrt_string_l1_1_0.dart')}';
-    import '${_relativePathTo('combase.dart')}';
-    import '${_relativePathTo('exceptions.dart')}';
-    import '${_relativePathTo('macros.dart')}';
-    import '${_relativePathTo('utils.dart')}';
-    import '${_relativePathTo('types.dart')}';
-    import '${_relativePathTo('winrt_callbacks.dart')}';
-    import '${_relativePathTo('winrt_helpers.dart')}';
+    import '${relativePathTo('api_ms_win_core_winrt_string_l1_1_0.dart')}';
+    import '${relativePathTo('combase.dart')}';
+    import '${relativePathTo('exceptions.dart')}';
+    import '${relativePathTo('macros.dart')}';
+    import '${relativePathTo('utils.dart')}';
+    import '${relativePathTo('types.dart')}';
+    import '${relativePathTo('winrt_callbacks.dart')}';
+    import '${relativePathTo('winrt_helpers.dart')}';
 
-    import '${_relativePathTo('winrt/internal/hstring_array.dart')}';
+    import '${relativePathTo('winrt/internal/hstring_array.dart')}';
   """;
 
   @override

--- a/tool/generator/lib/src/projection/winrt/winrt_interface.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_interface.dart
@@ -17,12 +17,14 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
       .toList()
       .join(', ');
 
-  /// Returns the path to the directory where the current interface is located.
-  String get _currentDirectory => 'winrt/${folderFromWinRTType(typeDef.name)}';
+  /// Returns the path to the folder where the current interface is located.
+  ///
+  /// e.g. `winrt/storage/pickers`
+  String get _currentFolderPath => 'winrt/${folderFromWinRTType(typeDef.name)}';
 
-  /// Converts [path] to an equivalent relative path from the [_currentDirectory].
+  /// Converts [path] to an equivalent relative path from the [_currentFolderPath].
   String _relativePathTo(String path) =>
-      relativePath(path, start: _currentDirectory);
+      relativePath(path, start: _currentFolderPath);
 
   /// The WinRT types to ignore when generating the imports.
   static const ignoredWindowsRuntimeTypes = <String>{

--- a/tool/generator/pubspec.yaml
+++ b/tool/generator/pubspec.yaml
@@ -11,7 +11,7 @@ platforms:
 dependencies:
   # Handle command-line arguments for development tooling.
   args: ^2.3.1
-  
+
   # For formatting Dart code (APIs for performing dart format).
   dart_style: ^2.2.3
 
@@ -20,6 +20,9 @@ dependencies:
 
   # Help ensure that the code is well-written.
   lints: ^2.0.0
+
+  # For calculating the relative file paths
+  path: ^1.8.2
 
   # Running the test suite.
   test: ^1.21.4

--- a/tool/generator/test/goldens/icalendar.golden
+++ b/tool/generator/test/goldens/icalendar.golden
@@ -19,11 +19,11 @@ import '../../types.dart';
 import '../../winrt_callbacks.dart';
 import '../../winrt_helpers.dart';
 
-import '../../winrt/internal/hstring_array.dart';
+import '../internal/hstring_array.dart';
 
-import '../../winrt/globalization/calendar.dart';
-import '../../winrt/foundation/collections/ivectorview.dart';
-import '../../winrt/globalization/enums.g.dart';
+import 'calendar.dart';
+import '../foundation/collections/ivectorview.dart';
+import 'enums.g.dart';
 import '../../com/iinspectable.dart';
 
 /// @nodoc

--- a/tool/generator/test/utils_test.dart
+++ b/tool/generator/test/utils_test.dart
@@ -419,6 +419,26 @@ void main() {
     expect(libraryFromDllName('winspool'), equals('winspool.drv'));
   });
 
+  test('relativePath', () {
+    expect(relativePath('winrt_helpers.dart', start: 'winrt/foundation'),
+        equals('../../winrt_helpers.dart'));
+    expect(
+        relativePath('winrt/globalization/calendar.dart',
+            start: 'winrt/globalization'),
+        equals('calendar.dart'));
+    expect(relativePath('com/iinspectable.dart', start: 'winrt/storage'),
+        equals('../../com/iinspectable.dart'));
+    expect(
+        relativePath('winrt/foundation/collections/ivector.dart',
+            start: 'winrt/globalization'),
+        equals('../foundation/collections/ivector.dart'));
+    expect(
+        relativePath(
+            'winrt/globalization/phonenumberformatting/phonenumberformatter.dart',
+            start: 'winrt/globalization'),
+        equals('phonenumberformatting/phonenumberformatter.dart'));
+  });
+
   test('folderFromNamespace', () {
     expect(
         folderFromNamespace('Windows.Win32.System.Console'), equals('system'));

--- a/tool/generator/test/winrt_projection_test.dart
+++ b/tool/generator/test/winrt_projection_test.dart
@@ -139,8 +139,7 @@ void main() {
         'Windows.Gaming.Input.IGamepadStatics2');
 
     final projection = WinRTInterfaceProjection(winTypeDef!);
-    expect(projection.importHeader,
-        contains("import '../../../winrt/gaming/input/igamepadstatics.dart'"));
+    expect(projection.importHeader, contains("import 'igamepadstatics.dart'"));
   });
 
   test('WinRT class includes correct import file for structs', () {
@@ -148,8 +147,7 @@ void main() {
         MetadataStore.getMetadataForType('Windows.Gaming.Input.Gamepad');
 
     final projection = WinRTClassProjection(winTypeDef!);
-    expect(projection.importHeader,
-        contains("import '../../../winrt/gaming/input/structs.g.dart'"));
+    expect(projection.importHeader, contains("import 'structs.g.dart'"));
   });
 
   test('WinRT interface includes correct import file for structs', () {
@@ -157,8 +155,7 @@ void main() {
         MetadataStore.getMetadataForType('Windows.Gaming.Input.IGamepad');
 
     final projection = WinRTInterfaceProjection(winTypeDef!);
-    expect(projection.importHeader,
-        contains("import '../../../winrt/gaming/input/structs.g.dart"));
+    expect(projection.importHeader, contains("import 'structs.g.dart"));
   });
 
   test('WinRT GetDateTime returns a DateTime', () {
@@ -535,7 +532,7 @@ void main() {
     final projection = WinRTClassProjection(winTypeDef!);
     expect(projection.inheritsFrom, contains('IStringable'));
     expect(projection.interfaceImport,
-        contains('../../../winrt/foundation/istringable.dart'));
+        contains('../../foundation/istringable.dart'));
   });
 
   test('WinRT class that does not inherit IStringable', () {
@@ -545,7 +542,7 @@ void main() {
     final projection = WinRTClassProjection(winTypeDef!);
     expect(projection.inheritsFrom, isNot(contains('IStringable')));
     expect(projection.interfaceImport,
-        isNot(contains('../../winrt/foundation/istringable.dart')));
+        isNot(contains('../foundation/istringable.dart')));
   });
 
   test('WinRT class that includes _className property', () {
@@ -577,12 +574,11 @@ void main() {
         MetadataStore.getMetadataForType('Windows.Gaming.Input.IGamepad');
 
     final projection = WinRTClassProjection(winTypeDef!);
+    expect(projection.importHeader, contains("import 'headset.dart'"));
+    expect(
+        projection.importHeader, contains("import '../../system/user.dart'"));
     expect(projection.importHeader,
-        contains("import '../../../winrt/gaming/input/headset.dart'"));
-    expect(projection.importHeader,
-        contains("import '../../../winrt/system/user.dart'"));
-    expect(projection.importHeader,
-        contains("import '../../../winrt/system/userchangedeventargs.dart'"));
+        contains("import '../../system/userchangedeventargs.dart'"));
   });
 
   if (windowsBuildNumber >= 18362) {


### PR DESCRIPTION
Currently, we are using relative paths to the `src` directory when generating imports. With this PR, the relative path from the current folder is used instead.

Take `IGamepad2` for example. It's currently located in `winrt/gaming/input`. It needs to import the `IGamepadController`. As they both are in the same folder, the import is generated as `import 'igamepadcontroller.dart';`.

Another example is `User` (located in `winrt/system`). The relative path from the current folder (`winrt/gaming/input`) should be calculated to the folder where the `User` is located e.g. `import '../../system/user.dart';`

![igamepad2](https://user-images.githubusercontent.com/45524029/197732395-e05bade4-17bf-4b05-b349-9fac3d520566.png)