### PR TITLE
Bump version of winmd to win32 4.x compatible

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -9,7 +9,8 @@ demonstrate various aspects of invoking Windows APIs, including:
 - Integrating Windows code with Flutter
 
 Other examples of packages that use Win32 can be found on pub.dev, at the
-following location: <https://pub.dev/packages?q=dependency%3Awin32>
+following location:
+[https://pub.dev/packages?q=dependency%3Awin32](https://pub.dev/packages?q=dependency%3Awin32).
 
 ## Windows system APIs (kernel32)
 

--- a/tool/generator/pubspec.yaml
+++ b/tool/generator/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # relationship between these two packages is tightly coupled, since this
   # package includes a specific version of the Win32 metadata, so we pin the
   # dependency by version to avoid surprising conflicts.
-  winmd: 2.4.6
+  winmd: 2.4.7
 
   # Win32 itself
   win32:


### PR DESCRIPTION
Also attempt to workaround a bug in how pub.dev escapes HTML links (https://github.com/dart-lang/pub-dev/issues/6331).