### PR TITLE
fix a dartdoc comment reference

### DIFF
--- a/lib/src/guid.dart
+++ b/lib/src/guid.dart
@@ -103,7 +103,7 @@ class Guid {
   /// location.
   ///
   /// It is the caller's responsibility to free the memory at the pointer
-  /// location, for example by calling [calloc.free].
+  /// location, for example by calling [calloc]'s `free` method.
   Pointer<GUID> toNativeGUID({Allocator allocator = malloc}) {
     final pGUID = allocator<Uint8>(16);
 


### PR DESCRIPTION
- fix a dartdoc comment reference

I know this isn't currently your biggest issue w/ dartdoc, but I saw this unresolved reference when playing with generation times and sizes locally.

```
Generating docs for library winrt from package:win32/winrt.dart...
  warning: unresolved doc reference [calloc.free]
    from winrt.Guid.toNativeGUID: (file:///Users/devoncarew/projects/timsneath/win32/lib/src/guid.dart:107:17)
```
