### PR TITLE
Add back `winrtUninitialize` and deprecate it

### DIFF
--- a/example/com_context.dart
+++ b/example/com_context.dart
@@ -140,7 +140,7 @@ Future<void> createIsolates() async {
 /// ...
 /// ```
 void main() async {
-  // The main thread is initiatlized for the COM apartment threading model.
+  // The main thread is initialized for the COM apartment threading model.
   CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
 
   // Should be mainSingleThreaded

--- a/lib/src/winrt_helpers.dart
+++ b/lib/src/winrt_helpers.dart
@@ -12,7 +12,6 @@ import 'package:ffi/ffi.dart';
 
 import 'com/iinspectable.dart';
 import 'combase.dart';
-import 'constants.dart';
 import 'constants_nodoc.dart';
 import 'exceptions.dart';
 import 'guid.dart';
@@ -24,23 +23,18 @@ import 'win32/api_ms_win_core_winrt_string_l1_1_0.g.dart';
 import 'win32/ole32.g.dart';
 import 'winrt/foundation/winrt_enum.dart';
 
-/// Initializes the Windows Runtime on the current thread with a single-threaded
-/// concurrency model.
-///
-/// This is usually not needed, as this package ensures that threads are
-/// implicitly assigned to the multi-threaded apartment (MTA). However, if you
-/// need your thread to be initialized with a single-threaded apartment (STA),
-/// you can call this function.
-///
-/// {@category winrt}
-void winrtInitialize() => RoInitialize(RO_INIT_TYPE.RO_INIT_SINGLETHREADED);
+@Deprecated('winrtInitialize is no longer required. The Windows Runtime is '
+    'automatically initialized by the Dart projection if it is not already initialized '
+    'on a given thread when a WinRT class is activated. If you explicitly want to '
+    'initialize the current thread with a specific threading model, use RoInitialize '
+    'directly instead. This function will be removed in the next major release.')
+void winrtInitialize() {}
 
-/// Closes the Windows Runtime on the current thread.
-///
-/// {@category winrt}
-@Deprecated('Using this function may cause segfaults or runtime exceptions and '
-    'will be removed in a future release.')
-void winrtUninitialize() => RoUninitialize();
+@Deprecated('winrtUninitialize is not required in most scenarios, since '
+    'Windows will clean up the process on exit. If you explicitly want to '
+    'uninitialize the Windows Runtime, use RoUninitialize directly instead. '
+    'This function will be removed in the next major release.')
+void winrtUninitialize() {}
 
 extension WinRTStringConversion on Pointer<HSTRING> {
   /// Gets the Dart string at the handle pointed to by this object.

--- a/lib/src/winrt_helpers.dart
+++ b/lib/src/winrt_helpers.dart
@@ -30,6 +30,11 @@ import 'winrt/foundation/winrt_enum.dart';
 /// {@category winrt}
 void winrtInitialize() => RoInitialize(RO_INIT_TYPE.RO_INIT_SINGLETHREADED);
 
+/// Closes the Windows Runtime on the current thread.
+///
+/// {@category winrt}
+void winrtUninitialize() => RoUninitialize();
+
 extension WinRTStringConversion on Pointer<HSTRING> {
   /// Gets the Dart string at the handle pointed to by this object.
   String toDartString() => convertFromHString(value);

--- a/lib/src/winrt_helpers.dart
+++ b/lib/src/winrt_helpers.dart
@@ -27,6 +27,11 @@ import 'winrt/foundation/winrt_enum.dart';
 /// Initializes the Windows Runtime on the current thread with a single-threaded
 /// concurrency model.
 ///
+/// This is usually not needed, as this package ensures that threads are
+/// implicitly assigned to the multi-threaded apartment (MTA). However, if you
+/// need your thread to be initialized with a single-threaded apartment (STA),
+/// you can call this function.
+///
 /// {@category winrt}
 void winrtInitialize() => RoInitialize(RO_INIT_TYPE.RO_INIT_SINGLETHREADED);
 

--- a/lib/src/winrt_helpers.dart
+++ b/lib/src/winrt_helpers.dart
@@ -24,10 +24,11 @@ import 'win32/ole32.g.dart';
 import 'winrt/foundation/winrt_enum.dart';
 
 @Deprecated('winrtInitialize is no longer required. The Windows Runtime is '
-    'automatically initialized by the Dart projection if it is not already initialized '
-    'on a given thread when a WinRT class is activated. If you explicitly want to '
-    'initialize the current thread with a specific threading model, use RoInitialize '
-    'directly instead. This function will be removed in the next major release.')
+    'automatically initialized by the Dart projection if it is not already '
+    'initialized on a given thread when a WinRT class is activated. If you '
+    'explicitly want to initialize the current thread with a specific '
+    'threading model, use RoInitialize directly instead. This function will be '
+    'removed in the next major release.')
 void winrtInitialize() {}
 
 @Deprecated('winrtUninitialize is not required in most scenarios, since '

--- a/lib/src/winrt_helpers.dart
+++ b/lib/src/winrt_helpers.dart
@@ -38,6 +38,8 @@ void winrtInitialize() => RoInitialize(RO_INIT_TYPE.RO_INIT_SINGLETHREADED);
 /// Closes the Windows Runtime on the current thread.
 ///
 /// {@category winrt}
+@Deprecated('Using this function may cause segfaults or runtime exceptions and '
+    'will be removed in a future release.')
 void winrtUninitialize() => RoUninitialize();
 
 extension WinRTStringConversion on Pointer<HSTRING> {

--- a/lib/winrt.dart
+++ b/lib/winrt.dart
@@ -22,8 +22,9 @@
 /// This package ensures that threads are implicitly assigned to the
 /// multi-threaded apartment (MTA) so most of the time you don't need to do
 /// anything. However, if you need to use APIs that only work in a
-/// single-threaded apartment (STA), you need to call [winrtInitialize] helper
-/// function to initialize the Windows Runtime with a single-threaded apartment.
+/// single-threaded apartment (STA), you need to call
+/// `RoInitialize(RO_INIT_TYPE.RO_INIT_SINGLETHREADED)` to initialize the
+/// Windows Runtime with a single-threaded apartment.
 ///
 /// ## Instantiating Windows Runtime objects
 ///

--- a/lib/winrt.dart
+++ b/lib/winrt.dart
@@ -19,11 +19,11 @@
 ///
 /// ## Initializing the Windows Runtime
 ///
-/// This package supports automatic initialization of the Windows Runtime on the
-/// current thread with a Multi-Threaded Apartment (MTA). However, if you wish
-/// to initialize the Windows Runtime manually or just call some APIs that only
-/// work in a Single-Threaded Apartment (STA), you can use the [winrtInitialize]
-/// helper function.
+/// This package ensures that threads are implicitly assigned to the
+/// multi-threaded apartment (MTA) so most of the time you don't need to do
+/// anything. However, if you need to use APIs that only work in a
+/// single-threaded apartment (STA), you need to call [winrtInitialize] helper
+/// function to initialize the Windows Runtime with a single-threaded apartment.
 ///
 /// ## Instantiating Windows Runtime objects
 ///


### PR DESCRIPTION
Added back the `winrtUninitialize()` helper function and deprecated it. Also updated some docs.