### PR TITLE
Don't manually free IDispatch's ptr

### DIFF
--- a/example/idispatch.dart
+++ b/example/idispatch.dart
@@ -109,10 +109,7 @@ class Dispatcher {
     }
   }
 
-  void dispose() {
-    free(disp.ptr);
-    free(IID_NULL);
-  }
+  void dispose() => free(IID_NULL);
 }
 
 void main() {


### PR DESCRIPTION
Don't manually free the pointer of `IDispatch` as it will be automatically freed by the `Finalizer`.