### PR TITLE
feat: add WinHttpRequest APIs

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -86,6 +86,7 @@ following location:
 | `guid.dart`         | Creates a globally unique identifier (GUID)           |
 | `idispatch.dart`    | Demonstrates calling a method using `IDispatch`       |
 | `uiautomation.dart` | Demonstrates calling Windows UI Automation APIs       |
+| `winhttp.dart`      | Demonstrates using WinHTTP APIs to make HTTP requests |
 | `winmd.dart`        | Interrogate Windows Runtime types                     |
 | `wmi_perf.dart`     | Uses WMI to retrieve performance counters             |
 | `wmi_wql.dart`      | Uses WMI to retrieve information using WQL            |

--- a/example/winhttp.dart
+++ b/example/winhttp.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2020, Dart | Windows.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:win32/win32.dart';
+
+void main() {
+  // Initialize COM
+  CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+
+  final method = BSTR.fromString('GET');
+  final url = BSTR.fromString('https://dart.dev');
+
+  final varFalse = calloc<VARIANT>();
+  final varEmpty = calloc<VARIANT>();
+
+  VariantInit(varFalse);
+  varFalse.ref.vt = VARENUM.VT_BOOL;
+  varFalse.ref.boolVal = false;
+
+  VariantInit(varEmpty);
+  varEmpty.ref.vt = VARENUM.VT_ERROR;
+
+  try {
+    // Create an instance of WinHttpRequest class
+    final winHttpRequest = WinHttpRequest.createInstance();
+
+    // Open an HTTP connection
+    var hr = winHttpRequest.open(method.ptr, url.ptr, varFalse.ref);
+    if (FAILED(hr)) throw WindowsException(hr);
+
+    // Send request
+    hr = winHttpRequest.send(varEmpty.ref);
+    if (FAILED(hr)) throw WindowsException(hr);
+
+    // Get response text
+    final responseText = winHttpRequest.responseText.toDartString();
+    print(responseText);
+  } finally {
+    VariantClear(varFalse);
+    VariantClear(varEmpty);
+    free(varFalse);
+    free(varEmpty);
+    method.free();
+    url.free();
+  }
+}

