### PR TITLE
Fix the Dart representation of the `VARIANT` structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.6
+
+- Fix the Dart representation of the `VARIANT` structure (#736)
+
 ## 5.0.5
 
 - Add `GetRestrictedErrorInfo` and `IRestrictedErrorInfo` (#732)

--- a/lib/src/variant.dart
+++ b/lib/src/variant.dart
@@ -35,7 +35,7 @@ import 'win32/oleaut32.g.dart';
 
 sealed class _VARIANT_Anonymous_3 extends Struct {
   external Pointer pvRecord;
-  external COMObject pRecInfo;
+  external VTablePointer pRecInfo;
 }
 
 sealed class _VARIANT_Anonymous_2 extends Union {
@@ -63,8 +63,8 @@ sealed class _VARIANT_Anonymous_2 extends Union {
   @Double()
   external double date;
   external Pointer<Utf16> bstrVal;
-  external COMObject punkVal;
-  external COMObject pdispVal;
+  external VTablePointer punkVal;
+  external VTablePointer pdispVal;
   external Pointer/*<SAFEARRAY>*/ parray;
   external Pointer<Uint8> pbVal;
   external Pointer<Int16> piVal;
@@ -211,17 +211,17 @@ base class VARIANT extends Struct {
 
   // IUnknown
   IUnknown get punkVal => IUnknown(calloc<COMObject>()
-    ..ref = __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.punkVal);
+    ..ref.lpVtbl = __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.punkVal);
   set punkVal(IUnknown value) =>
       __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.punkVal =
-          value.ptr.ref;
+          value.ptr.ref.lpVtbl;
 
   // IDispatch
   IDispatch get pdispVal => IDispatch(calloc<COMObject>()
-    ..ref = __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.pdispVal);
+    ..ref.lpVtbl = __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.pdispVal);
   set pdispVal(IDispatch value) =>
       __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.pdispVal =
-          value.ptr.ref;
+          value.ptr.ref.lpVtbl;
 
   Pointer get parray =>
       __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.parray;
@@ -396,10 +396,10 @@ base class VARIANT extends Struct {
       .__VARIANT_NAME_2.__VARIANT_NAME_3.__VARIANT_NAME_4.pvRecord = value;
 
   Pointer<COMObject> get pRecInfo => calloc<COMObject>()
-    ..ref = __VARIANT_NAME_1
+    ..ref.lpVtbl = __VARIANT_NAME_1
         .__VARIANT_NAME_2.__VARIANT_NAME_3.__VARIANT_NAME_4.pRecInfo;
-  set pRecInfo(Pointer<COMObject> value) => __VARIANT_NAME_1
-      .__VARIANT_NAME_2.__VARIANT_NAME_3.__VARIANT_NAME_4.pRecInfo = value.ref;
+  set pRecInfo(Pointer<COMObject> value) => __VARIANT_NAME_1.__VARIANT_NAME_2
+      .__VARIANT_NAME_3.__VARIANT_NAME_4.pRecInfo = value.ref.lpVtbl;
 }
 
 /// The PROPVARIANT structure is used in the ReadMultiple and WriteMultiple

--- a/lib/src/variant.dart
+++ b/lib/src/variant.dart
@@ -35,7 +35,7 @@ import 'win32/oleaut32.g.dart';
 
 sealed class _VARIANT_Anonymous_3 extends Struct {
   external Pointer pvRecord;
-  external Pointer<COMObject> pRecInfo;
+  external COMObject pRecInfo;
 }
 
 sealed class _VARIANT_Anonymous_2 extends Union {
@@ -63,8 +63,8 @@ sealed class _VARIANT_Anonymous_2 extends Union {
   @Double()
   external double date;
   external Pointer<Utf16> bstrVal;
-  external Pointer<COMObject> punkVal;
-  external Pointer<COMObject> pdispVal;
+  external COMObject punkVal;
+  external COMObject pdispVal;
   external Pointer/*<SAFEARRAY>*/ parray;
   external Pointer<Uint8> pbVal;
   external Pointer<Int16> piVal;
@@ -210,16 +210,18 @@ base class VARIANT extends Struct {
       __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.bstrVal = value;
 
   // IUnknown
-  IUnknown get punkVal =>
-      IUnknown(__VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.punkVal);
+  IUnknown get punkVal => IUnknown(calloc<COMObject>()
+    ..ref = __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.punkVal);
   set punkVal(IUnknown value) =>
-      __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.punkVal = value.ptr;
+      __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.punkVal =
+          value.ptr.ref;
 
   // IDispatch
-  IDispatch get pdispVal =>
-      IDispatch(__VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.pdispVal);
+  IDispatch get pdispVal => IDispatch(calloc<COMObject>()
+    ..ref = __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.pdispVal);
   set pdispVal(IDispatch value) =>
-      __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.pdispVal = value.ptr;
+      __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.pdispVal =
+          value.ptr.ref;
 
   Pointer get parray =>
       __VARIANT_NAME_1.__VARIANT_NAME_2.__VARIANT_NAME_3.parray;
@@ -393,10 +395,11 @@ base class VARIANT extends Struct {
   set pvRecord(Pointer value) => __VARIANT_NAME_1
       .__VARIANT_NAME_2.__VARIANT_NAME_3.__VARIANT_NAME_4.pvRecord = value;
 
-  Pointer<COMObject> get pRecInfo => __VARIANT_NAME_1
-      .__VARIANT_NAME_2.__VARIANT_NAME_3.__VARIANT_NAME_4.pRecInfo;
+  Pointer<COMObject> get pRecInfo => calloc<COMObject>()
+    ..ref = __VARIANT_NAME_1
+        .__VARIANT_NAME_2.__VARIANT_NAME_3.__VARIANT_NAME_4.pRecInfo;
   set pRecInfo(Pointer<COMObject> value) => __VARIANT_NAME_1
-      .__VARIANT_NAME_2.__VARIANT_NAME_3.__VARIANT_NAME_4.pRecInfo = value;
+      .__VARIANT_NAME_2.__VARIANT_NAME_3.__VARIANT_NAME_4.pRecInfo = value.ref;
 }
 
 /// The PROPVARIANT structure is used in the ReadMultiple and WriteMultiple

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: win32
 description: A Dart library for accessing common Win32 APIs using FFI. No C required!
-version: 5.0.5
+version: 5.0.6
 homepage: https://win32.pub
 repository: https://github.com/dart-windows/win32
 issue_tracker: https://github.com/dart-windows/win32/issues

--- a/test/variant_test.dart
+++ b/test/variant_test.dart
@@ -22,7 +22,7 @@ void main() {
       free(variant);
     });
 
-    test('IUnknown', () {
+    test('pointer to an object that implements the IUnknown interface', () {
       final spVoice = SpVoice.createInstance();
       final spellChecker = SpellCheckerFactory.createInstance()..addRef();
 
@@ -46,7 +46,7 @@ void main() {
       free(variant);
     });
 
-    test('Pointer to IUnknown', () {
+    test('reference to an IUnknown interface pointer', () {
       final spVoice = SpVoice.createInstance();
       final spellChecker = SpellCheckerFactory.createInstance()..addRef();
 

--- a/test/variant_test.dart
+++ b/test/variant_test.dart
@@ -7,164 +7,229 @@ import 'package:test/test.dart';
 import 'package:win32/win32.dart';
 
 void main() {
-  test('Variant creation', () {
-    final variant = calloc<VARIANT>();
-    VariantInit(variant);
-    expect(variant.ref.vt, equals(VARENUM.VT_EMPTY));
-    free(variant);
-  });
+  group('Variant', () {
+    setUp(() {
+      final hr = CoInitializeEx(
+          nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+      if (FAILED(hr)) throw WindowsException(hr);
+    });
 
-  test('Variant time representation from DOS date/time', () {
-    // MS-DOS dates are YYYYYYYMMMMDDDDD, where Y is offset from 1980
-    const theDate = 29 + (02 << 5) + (24 << 9); // Feb 29th, 2004
-    final pvTime = calloc<DOUBLE>();
-    expect(DosDateTimeToVariantTime(theDate, NULL, pvTime), equals(TRUE));
+    test('creation', () {
+      final variant = calloc<VARIANT>();
+      VariantInit(variant);
+      expect(variant.ref.vt, equals(VARENUM.VT_EMPTY));
+      VariantClear(variant);
+      free(variant);
+    });
 
-    final lpSystemTime = calloc<SYSTEMTIME>();
-    expect(VariantTimeToSystemTime(pvTime.value, lpSystemTime), equals(TRUE));
-    expect(lpSystemTime.ref.wYear, equals(2004));
-    expect(lpSystemTime.ref.wMonth, equals(2));
-    expect(lpSystemTime.ref.wDay, equals(29));
+    test('IUnknown', () {
+      final spVoice = SpVoice.createInstance();
+      final spellChecker = SpellCheckerFactory.createInstance()..addRef();
 
-    final dosDate = calloc<USHORT>();
-    final dosTime = calloc<USHORT>();
-    expect(
-        VariantTimeToDosDateTime(pvTime.value, dosDate, dosTime), equals(TRUE));
-    expect(dosDate.value, equals(theDate));
+      final variant = calloc<VARIANT>();
+      VariantInit(variant);
+      variant.ref.vt = VARENUM.VT_UNKNOWN;
+      variant.ref.punkVal = spVoice;
 
-    free(pvTime);
-    free(lpSystemTime);
-    free(dosDate);
-    free(dosTime);
-  });
+      final unk = variant.ref.punkVal;
+      expect(unk.ptr.address, isNonZero);
+      expect(unk.ptr.ref.isNull, isFalse);
+      expect(unk.addRef(), equals(2));
 
-  test('LONG Variant', () {
-    final intVar = calloc<VARIANT>();
-    VariantInit(intVar);
-    intVar.ref.vt = VARENUM.VT_I4;
-    intVar.ref.lVal = -2147483648;
-    expect(intVar.ref.lVal, equals(-2147483648));
+      variant.ref.punkVal = spellChecker;
+      final unk2 = variant.ref.punkVal;
+      expect(unk2.ptr.address, isNonZero);
+      expect(unk2.ptr.ref.isNull, isFalse);
+      expect(unk2.addRef(), equals(3));
 
-    intVar.ref.lVal = 2147483647;
-    expect(intVar.ref.lVal, equals(2147483647));
+      VariantClear(variant);
+      free(variant);
+    });
 
-    intVar.ref.lVal = 0x80000000;
-    expect(intVar.ref.lVal, equals(-2147483648));
+    test('Pointer to IUnknown', () {
+      final spVoice = SpVoice.createInstance();
+      final spellChecker = SpellCheckerFactory.createInstance()..addRef();
 
-    free(intVar);
-  });
+      final variant = calloc<VARIANT>();
+      VariantInit(variant);
+      variant.ref.vt = VARENUM.VT_UNKNOWN | VARENUM.VT_BYREF;
+      variant.ref.ppunkVal = spVoice.ptr.cast();
 
-  test('INT Variant', () {
-    final intVar = calloc<VARIANT>();
-    VariantInit(intVar);
-    intVar.ref.vt = VARENUM.VT_I4;
-    intVar.ref.intVal = -2147483648;
-    expect(intVar.ref.intVal, equals(-2147483648));
+      final unk = IUnknown(variant.ref.ppunkVal.cast());
+      expect(unk.ptr.address, isNonZero);
+      expect(unk.ptr.ref.isNull, isFalse);
+      expect(unk.addRef(), equals(2));
 
-    intVar.ref.intVal = 2147483647;
-    expect(intVar.ref.intVal, equals(2147483647));
+      variant.ref.ppunkVal = spellChecker.ptr.cast();
+      final unk2 = IUnknown(variant.ref.ppunkVal.cast());
+      expect(unk2.ptr.address, isNonZero);
+      expect(unk2.ptr.ref.isNull, isFalse);
+      expect(unk2.addRef(), equals(3));
 
-    intVar.ref.intVal = 0x80000000;
-    expect(intVar.ref.intVal, equals(-2147483648));
+      VariantClear(variant);
+      free(variant);
+    });
 
-    free(intVar);
-  });
+    test('time representation from DOS date/time', () {
+      // MS-DOS dates are YYYYYYYMMMMDDDDD, where Y is offset from 1980
+      const theDate = 29 + (02 << 5) + (24 << 9); // Feb 29th, 2004
+      final pvTime = calloc<DOUBLE>();
+      expect(DosDateTimeToVariantTime(theDate, NULL, pvTime), equals(TRUE));
 
-  test('ULONGLONG Variant', () {
-    final bigint = calloc<VARIANT>();
-    VariantInit(bigint);
-    bigint.ref.vt = VARENUM.VT_UI8;
-    bigint.ref.ullVal = BigInt.zero;
-    expect(bigint.ref.ullVal, equals(BigInt.from(0)));
+      final lpSystemTime = calloc<SYSTEMTIME>();
+      expect(VariantTimeToSystemTime(pvTime.value, lpSystemTime), equals(TRUE));
+      expect(lpSystemTime.ref.wYear, equals(2004));
+      expect(lpSystemTime.ref.wMonth, equals(2));
+      expect(lpSystemTime.ref.wDay, equals(29));
 
-    bigint.ref.ullVal = BigInt.parse('18446744073709551615');
-    final uint64Max = BigInt.parse('FFFFFFFFFFFFFFFF', radix: 16);
-    expect(bigint.ref.ullVal, equals(uint64Max));
+      final dosDate = calloc<USHORT>();
+      final dosTime = calloc<USHORT>();
+      expect(VariantTimeToDosDateTime(pvTime.value, dosDate, dosTime),
+          equals(TRUE));
+      expect(dosDate.value, equals(theDate));
 
-    bigint.ref.ullVal = BigInt.parse('8000000000000000', radix: 16);
-    final testValue2 = BigInt.parse('9223372036854775808');
-    expect(bigint.ref.ullVal, equals(testValue2));
+      free(pvTime);
+      free(lpSystemTime);
+      free(dosDate);
+      free(dosTime);
+    });
 
-    free(bigint);
-  });
+    test('LONG', () {
+      final intVar = calloc<VARIANT>();
+      VariantInit(intVar);
+      intVar.ref.vt = VARENUM.VT_I4;
+      intVar.ref.lVal = -2147483648;
+      expect(intVar.ref.lVal, equals(-2147483648));
 
-  test('ULONG Variant', () {
-    final intVar = calloc<VARIANT>();
-    VariantInit(intVar);
-    intVar.ref.vt = VARENUM.VT_UI4;
-    intVar.ref.ulVal = 0;
-    expect(intVar.ref.ulVal, equals(0));
+      intVar.ref.lVal = 2147483647;
+      expect(intVar.ref.lVal, equals(2147483647));
 
-    intVar.ref.ulVal = 4294967295;
-    expect(intVar.ref.ulVal, equals(4294967295));
+      intVar.ref.lVal = 0x80000000;
+      expect(intVar.ref.lVal, equals(-2147483648));
 
-    intVar.ref.ulVal = 0x80000000;
-    expect(intVar.ref.ulVal, equals(2147483648));
+      VariantClear(intVar);
+      free(intVar);
+    });
 
-    free(intVar);
-  });
+    test('INT', () {
+      final intVar = calloc<VARIANT>();
+      VariantInit(intVar);
+      intVar.ref.vt = VARENUM.VT_I4;
+      intVar.ref.intVal = -2147483648;
+      expect(intVar.ref.intVal, equals(-2147483648));
 
-  test('UINT Variant', () {
-    final intVar = calloc<VARIANT>();
-    VariantInit(intVar);
-    intVar.ref.vt = VARENUM.VT_UI4;
-    intVar.ref.uintVal = 0;
-    expect(intVar.ref.uintVal, equals(0));
+      intVar.ref.intVal = 2147483647;
+      expect(intVar.ref.intVal, equals(2147483647));
 
-    intVar.ref.uintVal = 4294967295;
-    expect(intVar.ref.uintVal, equals(4294967295));
+      intVar.ref.intVal = 0x80000000;
+      expect(intVar.ref.intVal, equals(-2147483648));
 
-    intVar.ref.uintVal = 0x80000000;
-    expect(intVar.ref.uintVal, equals(2147483648));
+      VariantClear(intVar);
+      free(intVar);
+    });
 
-    free(intVar);
-  });
+    test('ULONGLONG', () {
+      final bigint = calloc<VARIANT>();
+      VariantInit(bigint);
+      bigint.ref.vt = VARENUM.VT_UI8;
+      bigint.ref.ullVal = BigInt.zero;
+      expect(bigint.ref.ullVal, equals(BigInt.from(0)));
 
-  test('SHORT Variant', () {
-    final intVar = calloc<VARIANT>();
-    VariantInit(intVar);
-    intVar.ref.vt = VARENUM.VT_I2;
-    intVar.ref.iVal = -32768;
-    expect(intVar.ref.iVal, equals(-32768));
+      bigint.ref.ullVal = BigInt.parse('18446744073709551615');
+      final uint64Max = BigInt.parse('FFFFFFFFFFFFFFFF', radix: 16);
+      expect(bigint.ref.ullVal, equals(uint64Max));
 
-    intVar.ref.iVal = 32767;
-    expect(intVar.ref.iVal, equals(32767));
+      bigint.ref.ullVal = BigInt.parse('8000000000000000', radix: 16);
+      final testValue2 = BigInt.parse('9223372036854775808');
+      expect(bigint.ref.ullVal, equals(testValue2));
 
-    intVar.ref.iVal = 0x8000;
-    expect(intVar.ref.iVal, equals(-32768));
+      VariantClear(bigint);
+      free(bigint);
+    });
 
-    free(intVar);
-  });
-  test('BYTE Variant', () {
-    final intVar = calloc<VARIANT>();
-    VariantInit(intVar);
-    intVar.ref.vt = VARENUM.VT_UI1;
-    intVar.ref.bVal = 0;
-    expect(intVar.ref.bVal, equals(0));
+    test('ULONG', () {
+      final intVar = calloc<VARIANT>();
+      VariantInit(intVar);
+      intVar.ref.vt = VARENUM.VT_UI4;
+      intVar.ref.ulVal = 0;
+      expect(intVar.ref.ulVal, equals(0));
 
-    intVar.ref.bVal = 255;
-    expect(intVar.ref.bVal, equals(255));
+      intVar.ref.ulVal = 4294967295;
+      expect(intVar.ref.ulVal, equals(4294967295));
 
-    intVar.ref.bVal = 0x80;
-    expect(intVar.ref.bVal, equals(128));
+      intVar.ref.ulVal = 0x80000000;
+      expect(intVar.ref.ulVal, equals(2147483648));
 
-    free(intVar);
-  });
+      VariantClear(intVar);
+      free(intVar);
+    });
 
-  test('USHORT Variant', () {
-    final intVar = calloc<VARIANT>();
-    VariantInit(intVar);
-    intVar.ref.vt = VARENUM.VT_UI2;
-    intVar.ref.uiVal = 0;
-    expect(intVar.ref.uiVal, equals(0));
+    test('UINT', () {
+      final intVar = calloc<VARIANT>();
+      VariantInit(intVar);
+      intVar.ref.vt = VARENUM.VT_UI4;
+      intVar.ref.uintVal = 0;
+      expect(intVar.ref.uintVal, equals(0));
 
-    intVar.ref.uiVal = 65535;
-    expect(intVar.ref.uiVal, equals(65535));
+      intVar.ref.uintVal = 4294967295;
+      expect(intVar.ref.uintVal, equals(4294967295));
 
-    intVar.ref.uiVal = 0x8000;
-    expect(intVar.ref.uiVal, equals(32768));
+      intVar.ref.uintVal = 0x80000000;
+      expect(intVar.ref.uintVal, equals(2147483648));
 
-    free(intVar);
+      VariantClear(intVar);
+      free(intVar);
+    });
+
+    test('SHORT', () {
+      final intVar = calloc<VARIANT>();
+      VariantInit(intVar);
+      intVar.ref.vt = VARENUM.VT_I2;
+      intVar.ref.iVal = -32768;
+      expect(intVar.ref.iVal, equals(-32768));
+
+      intVar.ref.iVal = 32767;
+      expect(intVar.ref.iVal, equals(32767));
+
+      intVar.ref.iVal = 0x8000;
+      expect(intVar.ref.iVal, equals(-32768));
+
+      VariantClear(intVar);
+      free(intVar);
+    });
+    test('BYTE', () {
+      final intVar = calloc<VARIANT>();
+      VariantInit(intVar);
+      intVar.ref.vt = VARENUM.VT_UI1;
+      intVar.ref.bVal = 0;
+      expect(intVar.ref.bVal, equals(0));
+
+      intVar.ref.bVal = 255;
+      expect(intVar.ref.bVal, equals(255));
+
+      intVar.ref.bVal = 0x80;
+      expect(intVar.ref.bVal, equals(128));
+
+      VariantClear(intVar);
+      free(intVar);
+    });
+
+    test('USHORT', () {
+      final intVar = calloc<VARIANT>();
+      VariantInit(intVar);
+      intVar.ref.vt = VARENUM.VT_UI2;
+      intVar.ref.uiVal = 0;
+      expect(intVar.ref.uiVal, equals(0));
+
+      intVar.ref.uiVal = 65535;
+      expect(intVar.ref.uiVal, equals(65535));
+
+      intVar.ref.uiVal = 0x8000;
+      expect(intVar.ref.uiVal, equals(32768));
+
+      VariantClear(intVar);
+      free(intVar);
+    });
   });
 
   test('BSTR allocation', () {


### PR DESCRIPTION
Fixes #735

Some fields of the `VARIANT` were misrepresented, leading to the crash reported in issue #735. Added some tests to make sure the new representation of these fields is working properly.