### PR TITLE
Add `refCount` function to `utils.dart`

### DIFF
--- a/example/com_demo.dart
+++ b/example/com_demo.dart
@@ -9,18 +9,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
-/// Return the current reference count.
-int refCount(IUnknown unk) {
-  // Call addRef() and release(), which are inherited from IUnknown. Both return
-  // the refcount after the operation, so by adding a reference and immediately
-  // removing it, we can get the original refcount.
-
-  unk.addRef();
-  final refCount = unk.release();
-
-  return refCount;
-}
-
 void main() {
   final pTitle = 'Dart Open File Dialog'.toNativeUtf16();
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -10,6 +10,7 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 
+import 'com/iunknown.dart';
 import 'constants.dart';
 import 'exceptions.dart';
 import 'extensions/int_to_hexstring.dart';
@@ -152,3 +153,13 @@ LPWSTR wsalloc(int wChars) => calloc<WCHAR>(wChars).cast();
 /// `calloc.free` and `malloc.free` do the same thing, so this works regardless
 /// of whether memory was zero-allocated on creation or not.
 void free(Pointer pointer) => calloc.free(pointer);
+
+/// Returns the current reference count of the COM object.
+int refCount(IUnknown unk) {
+  // Call addRef() and release(), which are inherited from IUnknown. Both return
+  // the refcount after the operation, so by adding a reference and immediately
+  // removing it, we can get the original refcount.
+  unk.addRef();
+  final refCount = unk.release();
+  return refCount;
+}

--- a/test/variant_test.dart
+++ b/test/variant_test.dart
@@ -34,13 +34,13 @@ void main() {
       final unk = variant.ref.punkVal;
       expect(unk.ptr.address, isNonZero);
       expect(unk.ptr.ref.isNull, isFalse);
-      expect(unk.addRef(), equals(2));
+      expect(refCount(unk), equals(1));
 
       variant.ref.punkVal = spellChecker;
       final unk2 = variant.ref.punkVal;
       expect(unk2.ptr.address, isNonZero);
       expect(unk2.ptr.ref.isNull, isFalse);
-      expect(unk2.addRef(), equals(3));
+      expect(refCount(unk2), equals(2));
 
       VariantClear(variant);
       free(variant);


### PR DESCRIPTION
I think this is a useful function and should reside in `utils.dart`.