### PR TITLE
Migrate to `winmd` v4

### DIFF
--- a/tool/win32gen/example/example.dart
+++ b/tool/win32gen/example/example.dart
@@ -1,9 +1,7 @@
 import 'package:win32gen/win32gen.dart';
 import 'package:winmd/winmd.dart';
 
-final scope = MetadataStore.getWin32Scope();
-
-void printStruct() {
+void printStruct(Scope scope) {
   final struct = scope
       .findTypeDef('Windows.Win32.NetworkManagement.Dhcp.DHCP_ALL_OPTIONS');
   if (struct != null) {
@@ -12,7 +10,7 @@ void printStruct() {
   }
 }
 
-void printFunction() {
+void printFunction(Scope scope) {
   final typeDef =
       scope.findTypeDef('Windows.Win32.System.StationsAndDesktops.Apis');
   final method = typeDef?.findMethod('BroadcastSystemMessageW');
@@ -23,7 +21,7 @@ void printFunction() {
   }
 }
 
-void printCallback() {
+void printCallback(Scope scope) {
   final callback = scope
       .findTypeDef('Windows.Win32.System.StationsAndDesktops.DESKTOPENUMPROCW');
 
@@ -33,7 +31,7 @@ void printCallback() {
   }
 }
 
-void printComMethod() {
+void printComMethod(Scope scope) {
   final interface =
       scope.findTypeDef('Windows.Win32.UI.Shell.IDesktopWallpaper');
   final method = interface?.findMethod('SetWallpaper');
@@ -44,7 +42,7 @@ void printComMethod() {
   }
 }
 
-void printComGetProperty() {
+void printComGetProperty(Scope scope) {
   final interface = scope.findTypeDef(
       'Windows.Win32.Security.Cryptography.Certificates.ICEnroll4');
   final method = interface?.findMethod('get_IncludeSubjectKeyID');
@@ -55,7 +53,7 @@ void printComGetProperty() {
   }
 }
 
-void printComSetProperty() {
+void printComSetProperty(Scope scope) {
   final interface = scope.findTypeDef(
       'Windows.Win32.Networking.ActiveDirectory.IADsPropertyEntry');
   final method = interface?.findMethod('put_Name');
@@ -66,7 +64,7 @@ void printComSetProperty() {
   }
 }
 
-void printComInterface() {
+void printComInterface(Scope scope) {
   final interface =
       scope.findTypeDef('Windows.Win32.Media.DirectShow.ITuningSpace');
 
@@ -76,7 +74,7 @@ void printComInterface() {
   }
 }
 
-void printComClass() {
+void printComClass(Scope scope) {
   final comClass = scope.findTypeDef('Windows.Win32.UI.Shell.IFileOpenDialog');
 
   if (comClass != null) {
@@ -85,6 +83,9 @@ void printComClass() {
   }
 }
 
-void main() {
-  printStruct();
+void main() async {
+  final scope =
+      await MetadataStore.loadWin32Metadata(version: win32MetadataVersion);
+  printStruct(scope);
+  MetadataStore.close();
 }

--- a/tool/win32gen/lib/src/constants.dart
+++ b/tool/win32gen/lib/src/constants.dart
@@ -1,0 +1,7 @@
+/// The version of the Win32 metadata used for generating projections and
+/// running tests.
+///
+/// This version should only be updated when preparing for a major release of
+/// the `win32` package, as it may introduce breaking changes in the generated
+/// code.
+const win32MetadataVersion = '51.0.33-preview';

--- a/tool/win32gen/lib/win32gen.dart
+++ b/tool/win32gen/lib/win32gen.dart
@@ -2,6 +2,8 @@
 /// metadata.
 library win32gen;
 
+export 'src/constants.dart';
+
 export 'src/model/exclusions.dart';
 export 'src/model/false_properties.dart';
 export 'src/model/functions.dart';

--- a/tool/win32gen/pubspec.yaml
+++ b/tool/win32gen/pubspec.yaml
@@ -3,7 +3,7 @@ description: Auto-generate Dart wrapper classes for the Win32 API using Windows 
 publish_to: none
 
 environment:
-  sdk: '^3.0.0'
+  sdk: '^3.1.0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -11,22 +11,19 @@ platforms:
 
 dependencies:
   # For formatting Dart code (APIs for performing dart format).
-  dart_style: ^2.3.1
+  dart_style: ^2.3.2
 
   # Foreign Function Interface extension methods
-  ffi: ^2.0.2
+  ffi: ^2.1.0
 
   # Help ensure that the code is well-written.
-  lints: ^2.1.0
+  lints: ^2.1.1
 
   # Running the test suite.
-  test: ^1.24.2
+  test: ^1.24.6
 
-  # Windows metadata for automatically generating API signatures. The
-  # relationship between these two packages is tightly coupled, since this
-  # package includes a specific version of the Win32 metadata, so we pin the
-  # dependency by version to avoid surprising conflicts.
-  winmd: 3.0.1
+  # Windows metadata for automatically generating API signatures.
+  winmd: ^4.0.1
 
   # Win32 itself
-  win32: ^5.0.3
+  win32: ^5.0.7

--- a/tool/win32gen/test/com_projection_test.dart
+++ b/tool/win32gen/test/com_projection_test.dart
@@ -5,7 +5,12 @@ import 'package:win32gen/win32gen.dart';
 import 'package:winmd/winmd.dart';
 
 void main() {
-  final scope = MetadataStore.getWin32Scope();
+  late Scope scope;
+
+  setUpAll(() async {
+    scope =
+        await MetadataStore.loadWin32Metadata(version: win32MetadataVersion);
+  });
 
   test('COM method strings are projected to Dart accurately', () {
     final iNetwork = scope
@@ -224,4 +229,6 @@ void main() {
     expect(next, isNot(isA<ComGetPropertyProjection>()));
     expect(next, isA<ComMethodProjection>());
   });
+
+  tearDownAll(MetadataStore.close);
 }

--- a/tool/win32gen/test/field_projection_test.dart
+++ b/tool/win32gen/test/field_projection_test.dart
@@ -5,9 +5,14 @@ import 'package:win32gen/win32gen.dart';
 import 'package:winmd/winmd.dart';
 
 void main() {
-  test('BOOL types are projected to int', () {
-    final scope = MetadataStore.getWin32Scope();
+  late Scope scope;
 
+  setUpAll(() async {
+    scope =
+        await MetadataStore.loadWin32Metadata(version: win32MetadataVersion);
+  });
+
+  test('BOOL types are projected to int', () {
     final typeDef =
         scope.findTypeDef('Windows.Win32.Graphics.Dwm.DWM_BLURBEHIND')!;
 
@@ -20,8 +25,6 @@ void main() {
   });
 
   test('Structs are projected appropriately', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typeDef = scope
         .findTypeDef('Windows.Win32.Media.Multimedia.YAMAHA_ADPCMWAVEFORMAT')!;
 
@@ -31,4 +34,6 @@ void main() {
     final fieldProjection = FieldProjection(fEnable);
     expect(fieldProjection.toString(), contains('external WAVEFORMATEX'));
   });
+
+  tearDownAll(MetadataStore.close);
 }

--- a/tool/win32gen/test/goldens_test.dart
+++ b/tool/win32gen/test/goldens_test.dart
@@ -8,10 +8,11 @@ import 'package:win32gen/win32gen.dart';
 import 'package:winmd/winmd.dart';
 
 void main() {
-  test('COM golden', () {
+  test('COM golden', () async {
     const typeToGenerate =
         'Windows.Win32.Networking.NetworkListManager.INetwork';
-    final scope = MetadataStore.getWin32Scope();
+    final scope =
+        await MetadataStore.loadWin32Metadata(version: win32MetadataVersion);
     final typeDef = scope.findTypeDef(typeToGenerate)!;
 
     final comTypesToGenerate = loadMap('com_types.json');
@@ -26,5 +27,7 @@ void main() {
 
     // Ignore whitespace to avoid \r\n vs. \n conflicts.
     expect(formattedDartClass, equalsIgnoringWhitespace(golden));
+
+    MetadataStore.close();
   });
 }

--- a/tool/win32gen/test/input_test.dart
+++ b/tool/win32gen/test/input_test.dart
@@ -5,10 +5,11 @@ import 'package:win32gen/win32gen.dart';
 import 'package:winmd/winmd.dart';
 
 void main() {
-  test('All functions in JSON file map to methods in Win32 metadata', () {
+  test('All functions in JSON file map to methods in Win32 metadata', () async {
     final functionsToGenerate = loadFunctionsFromJson();
 
-    final scope = MetadataStore.getWin32Scope();
+    final scope =
+        await MetadataStore.loadWin32Metadata(version: win32MetadataVersion);
     final apis =
         scope.typeDefs.where((typeDef) => typeDef.name.endsWith('Apis'));
 
@@ -28,5 +29,7 @@ void main() {
             'the metadata. There were ${method.length} matching items.');
       }
     }
+
+    MetadataStore.close();
   }, skip: 'Waiting for Windows 11 on GitHub Actions hosted runners');
 }

--- a/tool/win32gen/test/struct_projection_test.dart
+++ b/tool/win32gen/test/struct_projection_test.dart
@@ -5,11 +5,16 @@ import 'package:win32gen/win32gen.dart';
 import 'package:winmd/winmd.dart';
 
 void main() {
+  late Scope scope;
+
+  setUpAll(() async {
+    scope =
+        await MetadataStore.loadWin32Metadata(version: win32MetadataVersion);
+  });
+
   test('Packed structs projected correctly 1', () {
     // DWM_BLURBEHIND contains a BOOL, which appears in Win32 metadata as a
     // struct, but that shouldn't stop it being packed.
-    final scope = MetadataStore.getWin32Scope();
-
     final typeDef =
         scope.findTypeDef('Windows.Win32.Graphics.Dwm.DWM_BLURBEHIND');
 
@@ -19,8 +24,6 @@ void main() {
   });
 
   test('Packed structs projected correctly 2', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typeDef =
         scope.findTypeDef('Windows.Win32.Media.Multimedia.MCI_OPEN_PARMSW');
 
@@ -30,8 +33,6 @@ void main() {
   });
 
   test('Packed structs projected correctly 3', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typeDef = scope
         .findTypeDef('Windows.Win32.Media.Multimedia.YAMAHA_ADPCMWAVEFORMAT');
 
@@ -42,8 +43,6 @@ void main() {
   });
 
   test('Packed structs projected correctly 4', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typeDef =
         scope.findTypeDef('Windows.Win32.Devices.Bluetooth.SOCKADDR_BTH');
 
@@ -51,4 +50,6 @@ void main() {
     expect(structProjection.packingAlignment, equals(1));
     expect(structProjection.classPreamble, contains('@Packed(1)'));
   });
+
+  tearDownAll(MetadataStore.close);
 }

--- a/tool/win32gen/test/type_projection_test.dart
+++ b/tool/win32gen/test/type_projection_test.dart
@@ -5,9 +5,14 @@ import 'package:win32gen/win32gen.dart';
 import 'package:winmd/winmd.dart';
 
 void main() {
-  test('Simple int type', () {
-    final scope = MetadataStore.getWin32Scope();
+  late Scope scope;
 
+  setUpAll(() async {
+    scope =
+        await MetadataStore.loadWin32Metadata(version: win32MetadataVersion);
+  });
+
+  test('Simple int type', () {
     final typedef = scope.findTypeDef('Windows.Win32.System.Console.Apis');
     final api = typedef?.findMethod('GenerateConsoleCtrlEvent');
     expect(api, isNotNull);
@@ -20,8 +25,6 @@ void main() {
   });
 
   test('HANDLE type', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef =
         scope.findTypeDef('Windows.Win32.UI.WindowsAndMessaging.Apis');
     final api = typedef?.findMethod('CloseWindow');
@@ -35,8 +38,6 @@ void main() {
   });
 
   test('HRESULT type', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.System.Com.Apis');
     final api = typedef?.findMethod('CoInitialize');
     expect(api, isNotNull);
@@ -49,8 +50,6 @@ void main() {
   });
 
   test('CreatedHDC type', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.Graphics.Gdi.Apis');
     final api = typedef?.findMethod('CreateCompatibleDC');
     expect(api, isNotNull);
@@ -63,7 +62,6 @@ void main() {
   });
 
   test('PWSTR type', () {
-    final scope = MetadataStore.getWin32Scope();
     final typedef =
         scope.findTypeDef('Windows.Win32.UI.WindowsAndMessaging.Apis');
     final api = typedef?.findMethod('GetWindowTextW');
@@ -77,8 +75,6 @@ void main() {
   });
 
   test('LPSTR type', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef =
         scope.findTypeDef('Windows.Win32.UI.Input.KeyboardAndMouse.Apis');
     final api = typedef?.findMethod('GetKeyNameTextA');
@@ -93,8 +89,6 @@ void main() {
   });
 
   test('Pointer<T>', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef =
         scope.findTypeDef('Windows.Win32.UI.Input.KeyboardAndMouse.Apis');
     final api = typedef?.findMethod('GetKeyboardState');
@@ -109,8 +103,6 @@ void main() {
   });
 
   test('LPHANDLE-style parameters have the correct projection', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef =
         scope.findTypeDef('Windows.Win32.UI.WindowsAndMessaging.Apis');
     final api = typedef?.findMethod('CascadeWindows');
@@ -124,8 +116,6 @@ void main() {
   });
 
   test('Unicode string w/ double pointer', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.UI.Shell.Apis');
     final api = typedef?.findMethod('SHGetKnownFolderPath');
 
@@ -139,8 +129,6 @@ void main() {
   });
 
   test('Pointer<Pointer<T>>', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef =
         scope.findTypeDef('Windows.Win32.Security.Credentials.Apis');
     final api = typedef?.findMethod('CredReadW');
@@ -155,8 +143,6 @@ void main() {
   });
 
   test('COM interface parameter', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.System.Com.Apis');
     final api = typedef?.findMethod('CoSetProxyBlanket')!;
 
@@ -170,8 +156,6 @@ void main() {
   });
 
   test('Inherited COM interface parameter', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.System.Com.Apis');
     final api = typedef?.findMethod('CreateAntiMoniker')!;
 
@@ -185,8 +169,6 @@ void main() {
   });
 
   test('Pass pointers to COM interfaces', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.System.Com.Apis');
     final api = typedef?.findMethod('CoCreateInstance');
 
@@ -200,8 +182,6 @@ void main() {
   });
 
   test('Pass double pointers to COM interfaces', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.System.Ole.Apis');
     final api = typedef?.findMethod('GetActiveObject');
 
@@ -215,8 +195,6 @@ void main() {
   });
 
   test('OLECHAR is represented correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.Foundation.Apis');
     final api = typedef?.findMethod('SysAllocString')!;
 
@@ -229,8 +207,6 @@ void main() {
   });
 
   test('Callbacks are represented correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.Graphics.Gdi.Apis');
     final api = typedef?.findMethod('EnumFontFamiliesExW');
 
@@ -246,8 +222,6 @@ void main() {
   });
 
   test('Callbacks are represented correctly 2', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef =
         scope.findTypeDef('Windows.Win32.System.Diagnostics.Debug.Apis');
     final api = typedef?.findMethod('SymEnumSymbolsW');
@@ -265,8 +239,6 @@ void main() {
   });
 
   test('Pointers to structs are represented correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.UI.Controls.Dialogs.Apis');
     final api = typedef?.findMethod('ChooseFontW');
 
@@ -279,8 +251,6 @@ void main() {
   });
 
   test('Naked structs are represented correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.System.Threading.Apis');
     final api = typedef?.findMethod('InitializeProcThreadAttributeList');
 
@@ -295,8 +265,6 @@ void main() {
   });
 
   test('Enumeration params are represented correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.Graphics.Gdi.Apis');
     final api = typedef?.findMethod('CreateDIBitmap');
 
@@ -309,8 +277,6 @@ void main() {
   });
 
   test('Enumerations that are not 32-bit are represented correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.System.EventLog.Apis');
     final api = typedef?.findMethod('ReportEventW');
 
@@ -325,8 +291,6 @@ void main() {
   });
 
   test('Pointer<Enum> params are represented correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.System.Pipes.Apis');
     final api = typedef?.findMethod('GetNamedPipeInfo')!;
 
@@ -339,8 +303,6 @@ void main() {
   });
 
   test('Void returns are represented correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef =
         scope.findTypeDef('Windows.Win32.Security.Credentials.Apis');
     final api = typedef?.findMethod('CredFree');
@@ -355,8 +317,6 @@ void main() {
   });
 
   test('HANDLE should be projected as an IntPtr', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.System.Threading.Apis');
     final api = typedef?.findMethod('GetCurrentProcess');
 
@@ -373,8 +333,6 @@ void main() {
   });
 
   test('LARGE_INTEGER should be projected as an Int64', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.Storage.FileSystem.Apis');
     final api = typedef?.findMethod('SetFilePointerEx');
 
@@ -388,8 +346,6 @@ void main() {
   });
 
   test('Struct array field projects correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final procInfo = scope.findTypeDef('Windows.Win32.Graphics.Gdi.BITMAPINFO');
     final bmiColors = procInfo?.fields.last.typeIdentifier;
 
@@ -402,8 +358,6 @@ void main() {
   });
 
   test('ULARGE_INTEGER projects correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final procInfo = scope.findTypeDef('Windows.Win32.System.Com.STATSTG');
     final cbSize = procInfo?.fields[2].typeIdentifier; // cbSize
 
@@ -415,8 +369,6 @@ void main() {
   });
 
   test('native int parameters have the correct projection', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.Devices.Bluetooth.Apis');
     final api = typedef?.findMethod('BluetoothFindNextDevice');
 
@@ -430,8 +382,6 @@ void main() {
   });
 
   test('LPVOID parameters are projected to Pointer, not Pointer<Void>', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef =
         scope.findTypeDef('Windows.Win32.Security.Credentials.Apis');
     final api = typedef?.findMethod('CredFree')!;
@@ -447,8 +397,6 @@ void main() {
   });
 
   test('BluetoothRemoveDevice struct', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef = scope.findTypeDef('Windows.Win32.Devices.Bluetooth.Apis');
     final api = typedef?.findMethod('BluetoothRemoveDevice');
 
@@ -463,8 +411,6 @@ void main() {
   });
 
   test('Array is projected correctly 1', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final struct = scope
         .findTypeDef('Windows.Win32.Devices.Bluetooth.BLUETOOTH_RADIO_INFO');
     expect(struct, isNotNull);
@@ -479,8 +425,6 @@ void main() {
   });
 
   test('Array is projected correctly 2', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final struct = scope
         .findTypeDef('Windows.Win32.NetworkManagement.WiFi.DOT11_NETWORK_LIST');
     expect(struct, isNotNull);
@@ -495,8 +439,6 @@ void main() {
   });
 
   test('Array is projected correctly 3', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final struct =
         scope.findTypeDef('Windows.Win32.UI.Magnification.MAGCOLOREFFECT');
     expect(struct, isNotNull);
@@ -510,8 +452,6 @@ void main() {
   });
 
   test('GUIDs are projected correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef =
         scope.findTypeDef('Windows.Win32.UI.Shell.PropertiesSystem.Apis');
     final api = typedef?.findMethod('PSPropertyBag_WriteGUID')!;
@@ -527,8 +467,6 @@ void main() {
   });
 
   test('FARPROC is projected correctly', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typedef =
         scope.findTypeDef('Windows.Win32.System.LibraryLoader.Apis');
     final api = typedef?.findMethod('GetProcAddress');
@@ -544,8 +482,6 @@ void main() {
   });
 
   test('BOOL types are projected to int', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typeDef =
         scope.findTypeDef('Windows.Win32.Graphics.Dwm.DWM_BLURBEHIND')!;
 
@@ -558,8 +494,6 @@ void main() {
   });
 
   test('Structs are projected to classes', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final typeDef = scope
         .findTypeDef('Windows.Win32.Media.Multimedia.YAMAHA_ADPCMWAVEFORMAT')!;
 
@@ -570,4 +504,6 @@ void main() {
     expect(typeProjection.dartType, equals('WAVEFORMATEX'));
     expect(typeProjection.isDartPrimitive, isFalse);
   });
+
+  tearDownAll(MetadataStore.close);
 }

--- a/tool/win32gen/test/utils_test.dart
+++ b/tool/win32gen/test/utils_test.dart
@@ -5,6 +5,13 @@ import 'package:win32gen/win32gen.dart';
 import 'package:winmd/winmd.dart';
 
 void main() {
+  late Scope scope;
+
+  setUpAll(() async {
+    scope =
+        await MetadataStore.loadWin32Metadata(version: win32MetadataVersion);
+  });
+
   test('typePretendsToBeAnsi', () {
     expect(typePretendsToBeAnsi('RGNDATA'), isTrue);
     expect(typePretendsToBeAnsi('ENUMLOGFONTEXA'), isFalse);
@@ -53,7 +60,6 @@ void main() {
   });
 
   test('typedefIsAnsi', () {
-    final scope = MetadataStore.getWin32Scope();
     final rgnData = scope.findTypeDef('Windows.Win32.Graphics.Gdi.RGNDATA')!;
     expect(typedefIsAnsi(rgnData), isFalse);
 
@@ -67,7 +73,6 @@ void main() {
   });
 
   test('mangleName', () {
-    final scope = MetadataStore.getWin32Scope();
     final propVariant = scope
         .findTypeDef('Windows.Win32.System.Com.StructuredStorage.PROPVARIANT')!;
 
@@ -145,4 +150,6 @@ void main() {
     expect(folderFromNamespace('Windows.Win32.UI.Shell.Common'),
         equals('ui/shell'));
   });
+
+  tearDownAll(MetadataStore.close);
 }

--- a/tool/win32gen/test/vtablestart_test.dart
+++ b/tool/win32gen/test/vtablestart_test.dart
@@ -9,7 +9,7 @@ import 'package:win32gen/win32gen.dart';
 import 'package:winmd/winmd.dart';
 
 void main() {
-  test('vTableStart for COM types', () {
+  test('vTableStart for COM types', () async {
     const testedTypes = <String, int>{
       'Windows.Win32.Globalization.IEnumSpellingError': 3,
       'Windows.Win32.Globalization.ISpellChecker': 3,
@@ -61,7 +61,8 @@ void main() {
       'Windows.Win32.UI.Shell.IShellItemFilter': 3,
     };
 
-    final scope = MetadataStore.getWin32Scope();
+    final scope =
+        await MetadataStore.loadWin32Metadata(version: win32MetadataVersion);
 
     for (final type in testedTypes.keys) {
       final typeDef = scope.findTypeDef(type);
@@ -74,5 +75,7 @@ void main() {
             reason: typeDef.name);
       }
     }
+
+    MetadataStore.close();
   });
 }

--- a/tool/win32gen/test/win32_projection_test.dart
+++ b/tool/win32gen/test/win32_projection_test.dart
@@ -5,8 +5,14 @@ import 'package:win32gen/win32gen.dart';
 import 'package:winmd/winmd.dart';
 
 void main() {
+  late Scope scope;
+
+  setUpAll(() async {
+    scope =
+        await MetadataStore.loadWin32Metadata(version: win32MetadataVersion);
+  });
+
   test('Special types exist in metadata', () {
-    final scope = MetadataStore.getWin32Scope();
     for (final specialType in specialTypes.keys
         .where((type) => type.startsWith('Windows.Win32'))) {
       expect(scope.findTypeDef(specialType), isNotNull,
@@ -15,8 +21,6 @@ void main() {
   });
 
   test('Packing aligment correct for non-packed struct', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final struct =
         scope.findTypeDef('Windows.Win32.Graphics.Printing.JOB_INFO_1W');
     expect(struct, isNotNull);
@@ -26,8 +30,6 @@ void main() {
   });
 
   test('Packing aligment correct for packed but non-nested struct', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final struct =
         scope.findTypeDef('Windows.Win32.UI.WindowsAndMessaging.DLGTEMPLATE');
     expect(struct, isNotNull);
@@ -37,8 +39,6 @@ void main() {
   });
 
   test('Packing aligment does not overflow for structs with enums', () {
-    final scope = MetadataStore.getWin32Scope();
-
     final struct = scope.findTypeDef(
         'Windows.Win32.Devices.Bluetooth.BLUETOOTH_AUTHENTICATION_METHOD');
     expect(struct, isNotNull);
@@ -47,4 +47,6 @@ void main() {
         StructProjection(struct!, 'BLUETOOTH_AUTHENTICATION_METHOD');
     expect(projection.toString(), isNot(contains('@Packed')));
   });
+
+  tearDownAll(MetadataStore.close);
 }


### PR DESCRIPTION
One significant change in this major version is the separation of Win32 metadata from the package. Instead of bundling it with the package, the Win32 metadata is now obtained from the NuGet package [Microsoft.Windows.SDK.Win32Metadata](https://www.nuget.org/packages/Microsoft.Windows.SDK.Win32Metadata/). Additionally, this update introduces the capability to load a specific version of the metadata.

These changes eliminate the necessity of locking the `winmd` dependency to a specific version. Nevertheless, we still need to load a specific metadata version when generating projections and running tests to maintain consistency. To facilitate this, I've introduced a new constant called `win32MetadataVersion`:
https://github.com/dart-windows/win32/blob/53b6445170b5d400c48cf84cfdcf369588c6b5ad/tool/win32gen/lib/src/constants.dart#L1-L7

(*Note that the `51.0.33-preview` version corresponds to the same metadata that was previously bundled with the `winmd` v3.*)

As explained in the documentation, it is crucial to increment this version only when gearing up for a major release of the `win32` package, as such updates may introduce breaking changes in the generated code.