### PR TITLE
Explicitly import required files

### DIFF
--- a/tool/generator/lib/src/projection/winrt/declarations/comobject.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/comobject.dart
@@ -1,4 +1,7 @@
-import '../../../../generator.dart';
+import '../../utils.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
+import '../winrt_set_property.dart';
 
 mixin _ComObjectProjection on WinRTMethodProjection {
   String get retType {

--- a/tool/generator/lib/src/projection/winrt/declarations/datetime.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/datetime.dart
@@ -1,4 +1,6 @@
-import '../../../../generator.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
+import '../winrt_set_property.dart';
 
 class WinRTMethodReturningDateTimeProjection extends WinRTMethodProjection {
   WinRTMethodReturningDateTimeProjection(super.method, super.vtableOffset);

--- a/tool/generator/lib/src/projection/winrt/declarations/default.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/default.dart
@@ -1,4 +1,6 @@
-import '../../../../generator.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
+import '../winrt_set_property.dart';
 
 mixin DefaultMethodProjection on WinRTMethodProjection {
   String get valRef => returnType.dartType == 'double' ||

--- a/tool/generator/lib/src/projection/winrt/declarations/duration.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/duration.dart
@@ -1,4 +1,6 @@
-import '../../../../generator.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
+import '../winrt_set_property.dart';
 
 class WinRTMethodReturningDurationProjection extends WinRTMethodProjection {
   WinRTMethodReturningDurationProjection(super.method, super.vtableOffset);

--- a/tool/generator/lib/src/projection/winrt/declarations/enum.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/enum.dart
@@ -1,4 +1,6 @@
-import '../../../../generator.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
+import '../winrt_set_property.dart';
 
 class WinRTMethodReturningEnumProjection extends WinRTMethodProjection {
   WinRTMethodReturningEnumProjection(super.method, super.vtableOffset);

--- a/tool/generator/lib/src/projection/winrt/declarations/guid.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/guid.dart
@@ -1,4 +1,6 @@
-import '../../../../generator.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
+import '../winrt_set_property.dart';
 
 class WinRTMethodReturningGuidProjection extends WinRTMethodProjection {
   WinRTMethodReturningGuidProjection(super.method, super.vtableOffset);

--- a/tool/generator/lib/src/projection/winrt/declarations/map.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/map.dart
@@ -1,6 +1,9 @@
 import 'package:winmd/winmd.dart';
 
-import '../../../../generator.dart';
+import '../../type.dart';
+import '../../utils.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
 
 mixin _MapProjection on WinRTMethodProjection {
   /// The type arguments of `IMap` and `IMapView`, as represented in the

--- a/tool/generator/lib/src/projection/winrt/declarations/reference.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/reference.dart
@@ -1,7 +1,11 @@
 import 'package:win32/winrt.dart';
 import 'package:winmd/winmd.dart';
 
-import '../../../../generator.dart';
+import '../../type.dart';
+import '../../utils.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
+import '../winrt_set_property.dart';
 
 mixin _ReferenceProjection on WinRTMethodProjection {
   /// The type argument of `IReference`, as represented in the [returnType]'s

--- a/tool/generator/lib/src/projection/winrt/declarations/string.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/string.dart
@@ -1,4 +1,6 @@
-import '../../../../generator.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
+import '../winrt_set_property.dart';
 
 class WinRTMethodReturningStringProjection extends WinRTMethodProjection {
   WinRTMethodReturningStringProjection(super.method, super.vtableOffset);

--- a/tool/generator/lib/src/projection/winrt/declarations/uri.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/uri.dart
@@ -1,4 +1,6 @@
-import '../../../../generator.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
+import '../winrt_set_property.dart';
 
 class WinRTMethodReturningUriProjection extends WinRTMethodProjection {
   WinRTMethodReturningUriProjection(super.method, super.vtableOffset);

--- a/tool/generator/lib/src/projection/winrt/declarations/vector.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/vector.dart
@@ -1,6 +1,9 @@
 import 'package:winmd/winmd.dart';
 
-import '../../../../generator.dart';
+import '../../type.dart';
+import '../../utils.dart';
+import '../winrt_get_property.dart';
+import '../winrt_method.dart';
 
 mixin _VectorProjection on WinRTMethodProjection {
   /// The type argument of `IVector` and `IVectorView`, as represented in the

--- a/tool/generator/lib/src/projection/winrt/declarations/void.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/void.dart
@@ -1,4 +1,4 @@
-import '../../../../generator.dart';
+import '../winrt_method.dart';
 
 class WinRTMethodReturningVoidProjection extends WinRTMethodProjection {
   WinRTMethodReturningVoidProjection(super.method, super.vtableOffset);

--- a/tool/generator/lib/src/projection/winrt/winrt_factory_interface_mapper.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_factory_interface_mapper.dart
@@ -1,6 +1,8 @@
 import 'package:winmd/winmd.dart';
 
-import '../../../generator.dart';
+import '../utils.dart';
+import 'winrt_class.dart';
+import 'winrt_interface.dart';
 
 class WinRTFactoryInterfaceMapperProjection extends WinRTClassProjection {
   WinRTFactoryInterfaceMapperProjection(super.typeDef, this.interface);

--- a/tool/generator/lib/src/projection/winrt/winrt_implements_mapper.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_implements_mapper.dart
@@ -1,6 +1,10 @@
 import 'package:winmd/winmd.dart';
 
-import '../../../generator.dart';
+import '../method.dart';
+import '../type.dart';
+import '../utils.dart';
+import 'winrt_class.dart';
+import 'winrt_interface.dart';
 
 class WinRTImplementsMapperProjection extends WinRTInterfaceProjection {
   WinRTImplementsMapperProjection(super.typeDef, this.interface);

--- a/tool/generator/lib/src/projection/winrt/winrt_static_interface_mapper.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_static_interface_mapper.dart
@@ -1,6 +1,8 @@
 import 'package:winmd/winmd.dart';
 
-import '../../../generator.dart';
+import '../utils.dart';
+import 'winrt_class.dart';
+import 'winrt_interface.dart';
 
 class WinRTStaticInterfaceMapperProjection extends WinRTClassProjection {
   WinRTStaticInterfaceMapperProjection(super.typeDef, this.interface);


### PR DESCRIPTION
Noticed that several files import just the root library file, which exports all files. 

Changed this to explicitly import the required Dart files, to avoid circular references.