### PR TITLE
Update docs.microsoft.com URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ Some tips:
 
 - When wrapping a Win32 API, use the Unicode ('W') wide variants of these APIs,
   rather than the ANSI ('A') variants. For example:
-  [CredWriteW](https://docs.microsoft.com/en-us/windows/win32/api/wincred/nf-wincred-credwritew),
+  [CredWriteW](https://learn.microsoft.com/windows/win32/api/wincred/nf-wincred-credwritew),
   rather than
-  [CredWriteA](https://docs.microsoft.com/en-us/windows/win32/api/wincred/nf-wincred-credwritea).
+  [CredWriteA](https://learn.microsoft.com/windows/win32/api/wincred/nf-wincred-credwritea).
 
 - To create a new API, *don't* edit the main library files themselves; these get
   overwritten. Instead, edit `win32_functions.json` in the `data\` folder and run

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This package lets you write apps that use the Windows API directly from Dart, by
 wrapping common Win32 and COM APIs using Dart FFI.
 
 You could use it to call a Win32 API like
-[EnumFontFamiliesEx](https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-enumfontfamiliesexw)
+[EnumFontFamiliesEx](https://learn.microsoft.com/windows/win32/api/wingdi/nf-wingdi-enumfontfamiliesexw)
 to enumerate all locally-installed fonts:
 
 ![Fonts screenshot](https://github.com/dart-windows/win32/blob/main/doc/images/fonts.png?raw=true)

--- a/doc/com.md
+++ b/doc/com.md
@@ -25,7 +25,7 @@ if (FAILED(hr)) throw WindowsException(hr);
 ### Creating a COM object
 
 You can create COM objects using the [C
-library](https://docs.microsoft.com/en-us/windows/win32/learnwin32/creating-an-object-in-com):
+library](https://learn.microsoft.com/windows/win32/learnwin32/creating-an-object-in-com):
 
 ```dart
 hr = CoCreateInstance(clsid, nullptr, CLSCTX_INPROC_SERVER, iid, ppv);
@@ -53,7 +53,7 @@ may call `queryInterface` on any object to retrieve a pointer to a different
 supported interface.
 
 More information on COM interfaces may be found in the [Microsoft
-documentation](https://docs.microsoft.com/en-us/windows/win32/learnwin32/asking-an-object-for-an-interface).
+documentation](https://learn.microsoft.com/windows/win32/learnwin32/asking-an-object-for-an-interface).
 
 COM interfaces supply a method that wraps `queryInterface`. If you have an
 existing COM object, you can call it as follows:

--- a/doc/winscard.md
+++ b/doc/winscard.md
@@ -4,4 +4,4 @@ The Smart Card subsystem, used to provide smartcard-aware applications with
 access to smartcard-related software resources and readers.
 
 [Microsoft documentation on
-smartcard-APIs](https://docs.microsoft.com/en-us/windows/win32/secauthn/smart-card-authentication)
+smartcard-APIs](https://learn.microsoft.com/windows/win32/secauthn/smart-card-authentication)

--- a/example/customtitlebar.dart
+++ b/example/customtitlebar.dart
@@ -339,7 +339,7 @@ int mainWindowProc(int hwnd, int msg, int wParam, int lParam) {
       // Handling this event allows us to extend the client (paintable) area
       // into the title bar region.
       //
-      // Per https://docs.microsoft.com/en-us/windows/win32/dwm/customframe :
+      // Per https://learn.microsoft.com/windows/win32/dwm/customframe :
       //
       // "To remove the standard window frame, you must handle the WM_NCCALCSIZE
       // message, specifically when its wParam value is TRUE and the return

--- a/example/dialogbox.dart
+++ b/example/dialogbox.dart
@@ -101,7 +101,7 @@ void main() {
 }
 
 // Documentation on this function here:
-// https://docs.microsoft.com/en-us/windows/win32/dlgbox/using-dialog-boxes
+// https://learn.microsoft.com/windows/win32/dlgbox/using-dialog-boxes
 int dialogReturnProc(int hwndDlg, int message, int wParam, int lParam) {
   switch (message) {
     case WM_INITDIALOG:

--- a/example/manifest/README.md
+++ b/example/manifest/README.md
@@ -9,7 +9,7 @@ same version information, regardless of whether you are running Windows 8,
 Windows 8.1, or Windows 10.
 
 You can tell Windows that your app is aware of later versions with an [app
-manifest](https://docs.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1),
+manifest](https://learn.microsoft.com/windows/win32/sysinfo/targeting-your-application-at-windows-8-1),
 which opts your app into new behavior.
 
 You can see this behavior in action by running `version.dart` (which calls

--- a/example/printer_raw.dart
+++ b/example/printer_raw.dart
@@ -1,7 +1,7 @@
 // Sends RAW data (string or hex sequences) directly to the printer
 
 // Example taken from:
-// https://docs.microsoft.com/en-us/windows/win32/printdocs/sending-data-directly-to-a-printer
+// https://learn.microsoft.com/windows/win32/printdocs/sending-data-directly-to-a-printer
 
 import 'dart:ffi';
 
@@ -21,21 +21,21 @@ class RawPrinter {
     final pPrinterName = printerName.toNativeUtf16(allocator: alloc);
     final phPrinter = alloc<HANDLE>();
 
-    // https://docs.microsoft.com/en-us/windows/win32/printdocs/openprinter
+    // https://learn.microsoft.com/windows/win32/printdocs/openprinter
     var fSuccess = OpenPrinter(pPrinterName, phPrinter, nullptr);
     if (fSuccess == 0) {
       final error = GetLastError();
       throw Exception('OpenPrint error, status: $fSuccess, error: $error');
     }
 
-    // https://docs.microsoft.com/en-us/windows/win32/printdocs/doc-info-1
+    // https://learn.microsoft.com/windows/win32/printdocs/doc-info-1
     final pDocInfo = alloc<DOC_INFO_1>()
       ..ref.pDocName = printerName.toNativeUtf16(allocator: alloc)
       ..ref.pDatatype =
           dataType.toNativeUtf16(allocator: alloc) // RAW, TEXT or XPS_PASS
       ..ref.pOutputFile = nullptr;
 
-    //https://docs.microsoft.com/en-us/windows/win32/printdocs/startdocprinter
+    //https://learn.microsoft.com/windows/win32/printdocs/startdocprinter
     fSuccess = StartDocPrinter(
         phPrinter.value,
         1, // Version of the structure to which pDocInfo points.
@@ -50,7 +50,7 @@ class RawPrinter {
   }
 
   bool _startRawPrintPage(Pointer<HANDLE> phPrinter) {
-    //https://docs.microsoft.com/en-us/windows/win32/printdocs/startpageprinter
+    //https://learn.microsoft.com/windows/win32/printdocs/startpageprinter
     return StartPagePrinter(phPrinter.value) != 0;
   }
 
@@ -67,7 +67,7 @@ class RawPrinter {
     final cWritten = alloc<DWORD>();
     final data = dataToPrint.toNativeUtf8(allocator: alloc);
 
-    // https://docs.microsoft.com/en-us/windows/win32/printdocs/writeprinter
+    // https://learn.microsoft.com/windows/win32/printdocs/writeprinter
     final result =
         WritePrinter(phPrinter.value, data, dataToPrint.length, cWritten);
 

--- a/example/sensor.dart
+++ b/example/sensor.dart
@@ -5,7 +5,7 @@
 // Example of retrieving a sensor using the Sensor API.
 
 // C++ implementation can be found here:
-// https://docs.microsoft.com/en-us/windows/win32/sensorsapi/retrieving-a-sensor
+// https://learn.microsoft.com/windows/win32/sensorsapi/retrieving-a-sensor
 
 import 'dart:ffi';
 

--- a/example/serial.dart
+++ b/example/serial.dart
@@ -5,7 +5,7 @@
 // Dart implementation of the Win32 sample of configuring a comms resource.
 
 // C++ implementation can be found here:
-// https://docs.microsoft.com/en-us/windows/win32/devio/configuring-a-communications-resource
+// https://learn.microsoft.com/windows/win32/devio/configuring-a-communications-resource
 
 // This sample assumes that you have a working COM serial port.
 

--- a/example/setupapi.dart
+++ b/example/setupapi.dart
@@ -10,7 +10,7 @@ import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
 void main() {
-  // https://docs.microsoft.com/en-us/windows-hardware/drivers/install/overview-of-device-setup-classes
+  // https://learn.microsoft.com/windows-hardware/drivers/install/overview-of-device-setup-classes
   using((Arena arena) {
     final deviceGuid = arena<GUID>()..ref.setGUID(GUID_DEVCLASS_NET);
 
@@ -26,7 +26,7 @@ void main() {
     }
   });
 
-  // https://docs.microsoft.com/en-us/windows-hardware/drivers/install/overview-of-device-interface-classes
+  // https://learn.microsoft.com/windows-hardware/drivers/install/overview-of-device-interface-classes
   using((Arena arena) {
     final interfaceGuid = arena<GUID>()..ref.setGUID(GUID_DEVINTERFACE_HID);
 

--- a/example/sysinfo.dart
+++ b/example/sysinfo.dart
@@ -14,7 +14,7 @@ bool testFlag(int value, int attribute) => value & attribute == attribute;
 /// Test for a minimum version of Windows.
 ///
 /// Per:
-/// https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexw,
+/// https://learn.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexw,
 /// applications not manifested for Windows 8.1 or Windows 10 will return the
 /// Windows 8 OS version value (6.2).
 bool isWindowsVersionAtLeast(int majorVersion, int minorVersion) {
@@ -148,7 +148,7 @@ Object getRegistryValue(int key, String subKey, String valueName) {
 /// Uses the GetSystemPowerStatus API call to get information about the battery.
 /// More information on the reported values can be found in the Windows API
 /// documentation, here:
-/// https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-system_power_status
+/// https://learn.microsoft.com/windows/win32/api/winbase/ns-winbase-system_power_status
 void printPowerInfo() {
   final powerStatus = calloc<SYSTEM_POWER_STATUS>();
 

--- a/lib/src/guid.dart
+++ b/lib/src/guid.dart
@@ -10,7 +10,7 @@
 // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Guid.cs
 
 // The GUID structure as used in Win32 is documented here:
-// https://docs.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid
+// https://learn.microsoft.com/windows/win32/api/guiddef/ns-guiddef-guid
 
 // ignore_for_file: camel_case_types
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -8,7 +8,7 @@
 /// ```
 ///
 /// For more on Windows data types, see
-/// https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types.
+/// https://learn.microsoft.com/windows/win32/winprog/windows-data-types.
 
 // ignore_for_file: camel_case_types
 

--- a/test/path_provider_test.dart
+++ b/test/path_provider_test.dart
@@ -439,7 +439,7 @@ class PathProviderWindows {
   }
 
   /// Makes [rawString] safe as a directory component. See
-  /// https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+  /// https://learn.microsoft.com/windows/win32/fileio/naming-a-file#naming-conventions
   ///
   /// If after sanitizing the string is empty, returns null.
   String? _sanitizedDirectoryName(String? rawString) {

--- a/test/spellcheck_test.dart
+++ b/test/spellcheck_test.dart
@@ -12,7 +12,7 @@ import 'helpers.dart';
 void main() {
   test('Spellcheck', () {
     // ISpellCheckerFactory is only available on Windows 8 or higher, per:
-    // https://docs.microsoft.com/en-us/windows/win32/api/spellcheck/nn-spellcheck-ispellcheckerfactory
+    // https://learn.microsoft.com/windows/win32/api/spellcheck/nn-spellcheck-ispellcheckerfactory
     if (getWindowsBuildNumber() >= 9200) {
       var hr = CoInitializeEx(
           nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);

--- a/tool/win32gen/data/README.md
+++ b/tool/win32gen/data/README.md
@@ -17,7 +17,7 @@ The format for the JSON file (`win32_functions.json`) is as follows:
         // The API prototype, as presented in Windows docs
         // Note that this should include a 'W' postfix if the declared function
         // has both Unicode and ANSI variants. See:
-        // https://docs.microsoft.com/en-us/windows/win32/intl/unicode-in-the-windows-api
+        // https://learn.microsoft.com/windows/win32/intl/unicode-in-the-windows-api
         //
         // The version presented in the docs is inconsistent -- some docs
         // include it, others don't -- so pay attention here. If you get a

--- a/tool/win32gen/lib/src/model/functions.dart
+++ b/tool/win32gen/lib/src/model/functions.dart
@@ -5,7 +5,7 @@ import 'dart:io';
 /// Maps between Windows versions and the corresponding build numbers
 ///
 /// Details from:
-/// https://docs.microsoft.com/en-us/windows/release-health/release-information
+/// https://learn.microsoft.com/windows/release-health/release-information
 const windowsBuilds = <String, int>{
   'WIN8': 9200,
   'WIN81': 9600,


### PR DESCRIPTION
Updates doc.microsoft.com URLs:

1. **Removes language codes** - Removing the `en-us` language code from the URL's path lets the docs website redirect to whichever locale is most appropriate for the user.
2. **Update to the 'learn' subdomain** - The `docs.microsoft.com` subdomain has been replaced with `learn.microsoft.com`.

