### PR TITLE
Migrate to `dartwindows_lints`

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,43 +1,12 @@
-include: package:lints/recommended.yaml
+include: package:dartwindows_lints/analysis_options.yaml
 
 analyzer:
   exclude: [example/explorer/**]
-  language: 
-    strict-casts: true
-    strict-inference: true
-    strict-raw-types: true
-  errors: 
+  errors:
     todo: ignore
-      
+
 linter:
   rules:
-    # Some additional lints we want to enforce
-    always_declare_return_types: true
-    avoid_type_to_string: true
-    cascade_invocations: true
-    discarded_futures: true
-    directives_ordering: true
-    invalid_case_patterns: true
-    leading_newlines_in_multiline_strings: true
-    literal_only_boolean_expressions: true
-    no_default_cases: true
-    omit_local_variable_types: true
-    prefer_const_constructors: true
-    prefer_const_literals_to_create_immutables: true
-    prefer_final_in_for_each: true
-    prefer_final_locals: true
-    prefer_relative_imports: true
-    sort_child_properties_last: true
-    sort_unnamed_constructors_first: true
-    test_types_in_equals: true
-    type_literal_in_constant_pattern: true
-    unawaited_futures: true
-    unnecessary_breaks: true
-    unnecessary_lambdas: true
-    unnecessary_parenthesis: true
-    unnecessary_statements: true
-    use_super_parameters: true
-
     # This is a good lint, but
     # https://github.com/microsoft/win32metadata/issues/99 makes it impossible
     # to resolve today.

--- a/lib/win32.dart
+++ b/lib/win32.dart
@@ -21,8 +21,8 @@
 /// more idiomatic for a Dart consumer.
 ///
 /// For more conceptual material about programming Win32 apps with Dart, consult
-/// the [Dart | Windows
-/// documentation](https://win32.pub/docs/category/win32-programming).
+/// the [Dart | Windows documentation](
+/// https://win32.pub/docs/category/win32-programming).
 library win32;
 
 // Core Win32 APIs, constants and macros

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - ffi
 
 environment:
-  sdk: '^3.0.0'
+  sdk: '^3.1.0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -26,10 +26,10 @@ dev_dependencies:
   args: ^2.4.2
 
   # Help ensure that the code is well-written.
-  lints: '^3.0.0'
+  dartwindows_lints: '^1.1.0'
 
   # Used for joining paths, as part of our path_provider integration test.
   path: ^1.8.3
 
   # Running the test suite.
-  test: ^1.24.6
+  test: ^1.24.9

--- a/tool/win32gen/analysis_options.yaml
+++ b/tool/win32gen/analysis_options.yaml
@@ -1,43 +1,11 @@
-include: package:lints/recommended.yaml
+include: package:dartwindows_lints/analysis_options.yaml
 
 analyzer:
-  language: 
-    strict-casts: true
-    strict-inference: true
-    strict-raw-types: true
-  errors: 
+  errors:
     todo: ignore
-      
+
 linter:
   rules:
-    # Some additional lints we want to enforce
-    always_declare_return_types: true
-    avoid_type_to_string: true
-    cascade_invocations: true
-    comment_references: true
-    discarded_futures: true
-    directives_ordering: true
-    invalid_case_patterns: true
-    leading_newlines_in_multiline_strings: true
-    literal_only_boolean_expressions: true
-    no_default_cases: true
-    omit_local_variable_types: true
-    prefer_const_constructors: true
-    prefer_const_literals_to_create_immutables: true
-    prefer_final_in_for_each: true
-    prefer_final_locals: true
-    prefer_relative_imports: true
-    sort_child_properties_last: true
-    sort_unnamed_constructors_first: true
-    test_types_in_equals: true
-    type_literal_in_constant_pattern: true
-    unawaited_futures: true
-    unnecessary_breaks: true
-    unnecessary_lambdas: true
-    unnecessary_parenthesis: true
-    unnecessary_statements: true
-    use_super_parameters: true
-
     # This is a good lint, but
     # https://github.com/microsoft/win32metadata/issues/99 makes it impossible
     # to resolve today.

--- a/tool/win32gen/pubspec.yaml
+++ b/tool/win32gen/pubspec.yaml
@@ -11,19 +11,19 @@ platforms:
 
 dependencies:
   # For formatting Dart code (APIs for performing dart format).
-  dart_style: ^2.3.2
+  dart_style: ^2.3.3
+
+  # Help ensure that the code is well-written.
+  dartwindows_lints: ^1.1.0
 
   # Foreign Function Interface extension methods
   ffi: ^2.1.0
 
-  # Help ensure that the code is well-written.
-  lints: ^3.0.0
-
   # Running the test suite.
-  test: ^1.24.6
+  test: ^1.24.9
 
   # Windows metadata for automatically generating API signatures.
   winmd: ^4.0.1
 
   # Win32 itself
-  win32: ^5.0.7
+  win32: ^5.0.9

--- a/tool/win32gen/test/type_projection_test.dart
+++ b/tool/win32gen/test/type_projection_test.dart
@@ -144,7 +144,7 @@ void main() {
 
   test('COM interface parameter', () {
     final typedef = scope.findTypeDef('Windows.Win32.System.Com.Apis');
-    final api = typedef?.findMethod('CoSetProxyBlanket')!;
+    final api = typedef?.findMethod('CoSetProxyBlanket');
 
     expect(api, isNotNull);
 
@@ -157,7 +157,7 @@ void main() {
 
   test('Inherited COM interface parameter', () {
     final typedef = scope.findTypeDef('Windows.Win32.System.Com.Apis');
-    final api = typedef?.findMethod('CreateAntiMoniker')!;
+    final api = typedef?.findMethod('CreateAntiMoniker');
 
     expect(api, isNotNull);
 
@@ -196,7 +196,7 @@ void main() {
 
   test('OLECHAR is represented correctly', () {
     final typedef = scope.findTypeDef('Windows.Win32.Foundation.Apis');
-    final api = typedef?.findMethod('SysAllocString')!;
+    final api = typedef?.findMethod('SysAllocString');
 
     expect(api, isNotNull);
     final type = api!.parameters.first.typeIdentifier; // OLECHAR *
@@ -292,7 +292,7 @@ void main() {
 
   test('Pointer<Enum> params are represented correctly', () {
     final typedef = scope.findTypeDef('Windows.Win32.System.Pipes.Apis');
-    final api = typedef?.findMethod('GetNamedPipeInfo')!;
+    final api = typedef?.findMethod('GetNamedPipeInfo');
 
     expect(api, isNotNull);
     final type = api!.parameters[1].typeIdentifier;
@@ -384,7 +384,7 @@ void main() {
   test('LPVOID parameters are projected to Pointer, not Pointer<Void>', () {
     final typedef =
         scope.findTypeDef('Windows.Win32.Security.Credentials.Apis');
-    final api = typedef?.findMethod('CredFree')!;
+    final api = typedef?.findMethod('CredFree');
 
     expect(api, isNotNull);
 
@@ -454,7 +454,7 @@ void main() {
   test('GUIDs are projected correctly', () {
     final typedef =
         scope.findTypeDef('Windows.Win32.UI.Shell.PropertiesSystem.Apis');
-    final api = typedef?.findMethod('PSPropertyBag_WriteGUID')!;
+    final api = typedef?.findMethod('PSPropertyBag_WriteGUID');
 
     expect(api, isNotNull);
 


### PR DESCRIPTION
I wanted to unify the set of lint rules used across all packages in this organization. With this PR, the migration will be complete, as I've already migrated the other packages.