### PR TITLE
Mark methods/properties that return WinRT objects as nullable

### DIFF
--- a/example/appcontainer.dart
+++ b/example/appcontainer.dart
@@ -43,6 +43,6 @@ void main() {
   print('${!isAppContainer() ? '!' : ''}isAppContainer');
 
   final userData = UserDataPaths.getDefault();
-  final roamingAppData = userData.roamingAppData;
+  final roamingAppData = userData?.roamingAppData;
   print('RoamingAppData: $roamingAppData');
 }

--- a/example/calendar.dart
+++ b/example/calendar.dart
@@ -19,7 +19,7 @@ void main() {
   final calendar = Calendar();
   print(calendarData(calendar));
 
-  final clonedCalendar = calendar.clone();
+  final clonedCalendar = calendar.clone()!;
   final comparisonResult = clonedCalendar.compare(calendar);
   print('Comparison result of calendar and its clone: $comparisonResult');
 

--- a/example/geolocation.dart
+++ b/example/geolocation.dart
@@ -21,11 +21,12 @@ void main() async {
     final location = await locator.getGeopositionAsync();
 
     if (location != null) {
-      print('Current location: (${location.coordinate.latitude}, '
-          '${location.coordinate.longitude})');
-      print('Location accuracy: ±${location.coordinate.accuracy} meters');
-      print('Current heading: ${location.coordinate.heading ?? 'N/A'}');
-      final positionSource = location.coordinate.positionSource;
+      final coordinate = location.coordinate!;
+      print('Current location: (${coordinate.latitude}, '
+          '${coordinate.longitude})');
+      print('Location accuracy: ±${coordinate.accuracy} meters');
+      print('Current heading: ${coordinate.heading ?? 'N/A'}');
+      final positionSource = coordinate.positionSource;
       print('Position source: ${positionSource.name}');
     } else {
       print('No location received.');

--- a/lib/src/winrt/data/json/ijsonarray.dart
+++ b/lib/src/winrt/data/json/ijsonarray.dart
@@ -37,7 +37,7 @@ class IJsonArray extends IInspectable implements IJsonValue {
   factory IJsonArray.from(IInspectable interface) =>
       IJsonArray.fromRawPointer(interface.toInterface(IID_IJsonArray));
 
-  JsonObject getObjectAt(int index) {
+  JsonObject? getObjectAt(int index) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -56,10 +56,15 @@ class IJsonArray extends IInspectable implements IJsonValue {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
+
     return JsonObject.fromRawPointer(retValuePtr);
   }
 
-  JsonArray getArrayAt(int index) {
+  JsonArray? getArrayAt(int index) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -76,6 +81,11 @@ class IJsonArray extends IInspectable implements IJsonValue {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return JsonArray.fromRawPointer(retValuePtr);
@@ -173,8 +183,8 @@ class IJsonArray extends IInspectable implements IJsonValue {
   bool getBoolean() => _iJsonValue.getBoolean();
 
   @override
-  JsonArray getArray() => _iJsonValue.getArray();
+  JsonArray? getArray() => _iJsonValue.getArray();
 
   @override
-  JsonObject getObject() => _iJsonValue.getObject();
+  JsonObject? getObject() => _iJsonValue.getObject();
 }

--- a/lib/src/winrt/data/json/ijsonarraystatics.dart
+++ b/lib/src/winrt/data/json/ijsonarraystatics.dart
@@ -35,7 +35,7 @@ class IJsonArrayStatics extends IInspectable {
       IJsonArrayStatics.fromRawPointer(
           interface.toInterface(IID_IJsonArrayStatics));
 
-  JsonArray parse(String input) {
+  JsonArray? parse(String input) {
     final retValuePtr = calloc<COMObject>();
     final inputHstring = convertToHString(input);
 
@@ -56,6 +56,11 @@ class IJsonArrayStatics extends IInspectable {
     }
 
     WindowsDeleteString(inputHstring);
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return JsonArray.fromRawPointer(retValuePtr);
   }

--- a/lib/src/winrt/data/json/ijsonobject.dart
+++ b/lib/src/winrt/data/json/ijsonobject.dart
@@ -38,7 +38,7 @@ class IJsonObject extends IInspectable implements IJsonValue {
   factory IJsonObject.from(IInspectable interface) =>
       IJsonObject.fromRawPointer(interface.toInterface(IID_IJsonObject));
 
-  JsonValue getNamedValue(String name) {
+  JsonValue? getNamedValue(String name) {
     final retValuePtr = calloc<COMObject>();
     final nameHstring = convertToHString(name);
 
@@ -59,6 +59,11 @@ class IJsonObject extends IInspectable implements IJsonValue {
     }
 
     WindowsDeleteString(nameHstring);
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return JsonValue.fromRawPointer(retValuePtr);
   }
@@ -85,7 +90,7 @@ class IJsonObject extends IInspectable implements IJsonValue {
     WindowsDeleteString(nameHstring);
   }
 
-  JsonObject getNamedObject(String name) {
+  JsonObject? getNamedObject(String name) {
     final retValuePtr = calloc<COMObject>();
     final nameHstring = convertToHString(name);
 
@@ -107,10 +112,15 @@ class IJsonObject extends IInspectable implements IJsonValue {
 
     WindowsDeleteString(nameHstring);
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
+
     return JsonObject.fromRawPointer(retValuePtr);
   }
 
-  JsonArray getNamedArray(String name) {
+  JsonArray? getNamedArray(String name) {
     final retValuePtr = calloc<COMObject>();
     final nameHstring = convertToHString(name);
 
@@ -131,6 +141,11 @@ class IJsonObject extends IInspectable implements IJsonValue {
     }
 
     WindowsDeleteString(nameHstring);
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return JsonArray.fromRawPointer(retValuePtr);
   }
@@ -234,8 +249,8 @@ class IJsonObject extends IInspectable implements IJsonValue {
   bool getBoolean() => _iJsonValue.getBoolean();
 
   @override
-  JsonArray getArray() => _iJsonValue.getArray();
+  JsonArray? getArray() => _iJsonValue.getArray();
 
   @override
-  JsonObject getObject() => _iJsonValue.getObject();
+  JsonObject? getObject() => _iJsonValue.getObject();
 }

--- a/lib/src/winrt/data/json/ijsonobjectstatics.dart
+++ b/lib/src/winrt/data/json/ijsonobjectstatics.dart
@@ -35,7 +35,7 @@ class IJsonObjectStatics extends IInspectable {
       IJsonObjectStatics.fromRawPointer(
           interface.toInterface(IID_IJsonObjectStatics));
 
-  JsonObject parse(String input) {
+  JsonObject? parse(String input) {
     final retValuePtr = calloc<COMObject>();
     final inputHstring = convertToHString(input);
 
@@ -56,6 +56,11 @@ class IJsonObjectStatics extends IInspectable {
     }
 
     WindowsDeleteString(inputHstring);
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return JsonObject.fromRawPointer(retValuePtr);
   }

--- a/lib/src/winrt/data/json/ijsonobjectwithdefaultvalues.dart
+++ b/lib/src/winrt/data/json/ijsonobjectwithdefaultvalues.dart
@@ -42,7 +42,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
       IJsonObjectWithDefaultValues.fromRawPointer(
           interface.toInterface(IID_IJsonObjectWithDefaultValues));
 
-  JsonValue getNamedValueOrDefault(String name, JsonValue defaultValue) {
+  JsonValue? getNamedValueOrDefault(String name, JsonValue defaultValue) {
     final retValuePtr = calloc<COMObject>();
     final nameHstring = convertToHString(name);
 
@@ -69,10 +69,15 @@ class IJsonObjectWithDefaultValues extends IInspectable
 
     WindowsDeleteString(nameHstring);
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
+
     return JsonValue.fromRawPointer(retValuePtr);
   }
 
-  JsonObject getNamedObjectOrDefault(String name, JsonObject defaultValue) {
+  JsonObject? getNamedObjectOrDefault(String name, JsonObject defaultValue) {
     final retValuePtr = calloc<COMObject>();
     final nameHstring = convertToHString(name);
 
@@ -98,6 +103,11 @@ class IJsonObjectWithDefaultValues extends IInspectable
     }
 
     WindowsDeleteString(nameHstring);
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return JsonObject.fromRawPointer(retValuePtr);
   }
@@ -133,7 +143,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
     }
   }
 
-  JsonArray getNamedArrayOrDefault(String name, JsonArray defaultValue) {
+  JsonArray? getNamedArrayOrDefault(String name, JsonArray defaultValue) {
     final retValuePtr = calloc<COMObject>();
     final nameHstring = convertToHString(name);
 
@@ -159,6 +169,11 @@ class IJsonObjectWithDefaultValues extends IInspectable
     }
 
     WindowsDeleteString(nameHstring);
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return JsonArray.fromRawPointer(retValuePtr);
   }
@@ -226,17 +241,17 @@ class IJsonObjectWithDefaultValues extends IInspectable
   late final _iJsonObject = IJsonObject.from(this);
 
   @override
-  JsonValue getNamedValue(String name) => _iJsonObject.getNamedValue(name);
+  JsonValue? getNamedValue(String name) => _iJsonObject.getNamedValue(name);
 
   @override
   void setNamedValue(String name, IJsonValue value) =>
       _iJsonObject.setNamedValue(name, value);
 
   @override
-  JsonObject getNamedObject(String name) => _iJsonObject.getNamedObject(name);
+  JsonObject? getNamedObject(String name) => _iJsonObject.getNamedObject(name);
 
   @override
-  JsonArray getNamedArray(String name) => _iJsonObject.getNamedArray(name);
+  JsonArray? getNamedArray(String name) => _iJsonObject.getNamedArray(name);
 
   @override
   String getNamedString(String name) => _iJsonObject.getNamedString(name);
@@ -266,8 +281,8 @@ class IJsonObjectWithDefaultValues extends IInspectable
   bool getBoolean() => _iJsonValue.getBoolean();
 
   @override
-  JsonArray getArray() => _iJsonValue.getArray();
+  JsonArray? getArray() => _iJsonValue.getArray();
 
   @override
-  JsonObject getObject() => _iJsonValue.getObject();
+  JsonObject? getObject() => _iJsonValue.getObject();
 }

--- a/lib/src/winrt/data/json/ijsonvalue.dart
+++ b/lib/src/winrt/data/json/ijsonvalue.dart
@@ -152,7 +152,7 @@ class IJsonValue extends IInspectable {
     }
   }
 
-  JsonArray getArray() {
+  JsonArray? getArray() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -170,10 +170,15 @@ class IJsonValue extends IInspectable {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
+
     return JsonArray.fromRawPointer(retValuePtr);
   }
 
-  JsonObject getObject() {
+  JsonObject? getObject() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -189,6 +194,11 @@ class IJsonValue extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return JsonObject.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/data/json/ijsonvaluestatics.dart
+++ b/lib/src/winrt/data/json/ijsonvaluestatics.dart
@@ -35,7 +35,7 @@ class IJsonValueStatics extends IInspectable {
       IJsonValueStatics.fromRawPointer(
           interface.toInterface(IID_IJsonValueStatics));
 
-  JsonValue parse(String input) {
+  JsonValue? parse(String input) {
     final retValuePtr = calloc<COMObject>();
     final inputHstring = convertToHString(input);
 
@@ -56,6 +56,11 @@ class IJsonValueStatics extends IInspectable {
     }
 
     WindowsDeleteString(inputHstring);
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return JsonValue.fromRawPointer(retValuePtr);
   }
@@ -89,7 +94,7 @@ class IJsonValueStatics extends IInspectable {
     }
   }
 
-  JsonValue createBooleanValue(bool input) {
+  JsonValue? createBooleanValue(bool input) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -109,10 +114,15 @@ class IJsonValueStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
+
     return JsonValue.fromRawPointer(retValuePtr);
   }
 
-  JsonValue createNumberValue(double input) {
+  JsonValue? createNumberValue(double input) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -132,10 +142,15 @@ class IJsonValueStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
+
     return JsonValue.fromRawPointer(retValuePtr);
   }
 
-  JsonValue createStringValue(String input) {
+  JsonValue? createStringValue(String input) {
     final retValuePtr = calloc<COMObject>();
     final inputHstring = convertToHString(input);
 
@@ -156,6 +171,11 @@ class IJsonValueStatics extends IInspectable {
     }
 
     WindowsDeleteString(inputHstring);
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return JsonValue.fromRawPointer(retValuePtr);
   }

--- a/lib/src/winrt/data/json/ijsonvaluestatics2.dart
+++ b/lib/src/winrt/data/json/ijsonvaluestatics2.dart
@@ -35,7 +35,7 @@ class IJsonValueStatics2 extends IInspectable {
       IJsonValueStatics2.fromRawPointer(
           interface.toInterface(IID_IJsonValueStatics2));
 
-  JsonValue createNullValue() {
+  JsonValue? createNullValue() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -51,6 +51,11 @@ class IJsonValueStatics2 extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return JsonValue.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/data/json/jsonarray.dart
+++ b/lib/src/winrt/data/json/jsonarray.dart
@@ -48,7 +48,7 @@ class JsonArray extends IInspectable
   static const _className = 'Windows.Data.Json.JsonArray';
 
   // IJsonArrayStatics methods
-  static JsonArray parse(String input) {
+  static JsonArray? parse(String input) {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IJsonArrayStatics);
     final object = IJsonArrayStatics.fromRawPointer(activationFactoryPtr);
@@ -76,10 +76,10 @@ class JsonArray extends IInspectable
   late final _iJsonArray = IJsonArray.from(this);
 
   @override
-  JsonObject getObjectAt(int index) => _iJsonArray.getObjectAt(index);
+  JsonObject? getObjectAt(int index) => _iJsonArray.getObjectAt(index);
 
   @override
-  JsonArray getArrayAt(int index) => _iJsonArray.getArrayAt(index);
+  JsonArray? getArrayAt(int index) => _iJsonArray.getArrayAt(index);
 
   @override
   String getStringAt(int index) => _iJsonArray.getStringAt(index);
@@ -109,10 +109,10 @@ class JsonArray extends IInspectable
   bool getBoolean() => _iJsonValue.getBoolean();
 
   @override
-  JsonArray getArray() => _iJsonValue.getArray();
+  JsonArray? getArray() => _iJsonValue.getArray();
 
   @override
-  JsonObject getObject() => _iJsonValue.getObject();
+  JsonObject? getObject() => _iJsonValue.getObject();
 
   // IVector<IJsonValue> methods
   late final _iVector = IVector<IJsonValue>.fromRawPointer(

--- a/lib/src/winrt/data/json/jsonobject.dart
+++ b/lib/src/winrt/data/json/jsonobject.dart
@@ -53,7 +53,7 @@ class JsonObject extends IInspectable
   static const _className = 'Windows.Data.Json.JsonObject';
 
   // IJsonObjectStatics methods
-  static JsonObject parse(String input) {
+  static JsonObject? parse(String input) {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IJsonObjectStatics);
     final object = IJsonObjectStatics.fromRawPointer(activationFactoryPtr);
@@ -81,17 +81,17 @@ class JsonObject extends IInspectable
   late final _iJsonObject = IJsonObject.from(this);
 
   @override
-  JsonValue getNamedValue(String name) => _iJsonObject.getNamedValue(name);
+  JsonValue? getNamedValue(String name) => _iJsonObject.getNamedValue(name);
 
   @override
   void setNamedValue(String name, IJsonValue value) =>
       _iJsonObject.setNamedValue(name, value);
 
   @override
-  JsonObject getNamedObject(String name) => _iJsonObject.getNamedObject(name);
+  JsonObject? getNamedObject(String name) => _iJsonObject.getNamedObject(name);
 
   @override
-  JsonArray getNamedArray(String name) => _iJsonObject.getNamedArray(name);
+  JsonArray? getNamedArray(String name) => _iJsonObject.getNamedArray(name);
 
   @override
   String getNamedString(String name) => _iJsonObject.getNamedString(name);
@@ -121,10 +121,10 @@ class JsonObject extends IInspectable
   bool getBoolean() => _iJsonValue.getBoolean();
 
   @override
-  JsonArray getArray() => _iJsonValue.getArray();
+  JsonArray? getArray() => _iJsonValue.getArray();
 
   @override
-  JsonObject getObject() => _iJsonValue.getObject();
+  JsonObject? getObject() => _iJsonValue.getObject();
 
   // IMap<String, IJsonValue?> methods
   late final _iMap = IMap<String, IJsonValue?>.fromRawPointer(
@@ -165,11 +165,11 @@ class JsonObject extends IInspectable
       IJsonObjectWithDefaultValues.from(this);
 
   @override
-  JsonValue getNamedValueOrDefault(String name, JsonValue defaultValue) =>
+  JsonValue? getNamedValueOrDefault(String name, JsonValue defaultValue) =>
       _iJsonObjectWithDefaultValues.getNamedValueOrDefault(name, defaultValue);
 
   @override
-  JsonObject getNamedObjectOrDefault(String name, JsonObject defaultValue) =>
+  JsonObject? getNamedObjectOrDefault(String name, JsonObject defaultValue) =>
       _iJsonObjectWithDefaultValues.getNamedObjectOrDefault(name, defaultValue);
 
   @override
@@ -177,7 +177,7 @@ class JsonObject extends IInspectable
       _iJsonObjectWithDefaultValues.getNamedStringOrDefault(name, defaultValue);
 
   @override
-  JsonArray getNamedArrayOrDefault(String name, JsonArray defaultValue) =>
+  JsonArray? getNamedArrayOrDefault(String name, JsonArray defaultValue) =>
       _iJsonObjectWithDefaultValues.getNamedArrayOrDefault(name, defaultValue);
 
   @override

--- a/lib/src/winrt/data/json/jsonvalue.dart
+++ b/lib/src/winrt/data/json/jsonvalue.dart
@@ -38,7 +38,7 @@ class JsonValue extends IInspectable implements IJsonValue, IStringable {
   static const _className = 'Windows.Data.Json.JsonValue';
 
   // IJsonValueStatics methods
-  static JsonValue parse(String input) {
+  static JsonValue? parse(String input) {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IJsonValueStatics);
     final object = IJsonValueStatics.fromRawPointer(activationFactoryPtr);
@@ -62,7 +62,7 @@ class JsonValue extends IInspectable implements IJsonValue, IStringable {
     }
   }
 
-  static JsonValue createBooleanValue(bool input) {
+  static JsonValue? createBooleanValue(bool input) {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IJsonValueStatics);
     final object = IJsonValueStatics.fromRawPointer(activationFactoryPtr);
@@ -74,7 +74,7 @@ class JsonValue extends IInspectable implements IJsonValue, IStringable {
     }
   }
 
-  static JsonValue createNumberValue(double input) {
+  static JsonValue? createNumberValue(double input) {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IJsonValueStatics);
     final object = IJsonValueStatics.fromRawPointer(activationFactoryPtr);
@@ -86,7 +86,7 @@ class JsonValue extends IInspectable implements IJsonValue, IStringable {
     }
   }
 
-  static JsonValue createStringValue(String input) {
+  static JsonValue? createStringValue(String input) {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IJsonValueStatics);
     final object = IJsonValueStatics.fromRawPointer(activationFactoryPtr);
@@ -99,7 +99,7 @@ class JsonValue extends IInspectable implements IJsonValue, IStringable {
   }
 
   // IJsonValueStatics2 methods
-  static JsonValue createNullValue() {
+  static JsonValue? createNullValue() {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IJsonValueStatics2);
     final object = IJsonValueStatics2.fromRawPointer(activationFactoryPtr);
@@ -130,10 +130,10 @@ class JsonValue extends IInspectable implements IJsonValue, IStringable {
   bool getBoolean() => _iJsonValue.getBoolean();
 
   @override
-  JsonArray getArray() => _iJsonValue.getArray();
+  JsonArray? getArray() => _iJsonValue.getArray();
 
   @override
-  JsonObject getObject() => _iJsonValue.getObject();
+  JsonObject? getObject() => _iJsonValue.getObject();
 
   // IStringable methods
   late final _iStringable = IStringable.from(this);

--- a/lib/src/winrt/devices/geolocation/geocoordinate.dart
+++ b/lib/src/winrt/devices/geolocation/geocoordinate.dart
@@ -79,14 +79,14 @@ class Geocoordinate extends IInspectable
       _iGeocoordinateWithPositionData.positionSource;
 
   @override
-  GeocoordinateSatelliteData get satelliteData =>
+  GeocoordinateSatelliteData? get satelliteData =>
       _iGeocoordinateWithPositionData.satelliteData;
 
   // IGeocoordinateWithPoint methods
   late final _iGeocoordinateWithPoint = IGeocoordinateWithPoint.from(this);
 
   @override
-  Geopoint get point => _iGeocoordinateWithPoint.point;
+  Geopoint? get point => _iGeocoordinateWithPoint.point;
 
   // IGeocoordinateWithPositionSourceTimestamp methods
   late final _iGeocoordinateWithPositionSourceTimestamp =

--- a/lib/src/winrt/devices/geolocation/geoposition.dart
+++ b/lib/src/winrt/devices/geolocation/geoposition.dart
@@ -38,14 +38,14 @@ class Geoposition extends IInspectable implements IGeoposition, IGeoposition2 {
   late final _iGeoposition = IGeoposition.from(this);
 
   @override
-  Geocoordinate get coordinate => _iGeoposition.coordinate;
+  Geocoordinate? get coordinate => _iGeoposition.coordinate;
 
   @override
-  CivicAddress get civicAddress => _iGeoposition.civicAddress;
+  CivicAddress? get civicAddress => _iGeoposition.civicAddress;
 
   // IGeoposition2 methods
   late final _iGeoposition2 = IGeoposition2.from(this);
 
   @override
-  VenueData get venueData => _iGeoposition2.venueData;
+  VenueData? get venueData => _iGeoposition2.venueData;
 }

--- a/lib/src/winrt/devices/geolocation/igeocoordinate.dart
+++ b/lib/src/winrt/devices/geolocation/igeocoordinate.dart
@@ -99,7 +99,10 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<double>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
@@ -150,7 +153,10 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<double>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
@@ -178,7 +184,10 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<double>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
@@ -206,7 +215,10 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<double>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');

--- a/lib/src/winrt/devices/geolocation/igeocoordinatesatellitedata.dart
+++ b/lib/src/winrt/devices/geolocation/igeocoordinatesatellitedata.dart
@@ -55,7 +55,10 @@ class IGeocoordinateSatelliteData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<double>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
@@ -83,7 +86,10 @@ class IGeocoordinateSatelliteData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<double>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
@@ -111,7 +117,10 @@ class IGeocoordinateSatelliteData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<double>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');

--- a/lib/src/winrt/devices/geolocation/igeocoordinatewithpoint.dart
+++ b/lib/src/winrt/devices/geolocation/igeocoordinatewithpoint.dart
@@ -35,7 +35,7 @@ class IGeocoordinateWithPoint extends IInspectable {
       IGeocoordinateWithPoint.fromRawPointer(
           interface.toInterface(IID_IGeocoordinateWithPoint));
 
-  Geopoint get point {
+  Geopoint? get point {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -51,6 +51,11 @@ class IGeocoordinateWithPoint extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return Geopoint.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/devices/geolocation/igeocoordinatewithpositiondata.dart
+++ b/lib/src/winrt/devices/geolocation/igeocoordinatewithpositiondata.dart
@@ -63,7 +63,7 @@ class IGeocoordinateWithPositionData extends IInspectable
     }
   }
 
-  GeocoordinateSatelliteData get satelliteData {
+  GeocoordinateSatelliteData? get satelliteData {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -79,6 +79,11 @@ class IGeocoordinateWithPositionData extends IInspectable
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return GeocoordinateSatelliteData.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/devices/geolocation/igeocoordinatewithpositionsourcetimestamp.dart
+++ b/lib/src/winrt/devices/geolocation/igeocoordinatewithpositionsourcetimestamp.dart
@@ -56,7 +56,10 @@ class IGeocoordinateWithPositionSourceTimestamp extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<DateTime>.fromRawPointer(retValuePtr,
         referenceIid: '{5541d8a7-497c-5aa4-86fc-7713adbf2a2c}');

--- a/lib/src/winrt/devices/geolocation/igeolocatorstatics2.dart
+++ b/lib/src/winrt/devices/geolocation/igeolocatorstatics2.dart
@@ -96,7 +96,10 @@ class IGeolocatorStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<BasicGeoposition>.fromRawPointer(retValuePtr,
         referenceIid: '{e4d5dda6-f57c-57cc-b67f-2939a901dabe}');

--- a/lib/src/winrt/devices/geolocation/igeolocatorwithscalaraccuracy.dart
+++ b/lib/src/winrt/devices/geolocation/igeolocatorwithscalaraccuracy.dart
@@ -63,7 +63,10 @@ class IGeolocatorWithScalarAccuracy extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<int>.fromRawPointer(retValuePtr,
         referenceIid: '{513ef3af-e784-5325-a91e-97c2b8111cf3}');

--- a/lib/src/winrt/devices/geolocation/igeoposition.dart
+++ b/lib/src/winrt/devices/geolocation/igeoposition.dart
@@ -35,7 +35,7 @@ class IGeoposition extends IInspectable {
   factory IGeoposition.from(IInspectable interface) =>
       IGeoposition.fromRawPointer(interface.toInterface(IID_IGeoposition));
 
-  Geocoordinate get coordinate {
+  Geocoordinate? get coordinate {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -53,10 +53,15 @@ class IGeoposition extends IInspectable {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
+
     return Geocoordinate.fromRawPointer(retValuePtr);
   }
 
-  CivicAddress get civicAddress {
+  CivicAddress? get civicAddress {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -72,6 +77,11 @@ class IGeoposition extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return CivicAddress.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/devices/geolocation/igeoposition2.dart
+++ b/lib/src/winrt/devices/geolocation/igeoposition2.dart
@@ -37,7 +37,7 @@ class IGeoposition2 extends IInspectable implements IGeoposition {
   factory IGeoposition2.from(IInspectable interface) =>
       IGeoposition2.fromRawPointer(interface.toInterface(IID_IGeoposition2));
 
-  VenueData get venueData {
+  VenueData? get venueData {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -55,6 +55,11 @@ class IGeoposition2 extends IInspectable implements IGeoposition {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
+
     return VenueData.fromRawPointer(retValuePtr);
   }
 
@@ -62,8 +67,8 @@ class IGeoposition2 extends IInspectable implements IGeoposition {
   late final _iGeoposition = IGeoposition.from(this);
 
   @override
-  Geocoordinate get coordinate => _iGeoposition.coordinate;
+  Geocoordinate? get coordinate => _iGeoposition.coordinate;
 
   @override
-  CivicAddress get civicAddress => _iGeoposition.civicAddress;
+  CivicAddress? get civicAddress => _iGeoposition.civicAddress;
 }

--- a/lib/src/winrt/devices/power/ibatteryreport.dart
+++ b/lib/src/winrt/devices/power/ibatteryreport.dart
@@ -54,7 +54,10 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<int>.fromRawPointer(retValuePtr,
         referenceIid: '{548cefbd-bc8a-5fa0-8df2-957440fc8bf4}');
@@ -82,7 +85,10 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<int>.fromRawPointer(retValuePtr,
         referenceIid: '{548cefbd-bc8a-5fa0-8df2-957440fc8bf4}');
@@ -110,7 +116,10 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<int>.fromRawPointer(retValuePtr,
         referenceIid: '{548cefbd-bc8a-5fa0-8df2-957440fc8bf4}');
@@ -138,7 +147,10 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<int>.fromRawPointer(retValuePtr,
         referenceIid: '{548cefbd-bc8a-5fa0-8df2-957440fc8bf4}');

--- a/lib/src/winrt/foundation/collections/ikeyvaluepair.dart
+++ b/lib/src/winrt/foundation/collections/ikeyvaluepair.dart
@@ -270,7 +270,10 @@ class IKeyValuePair<K, V> extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return IPropertyValue.fromRawPointer(retValuePtr).value;
   }

--- a/lib/src/winrt/foundation/collections/imap.dart
+++ b/lib/src/winrt/foundation/collections/imap.dart
@@ -227,7 +227,10 @@ class IMap<K, V> extends IInspectable
 
     free(nativeGuidPtr);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return IPropertyValue.fromRawPointer(retValuePtr).value;
   }
@@ -297,8 +300,10 @@ class IMap<K, V> extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
-
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
     return IPropertyValue.fromRawPointer(retValuePtr).value;
   }
 
@@ -376,7 +381,10 @@ class IMap<K, V> extends IInspectable
         throw WindowsException(hr);
       }
 
-      if (retValuePtr.ref.lpVtbl == nullptr) return null;
+      if (retValuePtr.ref.lpVtbl == nullptr) {
+        free(retValuePtr);
+        return null;
+      }
 
       return IPropertyValue.fromRawPointer(retValuePtr).value;
     } finally {

--- a/lib/src/winrt/foundation/collections/imapview.dart
+++ b/lib/src/winrt/foundation/collections/imapview.dart
@@ -175,7 +175,10 @@ class IMapView<K, V> extends IInspectable
 
     free(nativeGuidPtr);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return IPropertyValue.fromRawPointer(retValuePtr).value;
   }
@@ -245,7 +248,10 @@ class IMapView<K, V> extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return IPropertyValue.fromRawPointer(retValuePtr).value;
   }
@@ -324,7 +330,10 @@ class IMapView<K, V> extends IInspectable
         throw WindowsException(hr);
       }
 
-      if (retValuePtr.ref.lpVtbl == nullptr) return null;
+      if (retValuePtr.ref.lpVtbl == nullptr) {
+        free(retValuePtr);
+        return null;
+      }
 
       return IPropertyValue.fromRawPointer(retValuePtr).value;
     } finally {

--- a/lib/src/winrt/foundation/iasyncoperation.dart
+++ b/lib/src/winrt/foundation/iasyncoperation.dart
@@ -172,7 +172,10 @@ class IAsyncOperation<TResult> extends IInspectable implements IAsyncInfo {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return retValuePtr;
   }
@@ -342,7 +345,10 @@ class IAsyncOperation<TResult> extends IInspectable implements IAsyncInfo {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final winrtUri = winrt_uri.Uri.fromRawPointer(retValuePtr);
     final uriAsString = winrtUri.toString();

--- a/lib/src/winrt/foundation/iuriruntimeclass.dart
+++ b/lib/src/winrt/foundation/iuriruntimeclass.dart
@@ -252,7 +252,7 @@ class IUriRuntimeClass extends IInspectable {
     }
   }
 
-  WwwFormUrlDecoder get queryParsed {
+  WwwFormUrlDecoder? get queryParsed {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -268,6 +268,11 @@ class IUriRuntimeClass extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return WwwFormUrlDecoder.fromRawPointer(retValuePtr);
@@ -419,7 +424,7 @@ class IUriRuntimeClass extends IInspectable {
     }
   }
 
-  Uri combineUri(String relativeUri) {
+  Uri? combineUri(String relativeUri) {
     final retValuePtr = calloc<COMObject>();
     final relativeUriHstring = convertToHString(relativeUri);
 
@@ -441,6 +446,11 @@ class IUriRuntimeClass extends IInspectable {
     }
 
     WindowsDeleteString(relativeUriHstring);
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     return Uri.fromRawPointer(retValuePtr);
   }

--- a/lib/src/winrt/foundation/uri.dart
+++ b/lib/src/winrt/foundation/uri.dart
@@ -124,7 +124,7 @@ class Uri extends IInspectable
   String get query => _iUriRuntimeClass.query;
 
   @override
-  WwwFormUrlDecoder get queryParsed => _iUriRuntimeClass.queryParsed;
+  WwwFormUrlDecoder? get queryParsed => _iUriRuntimeClass.queryParsed;
 
   @override
   String get rawUri => _iUriRuntimeClass.rawUri;
@@ -145,7 +145,7 @@ class Uri extends IInspectable
   bool equals(Uri pUri) => _iUriRuntimeClass.equals(pUri);
 
   @override
-  Uri combineUri(String relativeUri) =>
+  Uri? combineUri(String relativeUri) =>
       _iUriRuntimeClass.combineUri(relativeUri);
 
   // IUriRuntimeClassWithAbsoluteCanonicalUri methods

--- a/lib/src/winrt/gaming/input/gamepad.dart
+++ b/lib/src/winrt/gaming/input/gamepad.dart
@@ -109,7 +109,7 @@ class Gamepad extends IInspectable
   }
 
   // IGamepadStatics2 methods
-  static Gamepad fromGameController(IGameController gameController) {
+  static Gamepad? fromGameController(IGameController gameController) {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IGamepadStatics2);
     final object = IGamepadStatics2.fromRawPointer(activationFactoryPtr);
@@ -162,13 +162,13 @@ class Gamepad extends IInspectable
       _iGameController.remove_UserChanged(token);
 
   @override
-  Headset get headset => _iGameController.headset;
+  Headset? get headset => _iGameController.headset;
 
   @override
   bool get isWireless => _iGameController.isWireless;
 
   @override
-  User get user => _iGameController.user;
+  User? get user => _iGameController.user;
 
   // IGamepad2 methods
   late final _iGamepad2 = IGamepad2.from(this);
@@ -182,6 +182,6 @@ class Gamepad extends IInspectable
       IGameControllerBatteryInfo.from(this);
 
   @override
-  BatteryReport tryGetBatteryReport() =>
+  BatteryReport? tryGetBatteryReport() =>
       _iGameControllerBatteryInfo.tryGetBatteryReport();
 }

--- a/lib/src/winrt/gaming/input/headset.dart
+++ b/lib/src/winrt/gaming/input/headset.dart
@@ -46,6 +46,6 @@ class Headset extends IInspectable
       IGameControllerBatteryInfo.from(this);
 
   @override
-  BatteryReport tryGetBatteryReport() =>
+  BatteryReport? tryGetBatteryReport() =>
       _iGameControllerBatteryInfo.tryGetBatteryReport();
 }

--- a/lib/src/winrt/gaming/input/igamecontroller.dart
+++ b/lib/src/winrt/gaming/input/igamecontroller.dart
@@ -157,7 +157,7 @@ class IGameController extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  Headset get headset {
+  Headset? get headset {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -173,6 +173,11 @@ class IGameController extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return Headset.fromRawPointer(retValuePtr);
@@ -201,7 +206,7 @@ class IGameController extends IInspectable {
     }
   }
 
-  User get user {
+  User? get user {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -217,6 +222,11 @@ class IGameController extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return User.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/gaming/input/igamecontrollerbatteryinfo.dart
+++ b/lib/src/winrt/gaming/input/igamecontrollerbatteryinfo.dart
@@ -35,7 +35,7 @@ class IGameControllerBatteryInfo extends IInspectable {
       IGameControllerBatteryInfo.fromRawPointer(
           interface.toInterface(IID_IGameControllerBatteryInfo));
 
-  BatteryReport tryGetBatteryReport() {
+  BatteryReport? tryGetBatteryReport() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -51,6 +51,11 @@ class IGameControllerBatteryInfo extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return BatteryReport.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/gaming/input/igamepad.dart
+++ b/lib/src/winrt/gaming/input/igamepad.dart
@@ -124,11 +124,11 @@ class IGamepad extends IInspectable implements IGameController {
       _iGameController.remove_UserChanged(token);
 
   @override
-  Headset get headset => _iGameController.headset;
+  Headset? get headset => _iGameController.headset;
 
   @override
   bool get isWireless => _iGameController.isWireless;
 
   @override
-  User get user => _iGameController.user;
+  User? get user => _iGameController.user;
 }

--- a/lib/src/winrt/gaming/input/igamepad2.dart
+++ b/lib/src/winrt/gaming/input/igamepad2.dart
@@ -103,11 +103,11 @@ class IGamepad2 extends IInspectable implements IGamepad, IGameController {
       _iGameController.remove_UserChanged(token);
 
   @override
-  Headset get headset => _iGameController.headset;
+  Headset? get headset => _iGameController.headset;
 
   @override
   bool get isWireless => _iGameController.isWireless;
 
   @override
-  User get user => _iGameController.user;
+  User? get user => _iGameController.user;
 }

--- a/lib/src/winrt/gaming/input/igamepadstatics2.dart
+++ b/lib/src/winrt/gaming/input/igamepadstatics2.dart
@@ -38,7 +38,7 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
       IGamepadStatics2.fromRawPointer(
           interface.toInterface(IID_IGamepadStatics2));
 
-  Gamepad fromGameController(IGameController gameController) {
+  Gamepad? fromGameController(IGameController gameController) {
     final retValuePtr = calloc<COMObject>();
 
     final hr =
@@ -60,6 +60,11 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return Gamepad.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/globalization/calendar.dart
+++ b/lib/src/winrt/globalization/calendar.dart
@@ -85,7 +85,7 @@ class Calendar extends IInspectable implements ICalendar, ITimeZoneOnCalendar {
   late final _iCalendar = ICalendar.from(this);
 
   @override
-  Calendar clone() => _iCalendar.clone();
+  Calendar? clone() => _iCalendar.clone();
 
   @override
   void setToMin() => _iCalendar.setToMin();

--- a/lib/src/winrt/globalization/icalendar.dart
+++ b/lib/src/winrt/globalization/icalendar.dart
@@ -36,7 +36,7 @@ class ICalendar extends IInspectable {
   factory ICalendar.from(IInspectable interface) =>
       ICalendar.fromRawPointer(interface.toInterface(IID_ICalendar));
 
-  Calendar clone() {
+  Calendar? clone() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -52,6 +52,11 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return Calendar.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/networking/connectivity/iipinformation.dart
+++ b/lib/src/winrt/networking/connectivity/iipinformation.dart
@@ -80,7 +80,10 @@ class IIPInformation extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<int>.fromRawPointer(retValuePtr,
         referenceIid: '{e5198cc8-2873-55f5-b0a1-84ff9e4aad62}');

--- a/lib/src/winrt/networking/connectivity/iipinformation.dart
+++ b/lib/src/winrt/networking/connectivity/iipinformation.dart
@@ -36,7 +36,7 @@ class IIPInformation extends IInspectable {
   factory IIPInformation.from(IInspectable interface) =>
       IIPInformation.fromRawPointer(interface.toInterface(IID_IIPInformation));
 
-  NetworkAdapter get networkAdapter {
+  NetworkAdapter? get networkAdapter {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -52,6 +52,11 @@ class IIPInformation extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return NetworkAdapter.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/networking/connectivity/inetworkadapter.dart
+++ b/lib/src/winrt/networking/connectivity/inetworkadapter.dart
@@ -109,7 +109,7 @@ class INetworkAdapter extends IInspectable {
     }
   }
 
-  NetworkItem get networkItem {
+  NetworkItem? get networkItem {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -125,6 +125,11 @@ class INetworkAdapter extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return NetworkItem.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/networking/connectivity/ipinformation.dart
+++ b/lib/src/winrt/networking/connectivity/ipinformation.dart
@@ -36,7 +36,7 @@ class IPInformation extends IInspectable implements IIPInformation {
   late final _iIPInformation = IIPInformation.from(this);
 
   @override
-  NetworkAdapter get networkAdapter => _iIPInformation.networkAdapter;
+  NetworkAdapter? get networkAdapter => _iIPInformation.networkAdapter;
 
   @override
   int? get prefixLength => _iIPInformation.prefixLength;

--- a/lib/src/winrt/networking/connectivity/networkadapter.dart
+++ b/lib/src/winrt/networking/connectivity/networkadapter.dart
@@ -46,7 +46,7 @@ class NetworkAdapter extends IInspectable implements INetworkAdapter {
   int get ianaInterfaceType => _iNetworkAdapter.ianaInterfaceType;
 
   @override
-  NetworkItem get networkItem => _iNetworkAdapter.networkItem;
+  NetworkItem? get networkItem => _iNetworkAdapter.networkItem;
 
   @override
   Guid get networkAdapterId => _iNetworkAdapter.networkAdapterId;

--- a/lib/src/winrt/networking/hostname.dart
+++ b/lib/src/winrt/networking/hostname.dart
@@ -66,7 +66,7 @@ class HostName extends IInspectable implements IHostName, IStringable {
   late final _iHostName = IHostName.from(this);
 
   @override
-  IPInformation get ipInformation => _iHostName.ipInformation;
+  IPInformation? get ipInformation => _iHostName.ipInformation;
 
   @override
   String get rawName => _iHostName.rawName;

--- a/lib/src/winrt/networking/ihostname.dart
+++ b/lib/src/winrt/networking/ihostname.dart
@@ -36,7 +36,7 @@ class IHostName extends IInspectable {
   factory IHostName.from(IInspectable interface) =>
       IHostName.fromRawPointer(interface.toInterface(IID_IHostName));
 
-  IPInformation get ipInformation {
+  IPInformation? get ipInformation {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -52,6 +52,11 @@ class IHostName extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return IPInformation.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/storage/iuserdatapathsstatics.dart
+++ b/lib/src/winrt/storage/iuserdatapathsstatics.dart
@@ -36,7 +36,7 @@ class IUserDataPathsStatics extends IInspectable {
       IUserDataPathsStatics.fromRawPointer(
           interface.toInterface(IID_IUserDataPathsStatics));
 
-  UserDataPaths getForUser(User user) {
+  UserDataPaths? getForUser(User user) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -57,10 +57,15 @@ class IUserDataPathsStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
+
     return UserDataPaths.fromRawPointer(retValuePtr);
   }
 
-  UserDataPaths getDefault() {
+  UserDataPaths? getDefault() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -76,6 +81,11 @@ class IUserDataPathsStatics extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return UserDataPaths.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/storage/pickers/fileopenpicker.dart
+++ b/lib/src/winrt/storage/pickers/fileopenpicker.dart
@@ -46,7 +46,7 @@ class FileOpenPicker extends IInspectable
   static const _className = 'Windows.Storage.Pickers.FileOpenPicker';
 
   // IFileOpenPickerStatics2 methods
-  static FileOpenPicker createForUser(User user) {
+  static FileOpenPicker? createForUser(User user) {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IFileOpenPickerStatics2);
     final object = IFileOpenPickerStatics2.fromRawPointer(activationFactoryPtr);
@@ -104,5 +104,5 @@ class FileOpenPicker extends IInspectable
   late final _iFileOpenPicker3 = IFileOpenPicker3.from(this);
 
   @override
-  User get user => _iFileOpenPicker3.user;
+  User? get user => _iFileOpenPicker3.user;
 }

--- a/lib/src/winrt/storage/pickers/ifileopenpicker3.dart
+++ b/lib/src/winrt/storage/pickers/ifileopenpicker3.dart
@@ -35,7 +35,7 @@ class IFileOpenPicker3 extends IInspectable {
       IFileOpenPicker3.fromRawPointer(
           interface.toInterface(IID_IFileOpenPicker3));
 
-  User get user {
+  User? get user {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -51,6 +51,11 @@ class IFileOpenPicker3 extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return User.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/storage/pickers/ifileopenpickerstatics2.dart
+++ b/lib/src/winrt/storage/pickers/ifileopenpickerstatics2.dart
@@ -36,7 +36,7 @@ class IFileOpenPickerStatics2 extends IInspectable {
       IFileOpenPickerStatics2.fromRawPointer(
           interface.toInterface(IID_IFileOpenPickerStatics2));
 
-  FileOpenPicker createForUser(User user) {
+  FileOpenPicker? createForUser(User user) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -55,6 +55,11 @@ class IFileOpenPickerStatics2 extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return FileOpenPicker.fromRawPointer(retValuePtr);

--- a/lib/src/winrt/storage/userdatapaths.dart
+++ b/lib/src/winrt/storage/userdatapaths.dart
@@ -35,7 +35,7 @@ class UserDataPaths extends IInspectable implements IUserDataPaths {
   static const _className = 'Windows.Storage.UserDataPaths';
 
   // IUserDataPathsStatics methods
-  static UserDataPaths getForUser(User user) {
+  static UserDataPaths? getForUser(User user) {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IUserDataPathsStatics);
     final object = IUserDataPathsStatics.fromRawPointer(activationFactoryPtr);
@@ -47,7 +47,7 @@ class UserDataPaths extends IInspectable implements IUserDataPaths {
     }
   }
 
-  static UserDataPaths getDefault() {
+  static UserDataPaths? getDefault() {
     final activationFactoryPtr =
         CreateActivationFactory(_className, IID_IUserDataPathsStatics);
     final object = IUserDataPathsStatics.fromRawPointer(activationFactoryPtr);

--- a/lib/src/winrt/ui/notifications/itoastnotification4.dart
+++ b/lib/src/winrt/ui/notifications/itoastnotification4.dart
@@ -34,7 +34,7 @@ class IToastNotification4 extends IInspectable {
       IToastNotification4.fromRawPointer(
           interface.toInterface(IID_IToastNotification4));
 
-  NotificationData get data {
+  NotificationData? get data {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -52,10 +52,15 @@ class IToastNotification4 extends IInspectable {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
+
     return NotificationData.fromRawPointer(retValuePtr);
   }
 
-  set data(NotificationData value) {
+  set data(NotificationData? value) {
     final hr = ptr.ref.vtable
             .elementAt(7)
             .cast<
@@ -64,7 +69,8 @@ class IToastNotification4 extends IInspectable {
                         HRESULT Function(Pointer, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, value.ptr.cast<Pointer<COMObject>>().value);
+        ptr.ref.lpVtbl,
+        value == null ? nullptr : value.ptr.cast<Pointer<COMObject>>().value);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/lib/src/winrt/ui/notifications/toastnotification.dart
+++ b/lib/src/winrt/ui/notifications/toastnotification.dart
@@ -138,10 +138,10 @@ class ToastNotification extends IInspectable
   late final _iToastNotification4 = IToastNotification4.from(this);
 
   @override
-  NotificationData get data => _iToastNotification4.data;
+  NotificationData? get data => _iToastNotification4.data;
 
   @override
-  set data(NotificationData value) => _iToastNotification4.data = value;
+  set data(NotificationData? value) => _iToastNotification4.data = value;
 
   @override
   ToastNotificationPriority get priority => _iToastNotification4.priority;

--- a/test/winrt_calendar_test.dart
+++ b/test/winrt_calendar_test.dart
@@ -21,7 +21,7 @@ void main() {
     });
 
     test('Calendar.clone', () {
-      final calendar2 = calendar.clone();
+      final calendar2 = calendar.clone()!;
 
       expect(
           calendar2.runtimeClassName, equals('Windows.Globalization.Calendar'));
@@ -31,7 +31,7 @@ void main() {
     });
 
     test('Calendar.setToMin', () {
-      final today = calendar.clone();
+      final today = calendar.clone()!;
 
       calendar.setToMin();
       expect(calendar.compare(today), isNegative);
@@ -40,7 +40,7 @@ void main() {
     });
 
     test('Calendar.setToMax', () {
-      final today = calendar.clone();
+      final today = calendar.clone()!;
 
       calendar.setToMax();
       expect(calendar.compare(today), isPositive);
@@ -371,7 +371,7 @@ void main() {
     });
 
     test('Compare equality', () {
-      final original = calendar.clone();
+      final original = calendar.clone()!;
       calendar
         ..addDays(1)
         ..addDays(-1);
@@ -382,7 +382,7 @@ void main() {
     });
 
     test('Compare positive', () {
-      final original = calendar.clone();
+      final original = calendar.clone()!;
       calendar
         ..addDays(2)
         ..addDays(-1);
@@ -393,7 +393,7 @@ void main() {
     });
 
     test('Compare negative', () {
-      final original = calendar.clone();
+      final original = calendar.clone()!;
       calendar
         ..addDays(2)
         ..addDays(-3);

--- a/test/winrt_uri_test.dart
+++ b/test/winrt_uri_test.dart
@@ -29,7 +29,7 @@ void main() {
       expect(winrtUri.extension, equals('.html'));
       expect(winrtUri.query, equals('?q1=v1&q2=v2'));
       final queryParsed = winrtUri.queryParsed;
-      expect(queryParsed.size, equals(2));
+      expect(queryParsed!.size, equals(2));
       final queryParameters = queryParsed.toList();
       expect(queryParameters.length, equals(2));
       expect(queryParameters.first.name, equals('q1'));

--- a/tool/generator/lib/src/projection/winrt/declarations/reference.dart
+++ b/tool/generator/lib/src/projection/winrt/declarations/reference.dart
@@ -83,7 +83,10 @@ class WinRTMethodReturningReferenceProjection extends WinRTMethodProjection
 
         ${ffiCall(freeRetValOnFailure: true)}
 
-        if (retValuePtr.ref.lpVtbl == nullptr) return null;
+        if (retValuePtr.ref.lpVtbl == nullptr) {
+          free(retValuePtr);
+          return null;
+        }
 
         final reference = IReference<$referenceTypeArg>.fromRawPointer
             (retValuePtr$referenceConstructorArgs);
@@ -109,7 +112,10 @@ class WinRTGetPropertyReturningReferenceProjection
 
         ${ffiCall(freeRetValOnFailure: true)}
 
-        if (retValuePtr.ref.lpVtbl == nullptr) return null;
+        if (retValuePtr.ref.lpVtbl == nullptr) {
+          free(retValuePtr);
+          return null;
+        }
 
         final reference = IReference<$referenceTypeArg>.fromRawPointer
             (retValuePtr$referenceConstructorArgs);

--- a/tool/generator/test/goldens/icalendar.golden
+++ b/tool/generator/test/goldens/icalendar.golden
@@ -36,7 +36,7 @@ class ICalendar extends IInspectable {
   factory ICalendar.from(IInspectable interface) =>
       ICalendar.fromRawPointer(interface.toInterface(IID_ICalendar));
 
-  Calendar clone() {
+  Calendar? clone() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -52,6 +52,11 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
     }
 
     return Calendar.fromRawPointer(retValuePtr);

--- a/tool/generator/test/winrt_projection_test.dart
+++ b/tool/generator/test/winrt_projection_test.dart
@@ -315,7 +315,8 @@ void main() {
         contains("iterableIid: '{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}'"));
   });
 
-  test('WinRT get property successfully projects nullable types', () {
+  test('WinRT get property successfully projects IReference<DateTime> type',
+      () {
     final winTypeDef = MetadataStore.getMetadataForType(
         'Windows.UI.Notifications.IToastNotification');
 
@@ -337,7 +338,9 @@ void main() {
         contains("referenceIid: '{5541d8a7-497c-5aa4-86fc-7713adbf2a2c}'"));
   });
 
-  test('WinRT Clone method successfully projects Pointer<COMObject>', () {
+  test(
+      'WinRT Clone method successfully projects Pointer<COMObject> as nullable',
+      () {
     final winTypeDef =
         MetadataStore.getMetadataForType('Windows.Globalization.ICalendar');
 
@@ -404,7 +407,8 @@ void main() {
         startsWith('set era(int value)'));
   });
 
-  test('WinRT set property successfully projects nullable DateTime parameter',
+  test(
+      'WinRT set property successfully projects IReference<DateTime> parameter',
       () {
     final winTypeDef = MetadataStore.getMetadataForType(
         'Windows.UI.Notifications.IToastNotification');
@@ -426,7 +430,34 @@ void main() {
             : boxValue(value, convertToIReference: true);'''));
   });
 
-  test('WinRT set property successfully projects nullable enum parameter', () {
+  test('WinRT set property projects WinRT object parameter as nullable', () {
+    final winTypeDef = MetadataStore.getMetadataForType(
+        'Windows.UI.Notifications.IToastNotification4');
+
+    final projection = WinRTInterfaceProjection(winTypeDef!);
+    final dataProjection =
+        projection.methodProjections.firstWhere((m) => m.name == 'put_Data');
+    final dataPropertyProjection =
+        WinRTSetPropertyProjection(dataProjection.method, 0);
+
+    expect(
+        dataProjection.nativePrototype,
+        equalsIgnoringWhitespace(
+            'HRESULT Function(Pointer, Pointer<COMObject>)'));
+    expect(dataProjection.dartPrototype,
+        equalsIgnoringWhitespace('int Function(Pointer, Pointer<COMObject>)'));
+    expect(dataProjection.returnType.dartType, equals('void'));
+    expect(dataProjection.toString().trimLeft(),
+        startsWith('set data(NotificationData? value)'));
+    expect(
+        dataPropertyProjection.toString(),
+        contains(
+            'value == null ? nullptr : value.ptr.cast<Pointer<COMObject>>().value'));
+  });
+
+  test(
+      'WinRT set property successfully projects IReference<BluetoothLEAdvertisementFlags> parameter',
+      () {
     final winTypeDef = MetadataStore.getMetadataForType(
         'Windows.Devices.Bluetooth.Advertisement.IBluetoothLEAdvertisement');
 
@@ -679,7 +710,7 @@ void main() {
         equalsIgnoringWhitespace('int Function(Pointer, Pointer<COMObject>)'));
     expect(fallbackUriProjection.returnType.methodParamType, equals('Uri'));
     expect(fallbackUriProjection.toString().trimLeft(),
-        startsWith('Uri get fallbackUri'));
+        startsWith('Uri? get fallbackUri'));
     expect(
         fallbackUriProjection.toString().trimLeft(),
         contains(
@@ -690,7 +721,9 @@ void main() {
         contains('return Uri.parse(uriAsString);'));
   });
 
-  test('WinRT set property successfully projects Uri', () {
+  test(
+      'WinRT set property successfully projects Windows.Foundation.Uri as Uri?',
+      () {
     final winTypeDef =
         MetadataStore.getMetadataForType('Windows.System.ILauncherOptions');
 
@@ -704,11 +737,11 @@ void main() {
     expect(fallbackUriProjection.dartPrototype,
         equalsIgnoringWhitespace('int Function(Pointer, Pointer<COMObject>)'));
     expect(fallbackUriProjection.toString().trimLeft(),
-        startsWith('set fallbackUri(Uri value)'));
+        startsWith('set fallbackUri(Uri? value)'));
     expect(
         fallbackUriProjection.toString().trimLeft(),
         contains(
-            'final winrtUri = winrt_uri.Uri.createUri(value.toString());'));
+            'final winrtUri = value == null ? null : winrt_uri.Uri.createUri(value.toString());'));
   });
 
   test('WinRT method successfully projects Uri parameter', () {

--- a/tool/generator/test/winrt_projection_test.dart
+++ b/tool/generator/test/winrt_projection_test.dart
@@ -8,6 +8,7 @@ import 'helpers.dart';
 
 void main() {
   final windowsBuildNumber = getWindowsBuildNumber();
+
   test('Class valuetype is correctly identified', () {
     final winTypeDef = MetadataStore.getMetadataForType(
         'Windows.Storage.Pickers.IFileOpenPicker')!;
@@ -352,7 +353,7 @@ void main() {
         equalsIgnoringWhitespace('int Function(Pointer, Pointer<COMObject>)'));
     expect(cloneProjection.returnType.dartType, equals('Pointer<COMObject>'));
     expect(
-        cloneProjection.toString().trimLeft(), startsWith('Calendar clone()'));
+        cloneProjection.toString().trimLeft(), startsWith('Calendar? clone()'));
   });
 
   test('WinRT TryCreate method successfully projects Pointer<COMObject>', () {


### PR DESCRIPTION
Fixes #647

Note that we must also mark WinRT object parameters as nullable. 

[IStorageItemExtraProperties.RetrievePropertiesAsync(IIterable<String>) Method](https://learn.microsoft.com/en-us/uwp/api/windows.storage.fileproperties.istorageitemextraproperties.retrievepropertiesasync?view=winrt-22621#parameters)'s parameter can take **null**:
> A collection that contains the names of the properties to retrieve. Pass null to retrieve all possible properties.

I'm thinking of doing that after we land this.