### PR TITLE
Convert acronyms in method/property names to lowercase

### DIFF
--- a/lib/src/winrt/networking/hostname.dart
+++ b/lib/src/winrt/networking/hostname.dart
@@ -66,7 +66,7 @@ class HostName extends IInspectable implements IHostName, IStringable {
   late final _iHostName = IHostName.from(this);
 
   @override
-  IPInformation get iPInformation => _iHostName.iPInformation;
+  IPInformation get ipInformation => _iHostName.ipInformation;
 
   @override
   String get rawName => _iHostName.rawName;

--- a/lib/src/winrt/networking/ihostname.dart
+++ b/lib/src/winrt/networking/ihostname.dart
@@ -36,7 +36,7 @@ class IHostName extends IInspectable {
   factory IHostName.from(IInspectable interface) =>
       IHostName.fromRawPointer(interface.toInterface(IID_IHostName));
 
-  IPInformation get iPInformation {
+  IPInformation get ipInformation {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable

--- a/lib/src/winrt/ui/viewmanagement/iuisettings.dart
+++ b/lib/src/winrt/ui/viewmanagement/iuisettings.dart
@@ -303,7 +303,7 @@ class IUISettings extends IInspectable {
     }
   }
 
-  Color uIElementColor(UIElementType desiredElement) {
+  Color uiElementColor(UIElementType desiredElement) {
     final retValuePtr = calloc<Color>();
 
     try {

--- a/lib/src/winrt/ui/viewmanagement/uisettings.dart
+++ b/lib/src/winrt/ui/viewmanagement/uisettings.dart
@@ -87,8 +87,8 @@ class UISettings extends IInspectable
   int get mouseHoverTime => _iUISettings.mouseHoverTime;
 
   @override
-  Color uIElementColor(UIElementType desiredElement) =>
-      _iUISettings.uIElementColor(desiredElement);
+  Color uiElementColor(UIElementType desiredElement) =>
+      _iUISettings.uiElementColor(desiredElement);
 
   // IUISettings2 methods
   late final _iUISettings2 = IUISettings2.from(this);

--- a/tool/generator/lib/src/projection/enum.dart
+++ b/tool/generator/lib/src/projection/enum.dart
@@ -29,14 +29,10 @@ class EnumProjection {
   List<Field> get _fields => typeDef.fields.skip(1).toList()
     ..sort((a, b) => a.value.compareTo(b.value));
 
-  static const _acronyms = <String>{
-    'AC', 'DB', 'DPad', 'HD', 'HR', 'IO', 'IP', 'NT', 'TV', 'UI', 'WiFi' //
-  };
-
   String safeEnumIdentifier(String fieldName) {
     if (fieldName.length == 1) return fieldName.toLowerCase();
 
-    for (final acronym in _acronyms) {
+    for (final acronym in acronyms) {
       if (fieldName.startsWith(acronym)) {
         // UInt32 -> uint32, IPAddress -> ipAddress, DPadUp -> dpadUp etc.
         return safeIdentifierForString(

--- a/tool/generator/lib/src/projection/method.dart
+++ b/tool/generator/lib/src/projection/method.dart
@@ -90,7 +90,17 @@ abstract class MethodProjection {
   /// COM and Windows Runtime methods and properties are typically named in
   /// TitleCase, but the Dart idiom is camelCase. This also has the significant
   /// advantage of making it easier to avoid name conflicts.
-  String get camelCasedName => safeIdentifierForString(name.toCamelCase());
+  String get camelCasedName {
+    for (final acronym in acronyms) {
+      if (name.startsWith(acronym)) {
+        // e.g. IPInformation -> ipInformation
+        return safeIdentifierForString(
+            acronym.toLowerCase() + name.substring(acronym.length));
+      }
+    }
+
+    return safeIdentifierForString(name.toCamelCase());
+  }
 
   /// The parameters exposed by a projected Dart method.
   String get methodParams =>

--- a/tool/generator/lib/src/projection/utils.dart
+++ b/tool/generator/lib/src/projection/utils.dart
@@ -14,6 +14,14 @@ import '../model/false_properties.dart';
 import 'safenames.dart';
 import 'type.dart';
 
+const acronyms = <String>{
+  // These are acronyms that appear in the WinRT enum identifiers, function
+  // names. We use this Set while projecting WinRT enums and functions to
+  // match the Dart style guide.
+  // See https://dart.dev/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words
+  'AC', 'DB', 'DPad', 'HD', 'HR', 'IO', 'IP', 'NT', 'TV', 'UI', 'WiFi' //
+};
+
 const falseAnsiEndings = <String>[
   // These are structs that appear in the Win32 metadata that end in 'A' but
   // are not ANSI. In the absence of a better way to determine ANSI attributes

--- a/tool/generator/lib/src/projection/winrt/winrt_property.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_property.dart
@@ -6,10 +6,36 @@ abstract class WinRTPropertyProjection extends WinRTMethodProjection {
   WinRTPropertyProjection(super.method, super.vtableOffset);
 
   /// Strip off all underscores, even if double underscores
-  String get exposedMethodName =>
-      method.name.startsWith('get__') || method.name.startsWith('put__')
-          ? safeIdentifierForString(method.name.substring(5)).toCamelCase()
-          : safeIdentifierForString(method.name.substring(4)).toCamelCase();
+  String get exposedMethodName {
+    // e.g. get__Languages, put__Data
+    if (method.name.startsWith('get__') || method.name.startsWith('put__')) {
+      // e.g. get__Languages -> Languages, put__Data -> Data
+      final formattedMethodName = method.name.substring(5);
+
+      for (final acronym in acronyms) {
+        if (formattedMethodName.startsWith(acronym)) {
+          // e.g. IPInformation -> ipInformation
+          return safeIdentifierForString(acronym.toLowerCase() +
+              formattedMethodName.substring(acronym.length));
+        }
+      }
+
+      return safeIdentifierForString(formattedMethodName).toCamelCase();
+    } else {
+      // e.g. get_Size -> Size, put_Completed -> Completed
+      final formattedMethodName = method.name.substring(4);
+
+      for (final acronym in acronyms) {
+        if (formattedMethodName.startsWith(acronym)) {
+          // e.g. IPInformation -> ipInformation
+          return safeIdentifierForString(acronym.toLowerCase() +
+              formattedMethodName.substring(acronym.length));
+        }
+      }
+
+      return safeIdentifierForString(formattedMethodName).toCamelCase();
+    }
+  }
 
   // WinRT properties always return an HRESULT
   @override

--- a/tool/generator/lib/src/projection/winrt/winrt_property.dart
+++ b/tool/generator/lib/src/projection/winrt/winrt_property.dart
@@ -7,34 +7,24 @@ abstract class WinRTPropertyProjection extends WinRTMethodProjection {
 
   /// Strip off all underscores, even if double underscores
   String get exposedMethodName {
-    // e.g. get__Languages, put__Data
+    final String formattedMethodName;
     if (method.name.startsWith('get__') || method.name.startsWith('put__')) {
       // e.g. get__Languages -> Languages, put__Data -> Data
-      final formattedMethodName = method.name.substring(5);
-
-      for (final acronym in acronyms) {
-        if (formattedMethodName.startsWith(acronym)) {
-          // e.g. IPInformation -> ipInformation
-          return safeIdentifierForString(acronym.toLowerCase() +
-              formattedMethodName.substring(acronym.length));
-        }
-      }
-
-      return safeIdentifierForString(formattedMethodName).toCamelCase();
+      formattedMethodName = method.name.substring(5);
     } else {
       // e.g. get_Size -> Size, put_Completed -> Completed
-      final formattedMethodName = method.name.substring(4);
-
-      for (final acronym in acronyms) {
-        if (formattedMethodName.startsWith(acronym)) {
-          // e.g. IPInformation -> ipInformation
-          return safeIdentifierForString(acronym.toLowerCase() +
-              formattedMethodName.substring(acronym.length));
-        }
-      }
-
-      return safeIdentifierForString(formattedMethodName).toCamelCase();
+      formattedMethodName = method.name.substring(4);
     }
+
+    for (final acronym in acronyms) {
+      if (formattedMethodName.startsWith(acronym)) {
+        // e.g. IPInformation -> ipInformation
+        return safeIdentifierForString(acronym.toLowerCase() +
+            formattedMethodName.substring(acronym.length));
+      }
+    }
+
+    return safeIdentifierForString(formattedMethodName).toCamelCase();
   }
 
   // WinRT properties always return an HRESULT

--- a/tool/generator/test/winrt_projection_test.dart
+++ b/tool/generator/test/winrt_projection_test.dart
@@ -175,6 +175,29 @@ void main() {
         startsWith('DateTime getDateTime'));
   });
 
+  test('WinRT exposed get property name is properly converted to camelCase',
+      () {
+    final winTypeDef =
+        MetadataStore.getMetadataForType('Windows.Networking.IHostName');
+
+    final projection = WinRTInterfaceProjection(winTypeDef!);
+    final ipInformationProjection = projection.methodProjections
+            .firstWhere((m) => m.name == 'get_IPInformation')
+        as WinRTGetPropertyProjection;
+    expect(ipInformationProjection.exposedMethodName, equals('ipInformation'));
+  });
+
+  test('WinRT exposed method name is properly converted to camelCase', () {
+    final winTypeDef = MetadataStore.getMetadataForType(
+        'Windows.UI.ViewManagement.IUISettings');
+
+    final projection = WinRTInterfaceProjection(winTypeDef!);
+    final ipInformationProjection = projection.methodProjections
+        .firstWhere((m) => m.name == 'UIElementColor');
+
+    expect(ipInformationProjection.camelCasedName, equals('uiElementColor'));
+  });
+
   test('WinRT get property successfully projects something', () {
     final winTypeDef = MetadataStore.getMetadataForType(
         'Windows.Storage.Pickers.IFileOpenPicker');


### PR DESCRIPTION
Fixes #648