--- a/lib/src/com/iwinhttprequest.dart
+++ b/lib/src/com/iwinhttprequest.dart
@@ -1,0 +1,334 @@
+// iwinhttprequest.dart
+
+// ignore_for_file: unused_import
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+// ignore_for_file: no_leading_underscores_for_local_identifiers
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+import '../callbacks.dart';
+import '../combase.dart';
+import '../constants.dart';
+import '../exceptions.dart';
+import '../guid.dart';
+import '../macros.dart';
+import '../structs.g.dart';
+import '../utils.dart';
+import '../variant.dart';
+import '../win32/ole32.g.dart';
+import 'idispatch.dart';
+import 'iunknown.dart';
+
+/// @nodoc
+const IID_IWinHttpRequest = '{016fe2ec-b2c8-45f8-b23b-39e53a75396b}';
+
+/// The IWinHttpRequest interface provides all of the nonevent methods for
+/// Microsoft Windows HTTP Services (WinHTTP).
+///
+/// {@category Interface}
+/// {@category com}
+class IWinHttpRequest extends IDispatch {
+  // vtable begins at 7, is 19 entries long.
+  IWinHttpRequest(super.ptr);
+
+  factory IWinHttpRequest.from(IUnknown interface) =>
+      IWinHttpRequest(interface.toInterface(IID_IWinHttpRequest));
+
+  int setProxy(int proxySetting, VARIANT proxyServer, VARIANT bypassList) =>
+      ptr.ref.vtable
+              .elementAt(7)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          Int32 Function(Pointer, Int32 proxySetting,
+                              VARIANT proxyServer, VARIANT bypassList)>>>()
+              .value
+              .asFunction<
+                  int Function(Pointer, int proxySetting, VARIANT proxyServer,
+                      VARIANT bypassList)>()(
+          ptr.ref.lpVtbl, proxySetting, proxyServer, bypassList);
+
+  int setCredentials(
+          Pointer<Utf16> userName, Pointer<Utf16> password, int flags) =>
+      ptr
+          .ref.vtable
+          .elementAt(8)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, Pointer<Utf16> userName,
+                          Pointer<Utf16> password, Int32 flags)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer,
+                  Pointer<Utf16> userName,
+                  Pointer<Utf16> password,
+                  int flags)>()(ptr.ref.lpVtbl, userName, password, flags);
+
+  int open(Pointer<Utf16> method, Pointer<Utf16> url, VARIANT async) =>
+      ptr.ref.vtable
+          .elementAt(9)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, Pointer<Utf16> method,
+                          Pointer<Utf16> url, VARIANT async)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer, Pointer<Utf16> method, Pointer<Utf16> url,
+                  VARIANT async)>()(ptr.ref.lpVtbl, method, url, async);
+
+  int setRequestHeader(Pointer<Utf16> header, Pointer<Utf16> value) => ptr
+      .ref.vtable
+      .elementAt(10)
+      .cast<
+          Pointer<
+              NativeFunction<
+                  Int32 Function(
+                      Pointer, Pointer<Utf16> header, Pointer<Utf16> value)>>>()
+      .value
+      .asFunction<
+          int Function(Pointer, Pointer<Utf16> header,
+              Pointer<Utf16> value)>()(ptr.ref.lpVtbl, header, value);
+
+  int getResponseHeader(Pointer<Utf16> header, Pointer<Pointer<Utf16>> value) =>
+      ptr.ref.vtable
+              .elementAt(11)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          Int32 Function(Pointer, Pointer<Utf16> header,
+                              Pointer<Pointer<Utf16>> value)>>>()
+              .value
+              .asFunction<
+                  int Function(Pointer, Pointer<Utf16> header,
+                      Pointer<Pointer<Utf16>> value)>()(
+          ptr.ref.lpVtbl, header, value);
+
+  int getAllResponseHeaders(Pointer<Pointer<Utf16>> headers) => ptr.ref.vtable
+      .elementAt(12)
+      .cast<
+          Pointer<
+              NativeFunction<
+                  Int32 Function(Pointer, Pointer<Pointer<Utf16>> headers)>>>()
+      .value
+      .asFunction<
+          int Function(Pointer,
+              Pointer<Pointer<Utf16>> headers)>()(ptr.ref.lpVtbl, headers);
+
+  int send(VARIANT body) => ptr.ref.vtable
+      .elementAt(13)
+      .cast<Pointer<NativeFunction<Int32 Function(Pointer, VARIANT body)>>>()
+      .value
+      .asFunction<int Function(Pointer, VARIANT body)>()(ptr.ref.lpVtbl, body);
+
+  int get status {
+    final retValuePtr = calloc<Int32>();
+
+    try {
+      final hr = ptr.ref.vtable
+          .elementAt(14)
+          .cast<
+              Pointer<
+                  NativeFunction<Int32 Function(Pointer, Pointer<Int32>)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer,
+                  Pointer<Int32> status)>()(ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      final retValue = retValuePtr.value;
+      return retValue;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  Pointer<Utf16> get statusText {
+    final retValuePtr = calloc<Pointer<Utf16>>();
+
+    try {
+      final hr = ptr.ref.vtable
+              .elementAt(15)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          Int32 Function(
+                              Pointer, Pointer<Pointer<Utf16>> status)>>>()
+              .value
+              .asFunction<
+                  int Function(Pointer, Pointer<Pointer<Utf16>> status)>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      final retValue = retValuePtr.value;
+      return retValue;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  Pointer<Utf16> get responseText {
+    final retValuePtr = calloc<Pointer<Utf16>>();
+
+    try {
+      final hr = ptr.ref.vtable
+          .elementAt(16)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, Pointer<Pointer<Utf16>> body)>>>()
+          .value
+          .asFunction<
+              int Function(Pointer,
+                  Pointer<Pointer<Utf16>> body)>()(ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      final retValue = retValuePtr.value;
+      return retValue;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  VARIANT get responseBody {
+    final retValuePtr = calloc<VARIANT>();
+
+    try {
+      final hr = ptr.ref.vtable
+              .elementAt(17)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          Int32 Function(Pointer, Pointer<VARIANT> body)>>>()
+              .value
+              .asFunction<int Function(Pointer, Pointer<VARIANT> body)>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      final retValue = retValuePtr.ref;
+      return retValue;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  VARIANT get responseStream {
+    final retValuePtr = calloc<VARIANT>();
+
+    try {
+      final hr = ptr.ref.vtable
+              .elementAt(18)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          Int32 Function(Pointer, Pointer<VARIANT> body)>>>()
+              .value
+              .asFunction<int Function(Pointer, Pointer<VARIANT> body)>()(
+          ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      final retValue = retValuePtr.ref;
+      return retValue;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  int get_Option(int option, VARIANT value) => ptr.ref.vtable
+          .elementAt(19)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, Int32 option, VARIANT value)>>>()
+          .value
+          .asFunction<int Function(Pointer, int option, VARIANT value)>()(
+      ptr.ref.lpVtbl, option, value);
+
+  int put_Option(int option, VARIANT value) => ptr.ref.vtable
+          .elementAt(20)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      Int32 Function(Pointer, Int32 option, VARIANT value)>>>()
+          .value
+          .asFunction<int Function(Pointer, int option, VARIANT value)>()(
+      ptr.ref.lpVtbl, option, value);
+
+  int waitForResponse(VARIANT timeout, Pointer<Int16> succeeded) => ptr
+      .ref.vtable
+      .elementAt(21)
+      .cast<
+          Pointer<
+              NativeFunction<
+                  Int32 Function(
+                      Pointer, VARIANT timeout, Pointer<Int16> succeeded)>>>()
+      .value
+      .asFunction<
+          int Function(Pointer, VARIANT timeout,
+              Pointer<Int16> succeeded)>()(ptr.ref.lpVtbl, timeout, succeeded);
+
+  int abort() => ptr.ref.vtable
+      .elementAt(22)
+      .cast<Pointer<NativeFunction<Int32 Function(Pointer)>>>()
+      .value
+      .asFunction<int Function(Pointer)>()(ptr.ref.lpVtbl);
+
+  int setTimeouts(int resolveTimeout, int connectTimeout, int sendTimeout,
+          int receiveTimeout) =>
+      ptr.ref.vtable
+              .elementAt(23)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          Int32 Function(
+                              Pointer,
+                              Int32 resolveTimeout,
+                              Int32 connectTimeout,
+                              Int32 sendTimeout,
+                              Int32 receiveTimeout)>>>()
+              .value
+              .asFunction<
+                  int Function(Pointer, int resolveTimeout, int connectTimeout,
+                      int sendTimeout, int receiveTimeout)>()(ptr.ref.lpVtbl,
+          resolveTimeout, connectTimeout, sendTimeout, receiveTimeout);
+
+  int setClientCertificate(Pointer<Utf16> clientCertificate) =>
+      ptr.ref.vtable
+              .elementAt(24)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          Int32 Function(
+                              Pointer, Pointer<Utf16> clientCertificate)>>>()
+              .value
+              .asFunction<
+                  int Function(Pointer, Pointer<Utf16> clientCertificate)>()(
+          ptr.ref.lpVtbl, clientCertificate);
+
+  int setAutoLogonPolicy(int autoLogonPolicy) => ptr.ref.vtable
+          .elementAt(25)
+          .cast<Pointer<NativeFunction<Int32 Function(Pointer, Int32)>>>()
+          .value
+          .asFunction<int Function(Pointer, int autoLogonPolicy)>()(
+      ptr.ref.lpVtbl, autoLogonPolicy);
+}
+
+/// @nodoc
+const CLSID_WinHttpRequest = '{2087c2f4-2cef-4953-a8ab-66779b670495}';
+
+/// {@category com}
+class WinHttpRequest extends IWinHttpRequest {
+  WinHttpRequest(super.ptr);
+
+  factory WinHttpRequest.createInstance() => WinHttpRequest(
+      COMObject.createFromID(CLSID_WinHttpRequest, IID_IWinHttpRequest));
+}

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -10715,3 +10715,126 @@ const UIA_IsVirtualizedItemPatternAvailablePropertyId = 30109;
 /// Identifies the IsWindowPatternAvailable property, which indicates whether
 /// the Window control pattern is available for the automation element.
 const UIA_IsWindowPatternAvailablePropertyId = 30044;
+
+/// Possible settings for the Automatic Logon Policy.
+///
+/// {@category Enum}
+class WinHttpRequestAutoLogonPolicy {
+  /// An authenticated log on, using the default credentials, is performed for
+  /// all requests.
+  static const AutoLogonPolicy_Always = 0;
+
+  /// An authenticated log on, using the default credentials, is performed only
+  /// for requests on the local intranet. The local intranet is considered to
+  /// be any server on the proxy bypass list in the current proxy configuration.
+  static const AutoLogonPolicy_OnlyIfBypassProxy = 1;
+
+  /// Authentication is not used automatically.
+  static const AutoLogonPolicy_Never = 2;
+}
+
+/// Options that can be set or retrieved for the current WinHTTP session.
+///
+/// {@category Enum}
+class WinHttpRequestOption {
+  /// Sets or retrieves a VARIANT that contains the user agent string.
+  static const WinHttpRequestOption_UserAgentString = 0;
+
+  /// Retrieves a VARIANT that contains the URL of the resource.
+  static const WinHttpRequestOption_URL = 1;
+
+  /// Sets or retrieves a VARIANT that identifies the code page for the URL
+  /// string.
+  static const WinHttpRequestOption_URLCodePage = 2;
+
+  /// Sets or retrieves a VARIANT that indicates whether percent characters in
+  /// the URL string are converted to an escape sequence.
+  static const WinHttpRequestOption_EscapePercentInURL = 3;
+
+  /// Sets or retrieves a VARIANT that indicates which server certificate
+  /// errors should be ignored.
+  static const WinHttpRequestOption_SslErrorIgnoreFlags = 4;
+
+  /// Sets a VARIANT that specifies the client certificate that is sent to a
+  /// server for authentication.
+  static const WinHttpRequestOption_SelectCertificate = 5;
+
+  /// Sets or retrieves a VARIANT that indicates whether requests are
+  /// automatically redirected when the server specifies a new location for the
+  /// resource.
+  static const WinHttpRequestOption_EnableRedirects = 6;
+
+  /// Sets or retrieves a VARIANT that indicates whether unsafe characters in
+  /// the path and query components of a URL are converted to escape sequences.
+  static const WinHttpRequestOption_UrlEscapeDisable = 7;
+
+  /// Sets or retrieves a VARIANT that indicates whether unsafe characters in
+  /// the query component of the URL are converted to escape sequences.
+  static const WinHttpRequestOption_UrlEscapeDisableQuery = 8;
+
+  /// Sets or retrieves a VARIANT that indicates which secure protocols can be
+  /// used.
+  static const WinHttpRequestOption_SecureProtocols = 9;
+
+  /// Sets or retrieves a VARIANT that indicates whether tracing is currently
+  /// enabled.
+  static const WinHttpRequestOption_EnableTracing = 10;
+
+  /// Controls whether the WinHttpRequest object temporarily reverts client
+  /// impersonation for the duration of the SSL certificate authentication
+  /// operations.
+  static const WinHttpRequestOption_RevertImpersonationOverSsl = 11;
+
+  /// Controls whether or not WinHTTP allows redirects.
+  static const WinHttpRequestOption_EnableHttpsToHttpRedirects = 12;
+
+  /// Enables or disables support for Passport authentication.
+  static const WinHttpRequestOption_EnablePassportAuthentication = 13;
+
+  /// Sets or retrieves the maximum number of redirects that WinHTTP follows;
+  /// the default is 10.
+  static const WinHttpRequestOption_MaxAutomaticRedirects = 14;
+
+  /// Sets or retrieves a bound set on the maximum size of the header portion
+  /// of the server's response.
+  static const WinHttpRequestOption_MaxResponseHeaderSize = 15;
+
+  /// Sets or retrieves a bound on the amount of data that will be drained from
+  /// responses in order to reuse a connection.
+  static const WinHttpRequestOption_MaxResponseDrainSize = 16;
+
+  /// Sets or retrieves a boolean value that indicates whether HTTP/1.1 or
+  /// HTTP/1.0 should be used.
+  static const WinHttpRequestOption_EnableHttp1_1 = 17;
+
+  /// Enables server certificate revocation checking during SSL negotiation.
+  static const WinHttpRequestOption_EnableCertificateRevocationCheck = 18;
+}
+
+// -----------------------------------------------------------------------------
+// WinHttpRequest PROXYSETTING flags
+// -----------------------------------------------------------------------------
+
+/// Default proxy setting. Equivalent to HTTPREQUEST_PROXYSETTING_PRECONFIG.
+const HTTPREQUEST_PROXYSETTING_DEFAULT = 0;
+
+/// Indicates that the proxy settings should be obtained from the registry.
+const HTTPREQUEST_PROXYSETTING_PRECONFIG = 0;
+
+/// Indicates that all HTTP and HTTPS servers should be accessed directly.
+const HTTPREQUEST_PROXYSETTING_DIRECT = 1;
+
+/// When HTTPREQUEST_PROXYSETTING_PROXY is specified, varProxyServer should be
+/// set to a proxy server string and varBypassList should be set to a domain
+/// bypass list string.
+const HTTPREQUEST_PROXYSETTING_PROXY = 2;
+
+// -----------------------------------------------------------------------------
+// WinHttpRequest SETCREDENTIALS flags
+// -----------------------------------------------------------------------------
+
+/// Credentials are passed to a server.
+const HTTPREQUEST_SETCREDENTIALS_FOR_SERVER = 0;
+
+/// Credentials are passed to a proxy.
+const HTTPREQUEST_SETCREDENTIALS_FOR_PROXY = 1;

--- a/lib/win32.dart
+++ b/lib/win32.dart
@@ -291,3 +291,4 @@ export 'src/com/iwbemobjectaccess.dart';
 export 'src/com/iwbemrefresher.dart';
 export 'src/com/iwbemservices.dart';
 export 'src/com/iwebauthenticationcoremanagerinterop.dart';
+export 'src/com/iwinhttprequest.dart';


### PR DESCRIPTION
Fixes #714

I had to write the bindings for this interface myself since it was not included in the Windows Metadata file. Additionally, I've included an example showing how to use these APIs to send an HTTP request.

@lublak please take a look and let me know if you see something missing.