### PR TITLE
Fix dartdoc category references

### DIFF
--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,75 +1,108 @@
 dartdoc:
   categories:
-    "advapi32":
+    'advapi32':
       markdown: doc/advapi32.md
-    "bluetooth":
+    'bluetooth':
       markdown: doc/bluetooth.md
-    "comctl32":
+    'comctl32':
       markdown: doc/comctl32.md
-    "comdlg32":
+    'comdlg32':
       markdown: doc/comdlg32.md
-    "crypt32":
+    'crypt32':
       markdown: doc/crypt32.md
-    "dxva2":
+    'dxva2':
       markdown: doc/dxva2.md
-    "gdi32":
+    'gdi32':
       markdown: doc/gdi32.md
-    "kernel32":
+    'kernel32':
       markdown: doc/kernel32.md
-    "netapi32":
+    'netapi32':
       markdown: doc/netapi32.md
-    "ole32":
+    'ole32':
       markdown: doc/ole32.md
-    "oleaut32":
+    'oleaut32':
       markdown: doc/oleaut32.md
-    "winsock":
+    'winsock':
       markdown: doc/winsock.md
-    "powrprof":
+    'powrprof':
       markdown: doc/powrprof.md
-    "psapi":
+    'psapi':
       markdown: doc/psapi.md
-    "winscard":
+    'winscard':
       markdown: doc/winscard.md
-    "winspool":
+    'winspool':
       markdown: doc/winspool.md
-    "wlanapi":
+    'wlanapi':
       markdown: doc/wlanapi.md
-    "shell32":
+    'shell32':
       markdown: doc/shell32.md
-    "user32":
+    'user32':
       markdown: doc/user32.md
-    "uxtheme":
+    'uxtheme':
       markdown: doc/uxtheme.md
-    "dwmapi":
+    'dwmapi':
       markdown: doc/dwmapi.md
-    "magnification":
+    'magnification':
       markdown: doc/magnification.md
-    "onecore":
+    'onecore':
       markdown: doc/onecore.md
-    "setupapi":
+    'setupapi':
       markdown: doc/setupapi.md
-    "version":
+    'version':
       markdown: doc/version.md
-    "xinput":
+    'xinput':
       markdown: doc/xinput.md
-    "winmm":
+    'winmm':
       markdown: doc/winmm.md
-    "com":
-      name: "COM-based APIs"
+    'com':
+      name: 'COM-based APIs'
       markdown: doc/com.md
-    "winrt":
-      name: "WinRT APIs"
+    'winrt':
+      name: 'WinRT APIs'
       markdown: doc/winrt.md
-    "struct":
-      name: "Structures"
+    'struct':
+      name: 'Structures'
       markdown: doc/struct.md
-    "enum":
-      name: "Enumerations"
+    'enum':
+      name: 'Enumerations'
       markdown: doc/enum.md
-    "examples":
-      name: "Sample apps"
+    'examples':
+      name: 'Sample apps'
       markdown: doc/examples.md
-  categoryOrder: ["kernel32", "user32", "gdi32", "shell32", "ole32", "oleaut32", "comctl32", "comdlg32", "netapi32", "uxtheme", "dwmapi", "magnification", "onecore", "psapi", "setupapi", "version", "xinput", "advapi32", "winsock", "bluetooth", "powrprof", "winscard", "winspool", "wlanapi", "dxva2", "winmm", "com", "winrt", "struct", "enum", "examples"]
+  categoryOrder:
+    [
+      'kernel32',
+      'user32',
+      'gdi32',
+      'shell32',
+      'ole32',
+      'oleaut32',
+      'comctl32',
+      'comdlg32',
+      'netapi32',
+      'uxtheme',
+      'dwmapi',
+      'magnification',
+      'onecore',
+      'psapi',
+      'setupapi',
+      'version',
+      'xinput',
+      'advapi32',
+      'winsock',
+      'bluetooth',
+      'powrprof',
+      'winscard',
+      'winspool',
+      'wlanapi',
+      'dxva2',
+      'winmm',
+      'com',
+      'winrt',
+      'struct',
+      'enum',
+      'examples',
+    ]
   showUndocumentedCategories: true
   nodoc: ['lib/src/constants_nodoc.dart']
   ignore:

--- a/lib/src/com/iagileobject.dart
+++ b/lib/src/com/iagileobject.dart
@@ -27,7 +27,6 @@ const IID_IAgileObject = '{94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90}';
 
 /// Marks an interface as agile across apartments.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAgileObject extends IUnknown {
   // vtable begins at 3, is 0 entries long.

--- a/lib/src/com/iapplicationactivationmanager.dart
+++ b/lib/src/com/iapplicationactivationmanager.dart
@@ -26,7 +26,6 @@ import 'iunknown.dart';
 const IID_IApplicationActivationManager =
     '{2e941141-7f97-4756-ba1d-9decde894a3d}';
 
-/// {@category Interface}
 /// {@category com}
 class IApplicationActivationManager extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iappxfactory.dart
+++ b/lib/src/com/iappxfactory.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IAppxFactory = '{beb94909-e451-438b-b5a7-d79e767b75d8}';
 
-/// {@category Interface}
 /// {@category com}
 class IAppxFactory extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/iappxfile.dart
+++ b/lib/src/com/iappxfile.dart
@@ -27,7 +27,6 @@ const IID_IAppxFile = '{91df827b-94fd-468f-827b-57f41b2f6f2e}';
 
 /// Retrieves information about a payload or footprint file in a package.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxFile extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/iappxfilesenumerator.dart
+++ b/lib/src/com/iappxfilesenumerator.dart
@@ -27,7 +27,6 @@ const IID_IAppxFilesEnumerator = '{f007eeaf-9831-411c-9847-917cdc62d1fe}';
 
 /// Enumerates the payload files in a package.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxFilesEnumerator extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iappxmanifestapplication.dart
+++ b/lib/src/com/iappxmanifestapplication.dart
@@ -27,7 +27,6 @@ const IID_IAppxManifestApplication = '{5da89bf4-3773-46be-b650-7e744863b7e8}';
 
 /// Provides access to attribute values of the application.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestApplication extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iappxmanifestapplicationsenumerator.dart
+++ b/lib/src/com/iappxmanifestapplicationsenumerator.dart
@@ -28,7 +28,6 @@ const IID_IAppxManifestApplicationsEnumerator =
 
 /// Enumerates the applications defined in the package manifest.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestApplicationsEnumerator extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iappxmanifestospackagedependency.dart
+++ b/lib/src/com/iappxmanifestospackagedependency.dart
@@ -26,7 +26,6 @@ import 'iunknown.dart';
 const IID_IAppxManifestOSPackageDependency =
     '{154995ee-54a6-4f14-ac97-d8cf0519644b}';
 
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestOSPackageDependency extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iappxmanifestpackagedependenciesenumerator.dart
+++ b/lib/src/com/iappxmanifestpackagedependenciesenumerator.dart
@@ -28,7 +28,6 @@ const IID_IAppxManifestPackageDependenciesEnumerator =
 
 /// Enumerates the package dependencies defined in the package manifest.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestPackageDependenciesEnumerator extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iappxmanifestpackagedependency.dart
+++ b/lib/src/com/iappxmanifestpackagedependency.dart
@@ -28,7 +28,6 @@ const IID_IAppxManifestPackageDependency =
 
 /// Describes the dependency of one package on another package.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestPackageDependency extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iappxmanifestpackageid.dart
+++ b/lib/src/com/iappxmanifestpackageid.dart
@@ -27,7 +27,6 @@ const IID_IAppxManifestPackageId = '{283ce2d7-7153-4a91-9649-7a0f7240945f}';
 
 /// Provides access to the package identity.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestPackageId extends IUnknown {
   // vtable begins at 3, is 8 entries long.

--- a/lib/src/com/iappxmanifestproperties.dart
+++ b/lib/src/com/iappxmanifestproperties.dart
@@ -28,7 +28,6 @@ const IID_IAppxManifestProperties = '{03faf64d-f26f-4b2c-aaf7-8fe7789b8bca}';
 /// Provides read-only access to the properties section of a package
 /// manifest.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestProperties extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iappxmanifestreader.dart
+++ b/lib/src/com/iappxmanifestreader.dart
@@ -28,7 +28,6 @@ const IID_IAppxManifestReader = '{4e1bd148-55a0-4480-a3d1-15544710637c}';
 /// Represents an object model of the package manifest that provides methods
 /// to access manifest elements and attributes.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestReader extends IUnknown {
   // vtable begins at 3, is 9 entries long.

--- a/lib/src/com/iappxmanifestreader2.dart
+++ b/lib/src/com/iappxmanifestreader2.dart
@@ -29,7 +29,6 @@ const IID_IAppxManifestReader2 = '{d06f67bc-b31d-4eba-a8af-638e73e77b4d}';
 /// Represents an object model of the package manifest that provides methods
 /// to access manifest elements and attributes.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestReader2 extends IAppxManifestReader {
   // vtable begins at 12, is 1 entries long.

--- a/lib/src/com/iappxmanifestreader3.dart
+++ b/lib/src/com/iappxmanifestreader3.dart
@@ -29,7 +29,6 @@ const IID_IAppxManifestReader3 = '{c43825ab-69b7-400a-9709-cc37f5a72d24}';
 /// Represents an object model of the package manifest that provides methods
 /// to access manifest elements and attributes.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestReader3 extends IAppxManifestReader2 {
   // vtable begins at 13, is 2 entries long.

--- a/lib/src/com/iappxmanifestreader4.dart
+++ b/lib/src/com/iappxmanifestreader4.dart
@@ -29,7 +29,6 @@ const IID_IAppxManifestReader4 = '{4579bb7c-741d-4161-b5a1-47bd3b78ad9b}';
 /// Represents an object model of the package manifest that provides methods
 /// to access manifest elements and attributes.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestReader4 extends IAppxManifestReader3 {
   // vtable begins at 15, is 1 entries long.

--- a/lib/src/com/iappxmanifestreader5.dart
+++ b/lib/src/com/iappxmanifestreader5.dart
@@ -28,7 +28,6 @@ const IID_IAppxManifestReader5 = '{8d7ae132-a690-4c00-b75a-6aae1feaac80}';
 /// Represents an object model of the package manifest that provides methods
 /// to access manifest elements and attributes.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestReader5 extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iappxmanifestreader6.dart
+++ b/lib/src/com/iappxmanifestreader6.dart
@@ -28,7 +28,6 @@ const IID_IAppxManifestReader6 = '{34deaca4-d3c0-4e3e-b312-e42625e3807e}';
 /// Represents an object model of the package manifest that provides methods
 /// to access manifest elements and attributes.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestReader6 extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iappxmanifestreader7.dart
+++ b/lib/src/com/iappxmanifestreader7.dart
@@ -28,7 +28,6 @@ const IID_IAppxManifestReader7 = '{8efe6f27-0ce0-4988-b32d-738eb63db3b7}';
 /// Represents an object model of the package manifest that provides methods
 /// to access manifest elements and attributes.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxManifestReader7 extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iappxpackagereader.dart
+++ b/lib/src/com/iappxpackagereader.dart
@@ -27,7 +27,6 @@ const IID_IAppxPackageReader = '{b5c49650-99bc-481c-9a34-3d53a4106708}';
 
 /// Provides a read-only object model for app packages.
 ///
-/// {@category Interface}
 /// {@category com}
 class IAppxPackageReader extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/iaudiocaptureclient.dart
+++ b/lib/src/com/iaudiocaptureclient.dart
@@ -31,7 +31,6 @@ const IID_IAudioCaptureClient = '{c8adbd64-e71e-48a0-a4de-185c395cd317}';
 /// `IAudioClient::GetService` method with parameter `riid` set to REFIID
 /// [IID_IAudioCaptureClient].
 ///
-/// {@category Interface}
 /// {@category com}
 class IAudioCaptureClient extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iaudioclient.dart
+++ b/lib/src/com/iaudioclient.dart
@@ -30,7 +30,6 @@ const IID_IAudioClient = '{1cb9ad4c-dbfa-4c32-b178-c2f568a703b2}';
 /// shared-mode stream) or the hardware buffer of an audio endpoint device
 /// (for an exclusive-mode stream).
 ///
-/// {@category Interface}
 /// {@category com}
 class IAudioClient extends IUnknown {
   // vtable begins at 3, is 12 entries long.

--- a/lib/src/com/iaudioclock.dart
+++ b/lib/src/com/iaudioclock.dart
@@ -31,7 +31,6 @@ const IID_IAudioClock = '{cd63314f-3fba-4a1b-812c-ef96358728e7}';
 /// the `IAudioClient::GetService` method with parameter `riid` set to
 /// REFIID [IID_IAudioClock].
 ///
-/// {@category Interface}
 /// {@category com}
 class IAudioClock extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iaudiorenderclient.dart
+++ b/lib/src/com/iaudiorenderclient.dart
@@ -31,7 +31,6 @@ const IID_IAudioRenderClient = '{f294acfc-3146-4483-a7bf-addca7c260e2}';
 /// `IAudioClient::GetService` method with parameter `riid` set to REFIID
 /// [IID_IAudioRenderClient].
 ///
-/// {@category Interface}
 /// {@category com}
 class IAudioRenderClient extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iaudiosessioncontrol.dart
+++ b/lib/src/com/iaudiosessioncontrol.dart
@@ -33,7 +33,6 @@ const IID_IAudioSessionControl = '{f4b1a599-7266-4319-a8ca-e70acb11e8cd}';
 /// calling the `IAudioClient::GetService` method with parameter riid set to
 /// REFIID [IID_IAudioSessionControl].
 ///
-/// {@category Interface}
 /// {@category com}
 class IAudioSessionControl extends IUnknown {
   // vtable begins at 3, is 9 entries long.

--- a/lib/src/com/iaudiosessionmanager.dart
+++ b/lib/src/com/iaudiosessionmanager.dart
@@ -31,7 +31,6 @@ const IID_IAudioSessionManager = '{bfa971f1-4d5e-40bb-935e-967039bfbee4}';
 /// [IAudioSessionManager] interface by calling the `IMMDevice::Activate`
 /// method with parameter `iid` set to REFIID [IID_IAudioSessionManager].
 ///
-/// {@category Interface}
 /// {@category com}
 class IAudioSessionManager extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iaudiostreamvolume.dart
+++ b/lib/src/com/iaudiostreamvolume.dart
@@ -31,7 +31,6 @@ const IID_IAudioStreamVolume = '{93014887-242d-4068-8a15-cf5e93b90fe3}';
 /// object by calling the `IAudioClient::GetService` method with parameter
 /// riid set to REFIID [IID_IAudioStreamVolume].
 ///
-/// {@category Interface}
 /// {@category com}
 class IAudioStreamVolume extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/ibindctx.dart
+++ b/lib/src/com/ibindctx.dart
@@ -28,7 +28,6 @@ const IID_IBindCtx = '{0000000e-0000-0000-c000-000000000046}';
 /// Provides access to a bind context, which is an object that stores
 /// information about a particular moniker binding operation.
 ///
-/// {@category Interface}
 /// {@category com}
 class IBindCtx extends IUnknown {
   // vtable begins at 3, is 10 entries long.

--- a/lib/src/com/ichannelaudiovolume.dart
+++ b/lib/src/com/ichannelaudiovolume.dart
@@ -33,7 +33,6 @@ const IID_IChannelAudioVolume = '{1c158861-b533-4b30-b1cf-e853e51c59b8}';
 /// a stream object by calling the `IAudioClient::GetService` method with
 /// parameter `riid` set to REFIID [IID_IChannelAudioVolume].
 ///
-/// {@category Interface}
 /// {@category com}
 class IChannelAudioVolume extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/iclassfactory.dart
+++ b/lib/src/com/iclassfactory.dart
@@ -28,7 +28,6 @@ const IID_IClassFactory = '{00000001-0000-0000-c000-000000000046}';
 /// Creates a call object for processing calls to the methods of an
 /// asynchronous interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IClassFactory extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iconnectionpoint.dart
+++ b/lib/src/com/iconnectionpoint.dart
@@ -27,7 +27,6 @@ const IID_IConnectionPoint = '{b196b286-bab4-101a-b69c-00aa00341d07}';
 
 /// Supports connection points for connectable objects.
 ///
-/// {@category Interface}
 /// {@category com}
 class IConnectionPoint extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/iconnectionpointcontainer.dart
+++ b/lib/src/com/iconnectionpointcontainer.dart
@@ -27,7 +27,6 @@ const IID_IConnectionPointContainer = '{b196b284-bab4-101a-b69c-00aa00341d07}';
 
 /// Supports connection points for connectable objects.
 ///
-/// {@category Interface}
 /// {@category com}
 class IConnectionPointContainer extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/idesktopwallpaper.dart
+++ b/lib/src/com/idesktopwallpaper.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IDesktopWallpaper = '{b92b56a9-8b55-4e14-9a89-0199bbb6f93b}';
 
-/// {@category Interface}
 /// {@category com}
 class IDesktopWallpaper extends IUnknown {
   // vtable begins at 3, is 16 entries long.

--- a/lib/src/com/idispatch.dart
+++ b/lib/src/com/idispatch.dart
@@ -28,7 +28,6 @@ const IID_IDispatch = '{00020400-0000-0000-c000-000000000046}';
 /// Exposes objects, methods and properties to programming tools and other
 /// applications that support Automation.
 ///
-/// {@category Interface}
 /// {@category com}
 class IDispatch extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/ienumidlist.dart
+++ b/lib/src/com/ienumidlist.dart
@@ -31,7 +31,6 @@ const IID_IEnumIDList = '{000214f2-0000-0000-c000-000000000046}';
 /// object and passes a pointer to the object's [IEnumIDList] interface back
 /// to the calling application.
 ///
-/// {@category Interface}
 /// {@category com}
 class IEnumIDList extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/ienummoniker.dart
+++ b/lib/src/com/ienummoniker.dart
@@ -28,7 +28,6 @@ const IID_IEnumMoniker = '{00000102-0000-0000-c000-000000000046}';
 /// Enumerates the components of a moniker or the monikers in a table of
 /// monikers.
 ///
-/// {@category Interface}
 /// {@category com}
 class IEnumMoniker extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/ienumnetworkconnections.dart
+++ b/lib/src/com/ienumnetworkconnections.dart
@@ -31,7 +31,6 @@ const IID_IEnumNetworkConnections = '{dcb00006-570f-4a9b-8d69-199fdba5723b}';
 /// connections within a network. This interface can be obtained from the
 /// INetwork interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IEnumNetworkConnections extends IDispatch {
   // vtable begins at 7, is 5 entries long.

--- a/lib/src/com/ienumnetworks.dart
+++ b/lib/src/com/ienumnetworks.dart
@@ -30,7 +30,6 @@ const IID_IEnumNetworks = '{dcb00003-570f-4a9b-8d69-199fdba5723b}';
 /// enumerates all networks available on the local machine. This interface
 /// can be obtained from the `INetworkListManager` interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IEnumNetworks extends IDispatch {
   // vtable begins at 7, is 5 entries long.

--- a/lib/src/com/ienumresources.dart
+++ b/lib/src/com/ienumresources.dart
@@ -27,7 +27,6 @@ const IID_IEnumResources = '{2dd81fe3-a83c-4da9-a330-47249d345ba1}';
 
 /// Exposes resource enumeration methods.
 ///
-/// {@category Interface}
 /// {@category com}
 class IEnumResources extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/ienumspellingerror.dart
+++ b/lib/src/com/ienumspellingerror.dart
@@ -27,7 +27,6 @@ const IID_IEnumSpellingError = '{803e3bd4-2828-4410-8290-418d1d73c762}';
 
 /// An enumeration of the spelling errors.
 ///
-/// {@category Interface}
 /// {@category com}
 class IEnumSpellingError extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/ienumstring.dart
+++ b/lib/src/com/ienumstring.dart
@@ -28,7 +28,6 @@ const IID_IEnumString = '{00000101-0000-0000-c000-000000000046}';
 /// Enumerate strings. `LPWSTR` is the type that indicates a pointer to a
 /// zero-terminated string of wide, or Unicode, characters.
 ///
-/// {@category Interface}
 /// {@category com}
 class IEnumString extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/ienumvariant.dart
+++ b/lib/src/com/ienumvariant.dart
@@ -30,7 +30,6 @@ const IID_IEnumVARIANT = '{00020404-0000-0000-c000-000000000046}';
 /// this interface do not need to know the specific type (or types) of the
 /// elements in the collection.
 ///
-/// {@category Interface}
 /// {@category com}
 class IEnumVARIANT extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/ienumwbemclassobject.dart
+++ b/lib/src/com/ienumwbemclassobject.dart
@@ -29,7 +29,6 @@ const IID_IEnumWbemClassObject = '{027947e1-d731-11ce-a357-000000000001}';
 /// Information Model (CIM) objects and is similar to a standard COM
 /// enumerator.
 ///
-/// {@category Interface}
 /// {@category com}
 class IEnumWbemClassObject extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/ierrorinfo.dart
+++ b/lib/src/com/ierrorinfo.dart
@@ -31,7 +31,6 @@ const IID_IErrorInfo = '{1cf2b120-547d-101b-8e65-08002b2bd119}';
 /// of the component and GUID of the interface in which the error occurred,
 /// and the name and topic of the Help file that applies to the error.
 ///
-/// {@category Interface}
 /// {@category com}
 class IErrorInfo extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/ifiledialog.dart
+++ b/lib/src/com/ifiledialog.dart
@@ -29,7 +29,6 @@ const IID_IFileDialog = '{42f85136-db7e-439c-85f1-e4075d135fc8}';
 /// Exposes methods that initialize, show, and get results from the common
 /// file dialog.
 ///
-/// {@category Interface}
 /// {@category com}
 class IFileDialog extends IModalWindow {
   // vtable begins at 4, is 23 entries long.

--- a/lib/src/com/ifiledialog2.dart
+++ b/lib/src/com/ifiledialog2.dart
@@ -31,7 +31,6 @@ const IID_IFileDialog2 = '{61744fc7-85b5-4791-a9b0-272276309b13}';
 /// the common file dialog as well as to specify alternate text to display
 /// as a label on the Cancel button.
 ///
-/// {@category Interface}
 /// {@category com}
 class IFileDialog2 extends IFileDialog {
   // vtable begins at 27, is 2 entries long.

--- a/lib/src/com/ifiledialogcustomize.dart
+++ b/lib/src/com/ifiledialogcustomize.dart
@@ -28,7 +28,6 @@ const IID_IFileDialogCustomize = '{e6fdd21a-163f-4975-9c8c-a69f1ba37034}';
 /// Exposes methods that allow an application to add controls to a common
 /// file dialog.
 ///
-/// {@category Interface}
 /// {@category com}
 class IFileDialogCustomize extends IUnknown {
   // vtable begins at 3, is 27 entries long.

--- a/lib/src/com/ifileisinuse.dart
+++ b/lib/src/com/ifileisinuse.dart
@@ -31,7 +31,6 @@ const IID_IFileIsInUse = '{64a1cbf0-3a1a-4461-9158-376969693950}';
 /// of this interface to gather information to present to the user in a
 /// dialog box.
 ///
-/// {@category Interface}
 /// {@category com}
 class IFileIsInUse extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/ifileopendialog.dart
+++ b/lib/src/com/ifileopendialog.dart
@@ -26,7 +26,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IFileOpenDialog = '{d57c7288-d4ad-4768-be02-9d969532d960}';
 
-/// {@category Interface}
 /// {@category com}
 class IFileOpenDialog extends IFileDialog {
   // vtable begins at 27, is 2 entries long.

--- a/lib/src/com/ifilesavedialog.dart
+++ b/lib/src/com/ifilesavedialog.dart
@@ -26,7 +26,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IFileSaveDialog = '{84bccd23-5fde-4cdb-aea4-af64b83d78ab}';
 
-/// {@category Interface}
 /// {@category com}
 class IFileSaveDialog extends IFileDialog {
   // vtable begins at 27, is 5 entries long.

--- a/lib/src/com/iinitializewithwindow.dart
+++ b/lib/src/com/iinitializewithwindow.dart
@@ -28,7 +28,6 @@ const IID_IInitializeWithWindow = '{3e68d4bd-7135-4d10-8018-9fb6d9f33fa1}';
 /// Exposes a method through which a client can provide an owner window to a
 /// Windows Runtime (WinRT) object used in a desktop application.
 ///
-/// {@category Interface}
 /// {@category com}
 class IInitializeWithWindow extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iinspectable.dart
+++ b/lib/src/com/iinspectable.dart
@@ -27,7 +27,6 @@ const IID_IInspectable = '{af86e2e0-b12d-4c6a-9c5a-d7aa65101e90}';
 
 /// Provides functionality required for all Windows Runtime classes.
 ///
-/// {@category Interface}
 /// {@category com}
 class IInspectable extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iknownfolder.dart
+++ b/lib/src/com/iknownfolder.dart
@@ -31,7 +31,6 @@ const IID_IKnownFolder = '{3aa7af7e-9b36-420c-a8e3-f77d4674a488}';
 /// a method for the retrieval of a known folder's `IShellItem` object. It
 /// also provides methods to get or set the path of the known folder.
 ///
-/// {@category Interface}
 /// {@category com}
 class IKnownFolder extends IUnknown {
   // vtable begins at 3, is 9 entries long.

--- a/lib/src/com/iknownfoldermanager.dart
+++ b/lib/src/com/iknownfoldermanager.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IKnownFolderManager = '{8be2d872-86aa-4d47-b776-32cca40c7018}';
 
-/// {@category Interface}
 /// {@category com}
 class IKnownFolderManager extends IUnknown {
   // vtable begins at 3, is 10 entries long.

--- a/lib/src/com/imetadataassemblyimport.dart
+++ b/lib/src/com/imetadataassemblyimport.dart
@@ -28,7 +28,6 @@ const IID_IMetaDataAssemblyImport = '{ee62470b-e94b-424e-9b7c-2f00c9249f93}';
 /// Provides methods to access and examine the contents of an assembly
 /// manifest.
 ///
-/// {@category Interface}
 /// {@category com}
 class IMetaDataAssemblyImport extends IUnknown {
   // vtable begins at 3, is 14 entries long.

--- a/lib/src/com/imetadatadispenser.dart
+++ b/lib/src/com/imetadatadispenser.dart
@@ -28,7 +28,6 @@ const IID_IMetaDataDispenser = '{809c652e-7396-11d2-9771-00a0c9b4d50c}';
 /// Provides methods to create a new metadata scope, or open an existing
 /// one.
 ///
-/// {@category Interface}
 /// {@category com}
 class IMetaDataDispenser extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/imetadatadispenserex.dart
+++ b/lib/src/com/imetadatadispenserex.dart
@@ -30,7 +30,6 @@ const IID_IMetaDataDispenserEx = '{31bcfce2-dafb-11d2-9f81-00c04f79a0a3}';
 /// capability to control how the metadata APIs operate on the current
 /// metadata scope.
 ///
-/// {@category Interface}
 /// {@category com}
 class IMetaDataDispenserEx extends IMetaDataDispenser {
   // vtable begins at 6, is 6 entries long.

--- a/lib/src/com/imetadataimport.dart
+++ b/lib/src/com/imetadataimport.dart
@@ -29,7 +29,6 @@ const IID_IMetaDataImport = '{7dac8207-d3ae-4c75-9b67-92801a497d44}';
 /// portable executable (PE) file or other source, such as a type library or
 /// a stand-alone, run-time metadata binary.
 ///
-/// {@category Interface}
 /// {@category com}
 class IMetaDataImport extends IUnknown {
   // vtable begins at 3, is 62 entries long.

--- a/lib/src/com/imetadataimport2.dart
+++ b/lib/src/com/imetadataimport2.dart
@@ -29,7 +29,6 @@ const IID_IMetaDataImport2 = '{fce5efa0-8bba-4f8e-a036-8f2022b08466}';
 /// Extends the IMetaDataImport interface to provide the capability of
 /// working with generic types.
 ///
-/// {@category Interface}
 /// {@category com}
 class IMetaDataImport2 extends IMetaDataImport {
   // vtable begins at 65, is 8 entries long.

--- a/lib/src/com/imetadatatables.dart
+++ b/lib/src/com/imetadatatables.dart
@@ -28,7 +28,6 @@ const IID_IMetaDataTables = '{d8f579ab-402d-4b8e-82d9-5d63b1065c68}';
 /// Provides methods for the storage and retrieval of metadata information
 /// in tables.
 ///
-/// {@category Interface}
 /// {@category com}
 class IMetaDataTables extends IUnknown {
   // vtable begins at 3, is 19 entries long.

--- a/lib/src/com/imetadatatables2.dart
+++ b/lib/src/com/imetadatatables2.dart
@@ -29,7 +29,6 @@ const IID_IMetaDataTables2 = '{badb5f70-58da-43a9-a1c6-d74819f19b15}';
 /// Extends IMetaDataTables to include methods for working with metadata
 /// streams.
 ///
-/// {@category Interface}
 /// {@category com}
 class IMetaDataTables2 extends IMetaDataTables {
   // vtable begins at 22, is 2 entries long.

--- a/lib/src/com/immdevice.dart
+++ b/lib/src/com/immdevice.dart
@@ -28,7 +28,6 @@ const IID_IMMDevice = '{d666063f-1587-4e43-81f1-b948e807363f}';
 /// The IMMDevice interface encapsulates the generic features of a
 /// multimedia device resource.
 ///
-/// {@category Interface}
 /// {@category com}
 class IMMDevice extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/immdeviceenumerator.dart
+++ b/lib/src/com/immdeviceenumerator.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IMMDeviceEnumerator = '{a95664d2-9614-4f35-a746-de8db63617e6}';
 
-/// {@category Interface}
 /// {@category com}
 class IMMDeviceEnumerator extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/imodalwindow.dart
+++ b/lib/src/com/imodalwindow.dart
@@ -27,7 +27,6 @@ const IID_IModalWindow = '{b4db1657-70d7-485e-8e3e-6fcb5a5c1802}';
 
 /// Exposes a method that represents a modal window.
 ///
-/// {@category Interface}
 /// {@category com}
 class IModalWindow extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/imoniker.dart
+++ b/lib/src/com/imoniker.dart
@@ -36,7 +36,6 @@ const IID_IMoniker = '{0000000f-0000-0000-c000-000000000046}';
 /// the linked object to edit it, the moniker is bound; this loads the link
 /// source into memory.
 ///
-/// {@category Interface}
 /// {@category com}
 class IMoniker extends IPersistStream {
   // vtable begins at 8, is 15 entries long.

--- a/lib/src/com/inetwork.dart
+++ b/lib/src/com/inetwork.dart
@@ -30,7 +30,6 @@ const IID_INetwork = '{dcb00002-570f-4a9b-8d69-199fdba5723b}';
 /// also represent a collection of network connections with a similar
 /// network signature.
 ///
-/// {@category Interface}
 /// {@category com}
 class INetwork extends IDispatch {
   // vtable begins at 7, is 13 entries long.

--- a/lib/src/com/inetworkconnection.dart
+++ b/lib/src/com/inetworkconnection.dart
@@ -28,7 +28,6 @@ const IID_INetworkConnection = '{dcb00005-570f-4a9b-8d69-199fdba5723b}';
 
 /// The INetworkConnection interface represents a single network connection.
 ///
-/// {@category Interface}
 /// {@category com}
 class INetworkConnection extends IDispatch {
   // vtable begins at 7, is 7 entries long.

--- a/lib/src/com/inetworklistmanager.dart
+++ b/lib/src/com/inetworklistmanager.dart
@@ -26,7 +26,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_INetworkListManager = '{dcb00000-570f-4a9b-8d69-199fdba5723b}';
 
-/// {@category Interface}
 /// {@category com}
 class INetworkListManager extends IDispatch {
   // vtable begins at 7, is 9 entries long.

--- a/lib/src/com/inetworklistmanagerevents.dart
+++ b/lib/src/com/inetworklistmanagerevents.dart
@@ -30,7 +30,6 @@ const IID_INetworkListManagerEvents = '{dcb00001-570f-4a9b-8d69-199fdba5723b}';
 /// that are interested on higher-level events, for example internet
 /// connectivity, implement this interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class INetworkListManagerEvents extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/ipersist.dart
+++ b/lib/src/com/ipersist.dart
@@ -30,7 +30,6 @@ const IID_IPersist = '{0000010c-0000-0000-c000-000000000046}';
 /// client process, as it is used in the default implementation of
 /// marshaling.
 ///
-/// {@category Interface}
 /// {@category com}
 class IPersist extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/ipersistfile.dart
+++ b/lib/src/com/ipersistfile.dart
@@ -31,7 +31,6 @@ const IID_IPersistFile = '{0000010b-0000-0000-c000-000000000046}';
 /// file varies greatly from one application to another, the implementation
 /// of `IPersistFile::Load`on the object must also open its disk file.
 ///
-/// {@category Interface}
 /// {@category com}
 class IPersistFile extends IPersist {
   // vtable begins at 4, is 5 entries long.

--- a/lib/src/com/ipersistmemory.dart
+++ b/lib/src/com/ipersistmemory.dart
@@ -28,7 +28,6 @@ const IID_IPersistMemory = '{bd1ae5e0-a6ae-11ce-bd37-504200c10000}';
 
 /// Saves and loads objects from a stream.
 ///
-/// {@category Interface}
 /// {@category com}
 class IPersistMemory extends IPersist {
   // vtable begins at 4, is 5 entries long.

--- a/lib/src/com/ipersiststream.dart
+++ b/lib/src/com/ipersiststream.dart
@@ -29,7 +29,6 @@ const IID_IPersistStream = '{00000109-0000-0000-c000-000000000046}';
 /// Enables the saving and loading of objects that use a simple serial
 /// stream for their storage needs.
 ///
-/// {@category Interface}
 /// {@category com}
 class IPersistStream extends IPersist {
   // vtable begins at 4, is 4 entries long.

--- a/lib/src/com/iprovideclassinfo.dart
+++ b/lib/src/com/iprovideclassinfo.dart
@@ -28,7 +28,6 @@ const IID_IProvideClassInfo = '{b196b283-bab4-101a-b69c-00aa00341d07}';
 /// Provides access to the type information for an object's coclass entry in
 /// its type library.
 ///
-/// {@category Interface}
 /// {@category com}
 class IProvideClassInfo extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/irestrictederrorinfo.dart
+++ b/lib/src/com/irestrictederrorinfo.dart
@@ -28,7 +28,6 @@ const IID_IRestrictedErrorInfo = '{82ba7092-4c88-427d-a7bc-16dd93feb67e}';
 /// Represents the details of an error, including restricted error
 /// information.
 ///
-/// {@category Interface}
 /// {@category com}
 class IRestrictedErrorInfo extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/irunningobjecttable.dart
+++ b/lib/src/com/irunningobjecttable.dart
@@ -33,7 +33,6 @@ const IID_IRunningObjectTable = '{00000010-0000-0000-c000-000000000046}';
 /// running; this allows the moniker to bind to the current instance instead
 /// of loading a new one.
 ///
-/// {@category Interface}
 /// {@category com}
 class IRunningObjectTable extends IUnknown {
   // vtable begins at 3, is 7 entries long.

--- a/lib/src/com/isensor.dart
+++ b/lib/src/com/isensor.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_ISensor = '{5fa08f80-2657-458e-af75-46f73fa6ac5c}';
 
-/// {@category Interface}
 /// {@category com}
 class ISensor extends IUnknown {
   // vtable begins at 3, is 15 entries long.

--- a/lib/src/com/isensorcollection.dart
+++ b/lib/src/com/isensorcollection.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_ISensorCollection = '{23571e11-e545-4dd8-a337-b89bf44b10df}';
 
-/// {@category Interface}
 /// {@category com}
 class ISensorCollection extends IUnknown {
   // vtable begins at 3, is 6 entries long.

--- a/lib/src/com/isensordatareport.dart
+++ b/lib/src/com/isensordatareport.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_ISensorDataReport = '{0ab9df9b-c4b5-4796-8898-0470706a2e1d}';
 
-/// {@category Interface}
 /// {@category com}
 class ISensorDataReport extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/isensormanager.dart
+++ b/lib/src/com/isensormanager.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_ISensorManager = '{bd77db67-45a8-42dc-8d00-6dcf15f8377a}';
 
-/// {@category Interface}
 /// {@category com}
 class ISensorManager extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/isequentialstream.dart
+++ b/lib/src/com/isequentialstream.dart
@@ -29,7 +29,6 @@ const IID_ISequentialStream = '{0c733a30-2a1c-11ce-ade5-00aa0044773d}';
 /// stream objects. The `IStream` interface inherits its Read and Write
 /// methods from ISequentialStream.
 ///
-/// {@category Interface}
 /// {@category com}
 class ISequentialStream extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/ishellfolder.dart
+++ b/lib/src/com/ishellfolder.dart
@@ -28,7 +28,6 @@ const IID_IShellFolder = '{000214e6-0000-0000-c000-000000000046}';
 /// Exposed by all Shell namespace folder objects, its methods are used to
 /// manage folders.
 ///
-/// {@category Interface}
 /// {@category com}
 class IShellFolder extends IUnknown {
   // vtable begins at 3, is 10 entries long.

--- a/lib/src/com/ishellitem.dart
+++ b/lib/src/com/ishellitem.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IShellItem = '{43826d1e-e718-42ee-bc55-a1e261c37bfe}';
 
-/// {@category Interface}
 /// {@category com}
 class IShellItem extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/ishellitem2.dart
+++ b/lib/src/com/ishellitem2.dart
@@ -30,7 +30,6 @@ const IID_IShellItem2 = '{7e9fb0d3-919f-4307-ab2e-9b1860310c93}';
 /// of the item. [IShellItem] and [IShellItem2] are the preferred
 /// representations of items in any new code.
 ///
-/// {@category Interface}
 /// {@category com}
 class IShellItem2 extends IShellItem {
   // vtable begins at 8, is 13 entries long.

--- a/lib/src/com/ishellitemarray.dart
+++ b/lib/src/com/ishellitemarray.dart
@@ -27,7 +27,6 @@ const IID_IShellItemArray = '{b63ea76d-1f85-456f-a19c-48159efa858b}';
 
 /// Exposes methods that create and manipulate Shell item arrays.
 ///
-/// {@category Interface}
 /// {@category com}
 class IShellItemArray extends IUnknown {
   // vtable begins at 3, is 7 entries long.

--- a/lib/src/com/ishellitemfilter.dart
+++ b/lib/src/com/ishellitemfilter.dart
@@ -28,7 +28,6 @@ const IID_IShellItemFilter = '{2659b475-eeb8-48b7-8f07-b378810f48cf}';
 /// Exposed by a client to specify how to filter the enumeration of a Shell
 /// item by a server application.
 ///
-/// {@category Interface}
 /// {@category com}
 class IShellItemFilter extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/ishellitemimagefactory.dart
+++ b/lib/src/com/ishellitemimagefactory.dart
@@ -29,7 +29,6 @@ const IID_IShellItemImageFactory = '{bcc18b79-ba16-442f-80c4-8a59c30c463b}';
 /// If no thumbnail or icon is available for the requested item, a per-class
 /// icon may be provided from the Shell.
 ///
-/// {@category Interface}
 /// {@category com}
 class IShellItemImageFactory extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/ishellitemresources.dart
+++ b/lib/src/com/ishellitemresources.dart
@@ -27,7 +27,6 @@ const IID_IShellItemResources = '{ff5693be-2ce0-4d48-b5c5-40817d1acdb9}';
 
 /// Exposes methods to manipulate and query Shell item resources.
 ///
-/// {@category Interface}
 /// {@category com}
 class IShellItemResources extends IUnknown {
   // vtable begins at 3, is 10 entries long.

--- a/lib/src/com/ishelllink.dart
+++ b/lib/src/com/ishelllink.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IShellLink = '{000214f9-0000-0000-c000-000000000046}';
 
-/// {@category Interface}
 /// {@category com}
 class IShellLink extends IUnknown {
   // vtable begins at 3, is 18 entries long.

--- a/lib/src/com/ishelllinkdatalist.dart
+++ b/lib/src/com/ishelllinkdatalist.dart
@@ -28,7 +28,6 @@ const IID_IShellLinkDataList = '{45e2b4ae-b1c3-11d0-b92f-00a0c90312e1}';
 /// Exposes methods that allow an application to attach extra data blocks to
 /// a Shell link. These methods add, copy, or remove data blocks.
 ///
-/// {@category Interface}
 /// {@category com}
 class IShellLinkDataList extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/ishelllinkdual.dart
+++ b/lib/src/com/ishelllinkdual.dart
@@ -26,7 +26,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IShellLinkDual = '{88a05c00-f000-11ce-8350-444553540000}';
 
-/// {@category Interface}
 /// {@category com}
 class IShellLinkDual extends IDispatch {
   // vtable begins at 7, is 16 entries long.

--- a/lib/src/com/ishellservice.dart
+++ b/lib/src/com/ishellservice.dart
@@ -29,7 +29,6 @@ const IID_IShellService = '{5836fb00-8187-11cf-a12b-00aa004ae837}';
 /// component implementing a certain interface is shared among multiple
 /// clients, such as Windows Internet Explorer and Windows Explorer.
 ///
-/// {@category Interface}
 /// {@category com}
 class IShellService extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/isimpleaudiovolume.dart
+++ b/lib/src/com/isimpleaudiovolume.dart
@@ -32,7 +32,6 @@ const IID_ISimpleAudioVolume = '{87ce5498-68d6-44e5-9215-6da47ef883d8}';
 /// a stream object by calling the `IAudioClient::GetService` method with
 /// parameter `riid` set to REFIID [IID_ISimpleAudioVolume].
 ///
-/// {@category Interface}
 /// {@category com}
 class ISimpleAudioVolume extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/ispeechobjecttoken.dart
+++ b/lib/src/com/ispeechobjecttoken.dart
@@ -26,7 +26,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_ISpeechObjectToken = '{c74a3adc-b727-4500-a84a-b526721c8b8c}';
 
-/// {@category Interface}
 /// {@category com}
 class ISpeechObjectToken extends IDispatch {
   // vtable begins at 7, is 13 entries long.

--- a/lib/src/com/ispeechobjecttokens.dart
+++ b/lib/src/com/ispeechobjecttokens.dart
@@ -29,7 +29,6 @@ const IID_ISpeechObjectTokens = '{9285b776-2e7b-4bc0-b53e-580eb6fa967f}';
 /// The ISpeechObjectTokens automation interface represents a collection of
 /// SpObjectToken objects.
 ///
-/// {@category Interface}
 /// {@category com}
 class ISpeechObjectTokens extends IDispatch {
   // vtable begins at 7, is 3 entries long.

--- a/lib/src/com/ispeechvoice.dart
+++ b/lib/src/com/ispeechvoice.dart
@@ -26,7 +26,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_ISpeechVoice = '{269316d8-57bd-11d2-9eee-00c04f797396}';
 
-/// {@category Interface}
 /// {@category com}
 class ISpeechVoice extends IDispatch {
   // vtable begins at 7, is 32 entries long.

--- a/lib/src/com/ispellchecker.dart
+++ b/lib/src/com/ispellchecker.dart
@@ -29,7 +29,6 @@ const IID_ISpellChecker = '{b6fd0b71-e2bc-4653-8d05-f197e412770b}';
 /// `ISpellChecker` can be used to check text, get suggestions, update user
 /// dictionaries, and maintain options.
 ///
-/// {@category Interface}
 /// {@category com}
 class ISpellChecker extends IUnknown {
   // vtable begins at 3, is 14 entries long.

--- a/lib/src/com/ispellchecker2.dart
+++ b/lib/src/com/ispellchecker2.dart
@@ -32,7 +32,6 @@ const IID_ISpellChecker2 = '{e7ed1c71-87f7-4378-a840-c9200dacee47}';
 /// text, get suggestions, update user dictionaries, and maintain options,
 /// as can ISpellChecker from which it is derived.
 ///
-/// {@category Interface}
 /// {@category com}
 class ISpellChecker2 extends ISpellChecker {
   // vtable begins at 17, is 1 entries long.

--- a/lib/src/com/ispellcheckerchangedeventhandler.dart
+++ b/lib/src/com/ispellcheckerchangedeventhandler.dart
@@ -29,7 +29,6 @@ const IID_ISpellCheckerChangedEventHandler =
 /// Allows the caller to create a handler for notifications that the state
 /// of the speller has changed.
 ///
-/// {@category Interface}
 /// {@category com}
 class ISpellCheckerChangedEventHandler extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/ispellcheckerfactory.dart
+++ b/lib/src/com/ispellcheckerfactory.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_ISpellCheckerFactory = '{8e018a9d-2415-4677-bf08-794ea61f94bb}';
 
-/// {@category Interface}
 /// {@category com}
 class ISpellCheckerFactory extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/ispellingerror.dart
+++ b/lib/src/com/ispellingerror.dart
@@ -27,7 +27,6 @@ const IID_ISpellingError = '{b7c82d61-fbe8-4b47-9b27-6c0d2e0de0a3}';
 
 /// Provides information about a spelling error.
 ///
-/// {@category Interface}
 /// {@category com}
 class ISpellingError extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/ispeventsource.dart
+++ b/lib/src/com/ispeventsource.dart
@@ -32,7 +32,6 @@ const IID_ISpEventSource = '{be7a9cce-5f9e-11d2-960f-00c04f8ee628}';
 /// retrieve queued events. ISpEventSource inherits from the
 /// [ISpNotifySource] interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class ISpEventSource extends ISpNotifySource {
   // vtable begins at 10, is 3 entries long.

--- a/lib/src/com/ispnotifysource.dart
+++ b/lib/src/com/ispnotifysource.dart
@@ -30,7 +30,6 @@ const IID_ISpNotifySource = '{5eff4aef-8487-11d2-961c-00c04f8ee628}';
 /// recognized. SAPI components that generate notifications implement an
 /// ISpNotifySource.
 ///
-/// {@category Interface}
 /// {@category com}
 class ISpNotifySource extends IUnknown {
   // vtable begins at 3, is 7 entries long.

--- a/lib/src/com/ispvoice.dart
+++ b/lib/src/com/ispvoice.dart
@@ -26,7 +26,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_ISpVoice = '{6c44df74-72b9-4992-a1ec-ef996e0422d4}';
 
-/// {@category Interface}
 /// {@category com}
 class ISpVoice extends ISpEventSource {
   // vtable begins at 13, is 25 entries long.

--- a/lib/src/com/istream.dart
+++ b/lib/src/com/istream.dart
@@ -32,7 +32,6 @@ const IID_IStream = '{0000000c-0000-0000-c000-000000000046}';
 /// stream but, most frequently, streams are elements nested within a
 /// storage object. They are similar to standard files.
 ///
-/// {@category Interface}
 /// {@category com}
 class IStream extends ISequentialStream {
   // vtable begins at 5, is 9 entries long.

--- a/lib/src/com/isupporterrorinfo.dart
+++ b/lib/src/com/isupporterrorinfo.dart
@@ -29,7 +29,6 @@ const IID_ISupportErrorInfo = '{df0b3d60-548f-101b-8e65-08002b2bd119}';
 /// correctly. Automation objects that use the error handling interfaces
 /// must implement ISupportErrorInfo.
 ///
-/// {@category Interface}
 /// {@category com}
 class ISupportErrorInfo extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/itypeinfo.dart
+++ b/lib/src/com/itypeinfo.dart
@@ -30,7 +30,6 @@ const IID_ITypeInfo = '{00020401-0000-0000-c000-000000000046}';
 /// can use ITypeInfo to extract information about the characteristics and
 /// capabilities of objects from type libraries.
 ///
-/// {@category Interface}
 /// {@category com}
 class ITypeInfo extends IUnknown {
   // vtable begins at 3, is 19 entries long.

--- a/lib/src/com/iuiautomation.dart
+++ b/lib/src/com/iuiautomation.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IUIAutomation = '{30cbe57d-d9d0-452a-ab13-7ac5ac4825ee}';
 
-/// {@category Interface}
 /// {@category com}
 class IUIAutomation extends IUnknown {
   // vtable begins at 3, is 55 entries long.

--- a/lib/src/com/iuiautomation2.dart
+++ b/lib/src/com/iuiautomation2.dart
@@ -26,7 +26,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IUIAutomation2 = '{34723aff-0c9d-49d0-9896-7ab52df8cd8a}';
 
-/// {@category Interface}
 /// {@category com}
 class IUIAutomation2 extends IUIAutomation {
   // vtable begins at 58, is 6 entries long.

--- a/lib/src/com/iuiautomation3.dart
+++ b/lib/src/com/iuiautomation3.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomation3 = '{73d768da-9b51-4b89-936e-c209290973e7}';
 /// Extends the IUIAutomation2 interface to expose additional methods for
 /// controlling Microsoft UI Automation functionality.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomation3 extends IUIAutomation2 {
   // vtable begins at 64, is 2 entries long.

--- a/lib/src/com/iuiautomation4.dart
+++ b/lib/src/com/iuiautomation4.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomation4 = '{1189c02a-05f8-4319-8e21-e817e3db2860}';
 /// Extends the IUIAutomation3 interface to expose additional methods for
 /// controlling Microsoft UI Automation functionality.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomation4 extends IUIAutomation3 {
   // vtable begins at 66, is 2 entries long.

--- a/lib/src/com/iuiautomation5.dart
+++ b/lib/src/com/iuiautomation5.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomation5 = '{25f700c8-d816-4057-a9dc-3cbdee77e256}';
 /// Extends the IUIAutomation4 interface to expose additional methods for
 /// controlling Microsoft UI Automation functionality.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomation5 extends IUIAutomation4 {
   // vtable begins at 68, is 2 entries long.

--- a/lib/src/com/iuiautomation6.dart
+++ b/lib/src/com/iuiautomation6.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomation6 = '{aae072da-29e3-413d-87a7-192dbf81ed10}';
 /// Extends the IUIAutomation5 interface to expose additional methods for
 /// controlling Microsoft UI Automation functionality.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomation6 extends IUIAutomation5 {
   // vtable begins at 70, is 9 entries long.

--- a/lib/src/com/iuiautomationandcondition.dart
+++ b/lib/src/com/iuiautomationandcondition.dart
@@ -30,7 +30,6 @@ const IID_IUIAutomationAndCondition = '{a7d0af36-b912-45fe-9855-091ddc174aec}';
 /// applications can use to retrieve information about an AND-based property
 /// condition.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationAndCondition extends IUIAutomationCondition {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iuiautomationannotationpattern.dart
+++ b/lib/src/com/iuiautomationannotationpattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationAnnotationPattern =
 
 /// Provides access to the properties of an annotation in a document.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationAnnotationPattern extends IUnknown {
   // vtable begins at 3, is 10 entries long.

--- a/lib/src/com/iuiautomationboolcondition.dart
+++ b/lib/src/com/iuiautomationboolcondition.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationBoolCondition = '{1b4e1f2e-75eb-4d0b-8952-5a69988e2307}';
 /// Represents a condition that can be either TRUE (selects all elements) or
 /// FALSE (selects no elements).
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationBoolCondition extends IUIAutomationCondition {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iuiautomationcacherequest.dart
+++ b/lib/src/com/iuiautomationcacherequest.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationCacheRequest = '{b32a92b5-bc25-4078-9c08-d7ee95c48e03}';
 /// use this interface to specify the properties and control patterns to be
 /// cached when a Microsoft UI Automation element is obtained.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationCacheRequest extends IUnknown {
   // vtable begins at 3, is 9 entries long.

--- a/lib/src/com/iuiautomationcondition.dart
+++ b/lib/src/com/iuiautomationcondition.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationCondition = '{352ffba8-0973-437c-a61f-f64cafd81df9}';
 /// This is the primary interface for conditions used in filtering when
 /// searching for elements in the UI Automation tree.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationCondition extends IUnknown {
   // vtable begins at 3, is 0 entries long.

--- a/lib/src/com/iuiautomationcustomnavigationpattern.dart
+++ b/lib/src/com/iuiautomationcustomnavigationpattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationCustomNavigationPattern =
 /// Exposes a method to support access by a Microsoft UI Automation client
 /// to controls that support a custom navigation order.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationCustomNavigationPattern extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iuiautomationdockpattern.dart
+++ b/lib/src/com/iuiautomationdockpattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationDockPattern = '{fde5ef97-1464-48f6-90bf-43d0948e86ec}';
 /// Provides access to a control that enables child elements to be arranged
 /// horizontally and vertically, relative to each other.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationDockPattern extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iuiautomationdragpattern.dart
+++ b/lib/src/com/iuiautomationdragpattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationDragPattern = '{1dc7b570-1f54-4bad-bcda-d36a722fb7bd}';
 /// Provides access to information exposed by a UI Automation provider for
 /// an element that can be dragged as part of a drag-and-drop operation.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationDragPattern extends IUnknown {
   // vtable begins at 3, is 8 entries long.

--- a/lib/src/com/iuiautomationdroptargetpattern.dart
+++ b/lib/src/com/iuiautomationdroptargetpattern.dart
@@ -30,7 +30,6 @@ const IID_IUIAutomationDropTargetPattern =
 /// Automation provider for an element that can be the drop target of a
 /// drag-and-drop operation.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationDropTargetPattern extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/iuiautomationelement.dart
+++ b/lib/src/com/iuiautomationelement.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationElement = '{d22108aa-8ac5-49a5-837b-37bbb3d7591e}';
 /// Exposes methods and properties for a UI Automation element, which
 /// represents a UI item.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationElement extends IUnknown {
   // vtable begins at 3, is 82 entries long.

--- a/lib/src/com/iuiautomationelement2.dart
+++ b/lib/src/com/iuiautomationelement2.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationElement2 = '{6749c683-f70d-4487-a698-5f79d55290d6}';
 
 /// Extends the IUIAutomationElement interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationElement2 extends IUIAutomationElement {
   // vtable begins at 85, is 6 entries long.

--- a/lib/src/com/iuiautomationelement3.dart
+++ b/lib/src/com/iuiautomationelement3.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationElement3 = '{8471df34-aee0-4a01-a7de-7db9af12c296}';
 
 /// Extends the IUIAutomationElement2 interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationElement3 extends IUIAutomationElement2 {
   // vtable begins at 91, is 3 entries long.

--- a/lib/src/com/iuiautomationelement4.dart
+++ b/lib/src/com/iuiautomationelement4.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationElement4 = '{3b6e233c-52fb-4063-a4c9-77c075c2a06b}';
 
 /// Extends the IUIAutomationElement3 interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationElement4 extends IUIAutomationElement3 {
   // vtable begins at 94, is 10 entries long.

--- a/lib/src/com/iuiautomationelement5.dart
+++ b/lib/src/com/iuiautomationelement5.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationElement5 = '{98141c1d-0d0e-4175-bbe2-6bff455842a7}';
 /// Extends the IUIAutomationElement4 interface to provide access to current
 /// and cached landmark data.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationElement5 extends IUIAutomationElement4 {
   // vtable begins at 104, is 4 entries long.

--- a/lib/src/com/iuiautomationelement6.dart
+++ b/lib/src/com/iuiautomationelement6.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationElement6 = '{4780d450-8bca-4977-afa5-a4a517f555e3}';
 /// Extends the IUIAutomationElement5 interface to provide access to current
 /// and cached full descriptions.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationElement6 extends IUIAutomationElement5 {
   // vtable begins at 108, is 2 entries long.

--- a/lib/src/com/iuiautomationelement7.dart
+++ b/lib/src/com/iuiautomationelement7.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationElement7 = '{204e8572-cfc3-4c11-b0c8-7da7420750b7}';
 
 /// Extends the IUIAutomationElement6 interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationElement7 extends IUIAutomationElement6 {
   // vtable begins at 110, is 5 entries long.

--- a/lib/src/com/iuiautomationelement8.dart
+++ b/lib/src/com/iuiautomationelement8.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationElement8 = '{8c60217d-5411-4cde-bcc0-1ceda223830c}';
 
 /// Extends the IUIAutomationElement7 interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationElement8 extends IUIAutomationElement7 {
   // vtable begins at 115, is 2 entries long.

--- a/lib/src/com/iuiautomationelement9.dart
+++ b/lib/src/com/iuiautomationelement9.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationElement9 = '{39325fac-039d-440e-a3a3-5eb81a5cecc3}';
 
 /// Extends the IUIAutomationElement8 interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationElement9 extends IUIAutomationElement8 {
   // vtable begins at 117, is 2 entries long.

--- a/lib/src/com/iuiautomationelementarray.dart
+++ b/lib/src/com/iuiautomationelementarray.dart
@@ -27,7 +27,6 @@ const IID_IUIAutomationElementArray = '{14314595-b4bc-4055-95f2-58f2e42c9855}';
 
 /// Represents a collection of UI Automation elements.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationElementArray extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iuiautomationexpandcollapsepattern.dart
+++ b/lib/src/com/iuiautomationexpandcollapsepattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationExpandCollapsePattern =
 /// Provides access to a control that can visually expand to display
 /// content, and collapse to hide content.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationExpandCollapsePattern extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/iuiautomationgriditempattern.dart
+++ b/lib/src/com/iuiautomationgriditempattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationGridItemPattern =
 /// Provides access to a child control in a grid-style container that
 /// supports the IUIAutomationGridPattern interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationGridItemPattern extends IUnknown {
   // vtable begins at 3, is 10 entries long.

--- a/lib/src/com/iuiautomationgridpattern.dart
+++ b/lib/src/com/iuiautomationgridpattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationGridPattern = '{414c3cdc-856b-4f5b-8538-3131c6302550}';
 /// of child controls that are organized in a two-dimensional logical
 /// coordinate system that can be traversed by row and column.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationGridPattern extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/iuiautomationinvokepattern.dart
+++ b/lib/src/com/iuiautomationinvokepattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationInvokePattern = '{fb377fbe-8ea6-46d5-9c73-6499642d3059}';
 /// Exposes a method that enables a client application to invoke the action
 /// of a control (typically a button).
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationInvokePattern extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iuiautomationitemcontainerpattern.dart
+++ b/lib/src/com/iuiautomationitemcontainerpattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationItemContainerPattern =
 /// Exposes a method that retrieves an item from a container, such as a
 /// virtual list.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationItemContainerPattern extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iuiautomationlegacyiaccessiblepattern.dart
+++ b/lib/src/com/iuiautomationlegacyiaccessiblepattern.dart
@@ -30,7 +30,6 @@ const IID_IUIAutomationLegacyIAccessiblePattern =
 /// clients to retrieve UI information from Microsoft Active Accessibility
 /// (MSAA) servers.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationLegacyIAccessiblePattern extends IUnknown {
   // vtable begins at 3, is 24 entries long.

--- a/lib/src/com/iuiautomationmultipleviewpattern.dart
+++ b/lib/src/com/iuiautomationmultipleviewpattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationMultipleViewPattern =
 /// Provides access to a control that can switch between multiple
 /// representations of the same information or set of child controls.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationMultipleViewPattern extends IUnknown {
   // vtable begins at 3, is 6 entries long.

--- a/lib/src/com/iuiautomationnotcondition.dart
+++ b/lib/src/com/iuiautomationnotcondition.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationNotCondition = '{f528b657-847b-498c-8896-d52b565407a1}';
 
 /// Represents a condition that is the negative of another condition.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationNotCondition extends IUIAutomationCondition {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iuiautomationobjectmodelpattern.dart
+++ b/lib/src/com/iuiautomationobjectmodelpattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationObjectModelPattern =
 /// Provides access to the underlying object model implemented by a control
 /// or application.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationObjectModelPattern extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iuiautomationorcondition.dart
+++ b/lib/src/com/iuiautomationorcondition.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationOrCondition = '{8753f032-3db1-47b5-a1fc-6e34a266c712}';
 /// Represents a condition made up of multiple conditions, at least one of
 /// which must be true.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationOrCondition extends IUIAutomationCondition {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iuiautomationpropertycondition.dart
+++ b/lib/src/com/iuiautomationpropertycondition.dart
@@ -30,7 +30,6 @@ const IID_IUIAutomationPropertyCondition =
 /// Represents a condition based on a property value that is used to find UI
 /// Automation elements.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationPropertyCondition extends IUIAutomationCondition {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iuiautomationproxyfactory.dart
+++ b/lib/src/com/iuiautomationproxyfactory.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationProxyFactory = '{85b94ecd-849d-42b6-b94d-d6db23fdf5a4}';
 /// Automation provider for UI elements that do not have native support for
 /// UI Automation. This interface is implemented by proxies.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationProxyFactory extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iuiautomationproxyfactoryentry.dart
+++ b/lib/src/com/iuiautomationproxyfactoryentry.dart
@@ -30,7 +30,6 @@ const IID_IUIAutomationProxyFactoryEntry =
 /// Automation, and exposes properties and methods that can be used by
 /// client applications to interact with IUIAutomationProxyFactory objects.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationProxyFactoryEntry extends IUnknown {
   // vtable begins at 3, is 13 entries long.

--- a/lib/src/com/iuiautomationproxyfactorymapping.dart
+++ b/lib/src/com/iuiautomationproxyfactorymapping.dart
@@ -31,7 +31,6 @@ const IID_IUIAutomationProxyFactoryMapping =
 /// interface. The entries are in the order in which the system will attempt
 /// to use the proxies.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationProxyFactoryMapping extends IUnknown {
   // vtable begins at 3, is 9 entries long.

--- a/lib/src/com/iuiautomationrangevaluepattern.dart
+++ b/lib/src/com/iuiautomationrangevaluepattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationRangeValuePattern =
 
 /// Provides access to a control that presents a range of values.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationRangeValuePattern extends IUnknown {
   // vtable begins at 3, is 13 entries long.

--- a/lib/src/com/iuiautomationscrollitempattern.dart
+++ b/lib/src/com/iuiautomationscrollitempattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationScrollItemPattern =
 /// Exposes a method that enables an item in a scrollable view to be placed
 /// in a visible portion of the view.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationScrollItemPattern extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iuiautomationscrollpattern.dart
+++ b/lib/src/com/iuiautomationscrollpattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationScrollPattern = '{88f4d42a-e881-459d-a77c-73bbbb7e02dc}';
 /// Provides access to a control that acts as a scrollable container for a
 /// collection of child elements.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationScrollPattern extends IUnknown {
   // vtable begins at 3, is 14 entries long.

--- a/lib/src/com/iuiautomationselectionitempattern.dart
+++ b/lib/src/com/iuiautomationselectionitempattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationSelectionItemPattern =
 /// Provides access to the selectable child items of a container control
 /// that supports IUIAutomationSelectionPattern.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationSelectionItemPattern extends IUnknown {
   // vtable begins at 3, is 7 entries long.

--- a/lib/src/com/iuiautomationselectionpattern.dart
+++ b/lib/src/com/iuiautomationselectionpattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationSelectionPattern =
 /// Provides access to a control that contains selectable child items. The
 /// children of this element support IUIAutomationSelectionItemPattern.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationSelectionPattern extends IUnknown {
   // vtable begins at 3, is 6 entries long.

--- a/lib/src/com/iuiautomationselectionpattern2.dart
+++ b/lib/src/com/iuiautomationselectionpattern2.dart
@@ -30,7 +30,6 @@ const IID_IUIAutomationSelectionPattern2 =
 /// Extends the IUIAutomationSelectionPattern interface to provide
 /// information about selected items.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationSelectionPattern2 extends IUIAutomationSelectionPattern {
   // vtable begins at 9, is 8 entries long.

--- a/lib/src/com/iuiautomationspreadsheetitempattern.dart
+++ b/lib/src/com/iuiautomationspreadsheetitempattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationSpreadsheetItemPattern =
 /// Enables a client application to retrieve information about an item
 /// (cell) in a spreadsheet.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationSpreadsheetItemPattern extends IUnknown {
   // vtable begins at 3, is 6 entries long.

--- a/lib/src/com/iuiautomationspreadsheetpattern.dart
+++ b/lib/src/com/iuiautomationspreadsheetpattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationSpreadsheetPattern =
 /// Enables a client application to access the items (cells) in a
 /// spreadsheet.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationSpreadsheetPattern extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iuiautomationstylespattern.dart
+++ b/lib/src/com/iuiautomationstylespattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationStylesPattern = '{85b5f0a2-bd79-484a-ad2b-388c9838d5fb}';
 /// Enables Microsoft UI Automation clients to retrieve the visual styles
 /// associated with an element in a document.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationStylesPattern extends IUnknown {
   // vtable begins at 3, is 16 entries long.

--- a/lib/src/com/iuiautomationsynchronizedinputpattern.dart
+++ b/lib/src/com/iuiautomationsynchronizedinputpattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationSynchronizedInputPattern =
 
 /// Provides access to the keyboard or mouse input of a control.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationSynchronizedInputPattern extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iuiautomationtableitempattern.dart
+++ b/lib/src/com/iuiautomationtableitempattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationTableItemPattern =
 /// Provides access to a child element in a container that supports
 /// IUIAutomationTablePattern.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTableItemPattern extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/iuiautomationtablepattern.dart
+++ b/lib/src/com/iuiautomationtablepattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationTablePattern = '{620e691c-ea96-4710-a850-754b24ce2417}';
 /// Provides access to a control that acts as a container for a collection
 /// of child elements.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTablePattern extends IUnknown {
   // vtable begins at 3, is 6 entries long.

--- a/lib/src/com/iuiautomationtextchildpattern.dart
+++ b/lib/src/com/iuiautomationtextchildpattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationTextChildPattern =
 /// Provides access a text-based control (or an object embedded in text)
 /// that is a child or descendant of another text-based control.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTextChildPattern extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iuiautomationtexteditpattern.dart
+++ b/lib/src/com/iuiautomationtexteditpattern.dart
@@ -31,7 +31,6 @@ const IID_IUIAutomationTextEditPattern =
 /// that performs auto-correction or enables input composition through an
 /// Input Method Editor (IME).
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTextEditPattern extends IUIAutomationTextPattern {
   // vtable begins at 9, is 2 entries long.

--- a/lib/src/com/iuiautomationtextpattern.dart
+++ b/lib/src/com/iuiautomationtextpattern.dart
@@ -27,7 +27,6 @@ const IID_IUIAutomationTextPattern = '{32eba289-3583-42c9-9c59-3b6d9a1e9b6a}';
 
 /// Provides access to a control that contains text.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTextPattern extends IUnknown {
   // vtable begins at 3, is 6 entries long.

--- a/lib/src/com/iuiautomationtextpattern2.dart
+++ b/lib/src/com/iuiautomationtextpattern2.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationTextPattern2 = '{506a921a-fcc9-409f-b23b-37eb74106872}';
 
 /// Extends the IUIAutomationTextPattern interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTextPattern2 extends IUIAutomationTextPattern {
   // vtable begins at 9, is 2 entries long.

--- a/lib/src/com/iuiautomationtextrange.dart
+++ b/lib/src/com/iuiautomationtextrange.dart
@@ -30,7 +30,6 @@ const IID_IUIAutomationTextRange = '{a543cc6a-f4ae-494b-8239-c814481187a8}';
 /// use the IUIAutomationTextRange interface to select, compare, and
 /// retrieve embedded objects from the text span.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTextRange extends IUnknown {
   // vtable begins at 3, is 18 entries long.

--- a/lib/src/com/iuiautomationtextrange2.dart
+++ b/lib/src/com/iuiautomationtextrange2.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationTextRange2 = '{bb9b40e0-5e04-46bd-9be0-4b601b9afad4}';
 /// Extends the IUIAutomationTextRange interface to enable Microsoft UI
 /// Automation clients to programmatically invoke context menus.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTextRange2 extends IUIAutomationTextRange {
   // vtable begins at 21, is 1 entries long.

--- a/lib/src/com/iuiautomationtextrange3.dart
+++ b/lib/src/com/iuiautomationtextrange3.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationTextRange3 = '{6a315d69-5512-4c2e-85f0-53fce6dd4bc2}';
 /// Extends the IUIAutomationTextRange2 interface to support faster access
 /// to the underlying rich text data on a text range.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTextRange3 extends IUIAutomationTextRange2 {
   // vtable begins at 22, is 3 entries long.

--- a/lib/src/com/iuiautomationtextrangearray.dart
+++ b/lib/src/com/iuiautomationtextrangearray.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationTextRangeArray =
 
 /// Represents a collection of IUIAutomationTextRange objects.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTextRangeArray extends IUnknown {
   // vtable begins at 3, is 2 entries long.

--- a/lib/src/com/iuiautomationtogglepattern.dart
+++ b/lib/src/com/iuiautomationtogglepattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationTogglePattern = '{94cf8058-9b8d-4ab9-8bfd-4cd0a33c8c70}';
 /// Provides access to a control that can cycle through a set of states, and
 /// maintain a state after it is set.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTogglePattern extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iuiautomationtransformpattern.dart
+++ b/lib/src/com/iuiautomationtransformpattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationTransformPattern =
 
 /// Provides access to a control that can be moved, resized, or rotated.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTransformPattern extends IUnknown {
   // vtable begins at 3, is 9 entries long.

--- a/lib/src/com/iuiautomationtransformpattern2.dart
+++ b/lib/src/com/iuiautomationtransformpattern2.dart
@@ -31,7 +31,6 @@ const IID_IUIAutomationTransformPattern2 =
 /// UI Automation clients to programmatically access the viewport zooming
 /// functionality of a control.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTransformPattern2 extends IUIAutomationTransformPattern {
   // vtable begins at 12, is 10 entries long.

--- a/lib/src/com/iuiautomationtreewalker.dart
+++ b/lib/src/com/iuiautomationtreewalker.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationTreeWalker = '{4042c624-389c-4afc-a630-9df854a541fc}';
 /// Exposes properties and methods that UI Automation client applications
 /// use to view and navigate the UI Automation elements on the desktop.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationTreeWalker extends IUnknown {
   // vtable begins at 3, is 13 entries long.

--- a/lib/src/com/iuiautomationvaluepattern.dart
+++ b/lib/src/com/iuiautomationvaluepattern.dart
@@ -28,7 +28,6 @@ const IID_IUIAutomationValuePattern = '{a94cd8b1-0844-4cd6-9d2d-640537ab39e9}';
 /// Provides access to a control that contains a value that does not span a
 /// range and that can be represented as a string.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationValuePattern extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/iuiautomationvirtualizeditempattern.dart
+++ b/lib/src/com/iuiautomationvirtualizeditempattern.dart
@@ -29,7 +29,6 @@ const IID_IUIAutomationVirtualizedItemPattern =
 /// Represents a virtualized item, which is an item that is represented by a
 /// placeholder automation element in the Microsoft UI Automation tree.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationVirtualizedItemPattern extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iuiautomationwindowpattern.dart
+++ b/lib/src/com/iuiautomationwindowpattern.dart
@@ -27,7 +27,6 @@ const IID_IUIAutomationWindowPattern = '{0faef453-9208-43ef-bbb2-3b485177864f}';
 
 /// Provides access to the fundamental functionality of a window.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUIAutomationWindowPattern extends IUnknown {
   // vtable begins at 3, is 15 entries long.

--- a/lib/src/com/iunknown.dart
+++ b/lib/src/com/iunknown.dart
@@ -22,7 +22,6 @@ const IID_IUnknown = '{00000000-0000-0000-c000-000000000046}';
 /// three methods in IUnknown are the first entries in the vtable for every
 /// interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IUnknown {
   // vtable begins at 0, is 3 entries long.

--- a/lib/src/com/iuri.dart
+++ b/lib/src/com/iuri.dart
@@ -28,7 +28,6 @@ const IID_IUri = '{a39ee748-6a27-4817-a6f2-13914bef5890}';
 /// Exposes methods and properties used to parse and build Uniform Resource
 /// Identifiers (URIs).
 ///
-/// {@category Interface}
 /// {@category com}
 class IUri extends IUnknown {
   // vtable begins at 3, is 25 entries long.

--- a/lib/src/com/ivirtualdesktopmanager.dart
+++ b/lib/src/com/ivirtualdesktopmanager.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IVirtualDesktopManager = '{a5cd92ff-29be-454c-8d04-d82879fb3f1b}';
 
-/// {@category Interface}
 /// {@category com}
 class IVirtualDesktopManager extends IUnknown {
   // vtable begins at 3, is 3 entries long.

--- a/lib/src/com/iwbemclassobject.dart
+++ b/lib/src/com/iwbemclassobject.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IWbemClassObject = '{dc12a681-737f-11cf-884d-00aa004b2e24}';
 
-/// {@category Interface}
 /// {@category com}
 class IWbemClassObject extends IUnknown {
   // vtable begins at 3, is 24 entries long.

--- a/lib/src/com/iwbemconfigurerefresher.dart
+++ b/lib/src/com/iwbemconfigurerefresher.dart
@@ -28,7 +28,6 @@ const IID_IWbemConfigureRefresher = '{49353c92-516b-11d1-aea6-00c04fb68820}';
 /// The IWbemConfigureRefresher interface is used by client code to add
 /// enumerators, objects, and nested refreshers into a refresher.
 ///
-/// {@category Interface}
 /// {@category com}
 class IWbemConfigureRefresher extends IUnknown {
   // vtable begins at 3, is 5 entries long.

--- a/lib/src/com/iwbemcontext.dart
+++ b/lib/src/com/iwbemcontext.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IWbemContext = '{44aca674-e8fc-11d0-a07c-00c04fb68820}';
 
-/// {@category Interface}
 /// {@category com}
 class IWbemContext extends IUnknown {
   // vtable begins at 3, is 9 entries long.

--- a/lib/src/com/iwbemhiperfenum.dart
+++ b/lib/src/com/iwbemhiperfenum.dart
@@ -31,7 +31,6 @@ const IID_IWbemHiPerfEnum = '{2705c288-79ae-11d2-b348-00105a1f8177}';
 /// `IWbemHiPerfProvider::CreateRefreshableEnum` is called, and it returns
 /// to clients when `IWbemConfigureRefresher::AddEnum` is called.
 ///
-/// {@category Interface}
 /// {@category com}
 class IWbemHiPerfEnum extends IUnknown {
   // vtable begins at 3, is 4 entries long.

--- a/lib/src/com/iwbemlocator.dart
+++ b/lib/src/com/iwbemlocator.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IWbemLocator = '{dc12a687-737f-11cf-884d-00aa004b2e24}';
 
-/// {@category Interface}
 /// {@category com}
 class IWbemLocator extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iwbemobjectaccess.dart
+++ b/lib/src/com/iwbemobjectaccess.dart
@@ -32,7 +32,6 @@ const IID_IWbemObjectAccess = '{49353c9a-516b-11d1-aea6-00c04fb68820}';
 /// interface, you can get and set properties by using property handles
 /// instead of object property names.
 ///
-/// {@category Interface}
 /// {@category com}
 class IWbemObjectAccess extends IWbemClassObject {
   // vtable begins at 27, is 10 entries long.

--- a/lib/src/com/iwbemrefresher.dart
+++ b/lib/src/com/iwbemrefresher.dart
@@ -25,7 +25,6 @@ import 'iunknown.dart';
 /// @nodoc
 const IID_IWbemRefresher = '{49353c99-516b-11d1-aea6-00c04fb68820}';
 
-/// {@category Interface}
 /// {@category com}
 class IWbemRefresher extends IUnknown {
   // vtable begins at 3, is 1 entries long.

--- a/lib/src/com/iwbemservices.dart
+++ b/lib/src/com/iwbemservices.dart
@@ -29,7 +29,6 @@ const IID_IWbemServices = '{9556dc99-828c-11cf-a37e-00aa003240c7}';
 /// WMI services. The interface is implemented by WMI and WMI providers, and
 /// is the primary WMI interface.
 ///
-/// {@category Interface}
 /// {@category com}
 class IWbemServices extends IUnknown {
   // vtable begins at 3, is 23 entries long.

--- a/lib/src/com/iwebauthenticationcoremanagerinterop.dart
+++ b/lib/src/com/iwebauthenticationcoremanagerinterop.dart
@@ -31,7 +31,6 @@ const IID_IWebAuthenticationCoreManagerInterop =
 /// WebAuthenticationCoreManager that are otherwise available only to UWP
 /// apps.
 ///
-/// {@category Interface}
 /// {@category com}
 class IWebAuthenticationCoreManagerInterop extends IInspectable {
   // vtable begins at 6, is 2 entries long.

--- a/lib/src/com/iwinhttprequest.dart
+++ b/lib/src/com/iwinhttprequest.dart
@@ -27,7 +27,6 @@ const IID_IWinHttpRequest = '{016fe2ec-b2c8-45f8-b23b-39e53a75396b}';
 /// The IWinHttpRequest interface provides all of the nonevent methods for
 /// Microsoft Windows HTTP Services (WinHTTP).
 ///
-/// {@category Interface}
 /// {@category com}
 class IWinHttpRequest extends IDispatch {
   // vtable begins at 7, is 19 entries long.

--- a/lib/src/combase.dart
+++ b/lib/src/combase.dart
@@ -21,7 +21,6 @@ typedef VTablePointer = Pointer<Pointer<IntPtr>>;
 /// A representation of a generic COM object. All Dart COM objects inherit from
 /// this class.
 ///
-/// {@category Interface}
 /// {@category com}
 base class COMObject extends Struct {
   external VTablePointer lpVtbl;

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -5802,7 +5802,7 @@ final VARIANT_FALSE = 0;
 
 /// Specifies the variant types.
 ///
-/// {@category Enum}
+/// {@category enum}
 class VARENUM {
   static const VT_EMPTY = 0;
   static const VT_NULL = 1;
@@ -6628,7 +6628,7 @@ const MONITORINFOF_PRIMARY = 0x00000001;
 
 /// Describes a monitor's color temperature.
 ///
-/// {@category Enum}
+/// {@category enum}
 class MC_COLOR_TEMPERATURE {
   static const MC_COLOR_TEMPERATURE_UNKNOWN = 0;
   static const MC_COLOR_TEMPERATURE_4000K = 1;
@@ -6643,7 +6643,7 @@ class MC_COLOR_TEMPERATURE {
 
 /// Identifies monitor display technologies.
 ///
-/// {@category Enum}
+/// {@category enum}
 class MC_DISPLAY_TECHNOLOGY_TYPE {
   static const MC_SHADOW_MASK_CATHODE_RAY_TUBE = 0;
   static const MC_APERTURE_GRILL_CATHODE_RAY_TUBE = 1;
@@ -6658,7 +6658,7 @@ class MC_DISPLAY_TECHNOLOGY_TYPE {
 
 /// Specifies whether to set or get a monitor's red, green, or blue drive.
 ///
-/// {@category Enum}
+/// {@category enum}
 class MC_DRIVE_TYPE {
   static const MC_RED_DRIVE = 0;
   static const MC_GREEN_DRIVE = 1;
@@ -6667,7 +6667,7 @@ class MC_DRIVE_TYPE {
 
 /// Specifies whether to get or set a monitor's red, green, or blue gain.
 ///
-/// {@category Enum}
+/// {@category enum}
 class MC_GAIN_TYPE {
   static const MC_RED_GAIN = 0;
   static const MC_GREEN_GAIN = 1;
@@ -6677,7 +6677,7 @@ class MC_GAIN_TYPE {
 /// Specifies whether to get or set the vertical or horizontal position of a
 /// monitor's display area.
 ///
-/// {@category Enum}
+/// {@category enum}
 class MC_POSITION_TYPE {
   static const MC_HORIZONTAL_POSITION = 0;
   static const MC_VERTICAL_POSITION = 1;
@@ -6686,7 +6686,7 @@ class MC_POSITION_TYPE {
 /// Specifies whether to get or set the width or height of a monitor's display
 /// area.
 ///
-/// {@category Enum}
+/// {@category enum}
 class MC_SIZE_TYPE {
   static const MC_WIDTH = 0;
   static const MC_HEIGHT = 1;
@@ -6694,7 +6694,7 @@ class MC_SIZE_TYPE {
 
 /// Identifies the dots per inch (dpi) setting for a thread, process, or window.
 ///
-/// {@category Enum}
+/// {@category enum}
 class DPI_AWARENESS {
   /// Invalid DPI awareness. This is an invalid DPI awareness value.
   static const DPI_AWARENESS_INVALID = -1;
@@ -6755,7 +6755,7 @@ const DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED = -5;
 /// windows created in the thread to host child windows with a different
 /// DPI_AWARENESS_CONTEXT.
 ///
-/// {@category Enum}
+/// {@category enum}
 class DPI_HOSTING_BEHAVIOR {
   /// Invalid DPI hosting behavior. This usually occurs if the previous
   /// SetThreadDpiHostingBehavior call used an invalid parameter.
@@ -6776,7 +6776,7 @@ class DPI_HOSTING_BEHAVIOR {
 /// much scaling work an application performs for DPI versus how much is done by
 /// the system.
 ///
-/// {@category Enum}
+/// {@category enum}
 class PROCESS_DPI_AWARENESS {
   /// DPI unaware. This app does not scale for DPI changes and is always assumed
   /// to have a scale factor of 100% (96 DPI). It will be automatically scaled
@@ -6798,7 +6798,7 @@ class PROCESS_DPI_AWARENESS {
 
 /// Identifies the dots per inch (dpi) setting for a monitor.
 ///
-/// {@category Enum}
+/// {@category enum}
 class MONITOR_DPI_TYPE {
   /// The effective DPI. This value should be used when determining the correct
   /// scale factor for scaling UI elements. This incorporates the scale factor
@@ -7412,7 +7412,7 @@ const DTT_VALIDBITS = DTT_TEXTCOLOR |
 /// within dialogs. The values in this enumeration are bitfields and can be
 /// combined.
 ///
-/// {@category Enum}
+/// {@category enum}
 class DIALOG_CONTROL_DPI_CHANGE_BEHAVIORS {
   /// The default behavior of the dialog manager. The dialog managed will update
   /// the font, size, and position of the child window on DPI changes.
@@ -7433,7 +7433,7 @@ class DIALOG_CONTROL_DPI_CHANGE_BEHAVIORS {
 /// with SetDialogDpiChangeBehavior in order to override the default DPI scaling
 /// behavior for dialogs.
 ///
-/// {@category Enum}
+/// {@category enum}
 class DIALOG_DPI_CHANGE_BEHAVIORS {
   /// The default behavior of the dialog manager. In response to a DPI change,
   /// the dialog manager will re-layout each control, update the font on each
@@ -7488,7 +7488,7 @@ const DISPLAY_DEVICE_MODESPRUNED = 0x08000000;
 /// The BLUETOOTH_AUTHENTICATION_METHOD enumeration defines the supported
 /// authentication types during device pairing.
 ///
-/// {@category Enum}
+/// {@category enum}
 class BLUETOOTH_AUTHENTICATION_METHOD {
   static const BLUETOOTH_AUTHENTICATION_METHOD_LEGACY = 0;
   static const BLUETOOTH_AUTHENTICATION_METHOD_OOB = 1;
@@ -7500,7 +7500,7 @@ class BLUETOOTH_AUTHENTICATION_METHOD {
 /// The BLUETOOTH_AUTHENTICATION_REQUIREMENTS enumeration specifies the 'Man in
 /// the Middle' protection required for authentication.
 ///
-/// {@category Enum}
+/// {@category enum}
 class BLUETOOTH_AUTHENTICATION_REQUIREMENTS {
   static const BLUETOOTH_MITM_ProtectionNotRequired = 0;
   static const BLUETOOTH_MITM_ProtectionRequired = 1;
@@ -7514,7 +7514,7 @@ class BLUETOOTH_AUTHENTICATION_REQUIREMENTS {
 /// The BLUETOOTH_IO_CAPABILITY enumeration defines the input/output
 /// capabilities of a Bluetooth Device.
 ///
-/// {@category Enum}
+/// {@category enum}
 class BLUETOOTH_IO_CAPABILITY {
   static const BLUETOOTH_IO_CAPABILITY_DISPLAYONLY = 0;
   static const BLUETOOTH_IO_CAPABILITY_DISPLAYYESNO = 1;
@@ -7529,7 +7529,7 @@ class BLUETOOTH_IO_CAPABILITY {
 
 /// Defines the set of options available to an Open or Save dialog.
 ///
-/// {@category Enum}
+/// {@category enum}
 class FILEOPENDIALOGOPTIONS {
   static const FOS_OVERWRITEPROMPT = 0x2;
   static const FOS_STRICTFILETYPES = 0x4;
@@ -7562,7 +7562,7 @@ class FILEOPENDIALOGOPTIONS {
 
 /// Desktop wallpaper slideshow settings for shuffling images.
 ///
-/// {@category Enum}
+/// {@category enum}
 class DESKTOP_SLIDESHOW_OPTIONS {
   /// Shuffle is enabled; the images are shown in a random order.
   static const DSO_SHUFFLEIMAGES = 0x1;
@@ -7570,7 +7570,7 @@ class DESKTOP_SLIDESHOW_OPTIONS {
 
 /// Gets the current status of the slideshow.
 ///
-/// {@category Enum}
+/// {@category enum}
 class DESKTOP_SLIDESHOW_STATE {
   /// Slideshows are enabled.
   static const DSS_ENABLED = 0x1;
@@ -7584,7 +7584,7 @@ class DESKTOP_SLIDESHOW_STATE {
 
 /// The direction that the slideshow should advance.
 ///
-/// {@category Enum}
+/// {@category enum}
 class DESKTOP_SLIDESHOW_DIRECTION {
   /// Advance the slideshow forward.
   static const DSD_FORWARD = 0;
@@ -7595,7 +7595,7 @@ class DESKTOP_SLIDESHOW_DIRECTION {
 
 /// Specifies how the desktop wallpaper should be displayed.
 ///
-/// {@category Enum}
+/// {@category enum}
 class DESKTOP_WALLPAPER_POSITION {
   /// Center the image; do not stretch.
   static const DWPOS_CENTER = 0;
@@ -8241,7 +8241,7 @@ const LR_SHARED = 0x00008000;
 /// Determines the concurrency model used for incoming calls to the objects
 /// created by this thread.
 ///
-/// {@category Enum}
+/// {@category enum}
 class RO_INIT_TYPE {
   static const RO_INIT_SINGLETHREADED = 0;
 
@@ -8256,7 +8256,7 @@ class RO_INIT_TYPE {
 
 /// Identifies the type of corrective action to be taken for a spelling error.
 ///
-/// {@category Enum}
+/// {@category enum}
 class CORRECTIVE_ACTION {
   /// There are no errors.
   static const NONE = 0;
@@ -8638,7 +8638,7 @@ class DWM_WINDOW_CORNER_PREFERENCE {
 /// The TOKEN_INFORMATION_CLASS enumeration contains values that specify the
 /// type of information being assigned to or retrieved from an access token.
 ///
-/// {@category Struct}
+/// {@category struct}
 class TOKEN_INFORMATION_CLASS {
   static const TokenUser = 1;
   static const TokenGroups = 2;
@@ -8954,7 +8954,7 @@ const GW_OWNER = 4;
 /// The WSL_DISTRIBUTION_FLAGS enumeration specifies the behavior of a
 /// distribution in the Windows Subsystem for Linux (WSL).
 ///
-/// {@category Enum}
+/// {@category enum}
 class WSL_DISTRIBUTION_FLAGS {
   /// No flags are being supplied.
   static const WSL_DISTRIBUTION_FLAGS_NONE = 0x0;
@@ -9364,7 +9364,7 @@ const SDC_VIRTUAL_REFRESH_RATE_AWARE = 0x00020000;
 /// The AUDCLNT_SHAREMODE enumeration defines constants that indicate whether an
 /// audio stream will run in shared mode or in exclusive mode.
 ///
-/// {@category Enum}
+/// {@category enum}
 class AUDCLNT_SHAREMODE {
   /// The audio stream will run in shared mode.
   static const AUDCLNT_SHAREMODE_SHARED = 0;
@@ -9376,7 +9376,7 @@ class AUDCLNT_SHAREMODE {
 /// The AUDCLNT_BUFFERFLAGS enumeration defines flags that indicate the status
 /// of an audio endpoint buffer.
 ///
-/// {@category Enum}
+/// {@category enum}
 class AUDCLNT_BUFFERFLAGS {
   /// The data in the packet is not correlated with the previous packet's device
   /// position; this is possibly due to a stream state transition or timing
@@ -9395,7 +9395,7 @@ class AUDCLNT_BUFFERFLAGS {
 
 /// Defines values that describe the characteristics of an audio stream.
 ///
-/// {@category Enum}
+/// {@category enum}
 class AUDCLNT_STREAMOPTIONS {
   /// No stream options.
   static const AUDCLNT_STREAMOPTIONS_NONE = 0;
@@ -9413,7 +9413,7 @@ class AUDCLNT_STREAMOPTIONS {
 
 /// Device registry property codes.
 ///
-/// {@category Enum}
+/// {@category enum}
 class SPDRP {
   /// The function retrieves a REG_SZ string that contains the description of a
   /// device.
@@ -9560,7 +9560,7 @@ class SPDRP {
 
 /// Specifies the set of possible COM apartment type qualifiers.
 ///
-/// {@category Enum}
+/// {@category enum}
 class APTTYPEQUALIFIER {
   /// No qualifier information for the current COM apartment type is available.
   static const APTTYPEQUALIFIER_NONE = 0;
@@ -9613,7 +9613,7 @@ class APTTYPEQUALIFIER {
 
 /// Specifies different types of apartments.
 ///
-/// {@category Enum}
+/// {@category enum}
 class APTTYPE {
   /// The current thread.
   static const APTTYPE_CURRENT = -1;
@@ -9634,7 +9634,7 @@ class APTTYPE {
 /// Contains values that specify the type of reference to use when returning UI
 /// Automation elements.
 ///
-/// {@category Enum}
+/// {@category enum}
 class AutomationElementMode {
   /// Specifies that returned elements have no reference to the underlying UI
   /// and contain only cached information.
@@ -9649,7 +9649,7 @@ class AutomationElementMode {
 /// whether an accessible technology client receives all events, or a subset
 /// where duplicate events are detected and filtered.
 ///
-/// {@category Enum}
+/// {@category enum}
 class CoalesceEventsOptions {
   /// Event coalescing is disabled.
   static const CoalesceEventsOptions_Disabled = 0;
@@ -9662,7 +9662,7 @@ class CoalesceEventsOptions {
 /// indicates whether an accessible technology client adjusts provider request
 /// timeouts when the provider is non-responsive.
 ///
-/// {@category Enum}
+/// {@category enum}
 class ConnectionRecoveryBehaviorOptions {
   /// Connection recovery is disabled.
   static const ConnectionRecoveryBehaviorOptions_Disabled = 0;
@@ -9674,7 +9674,7 @@ class ConnectionRecoveryBehaviorOptions {
 /// The PropertyConditionFlags (uiautomationclient.h) enumeration contains
 /// values used in creating property conditions.
 ///
-/// {@category Enum}
+/// {@category enum}
 class PropertyConditionFlags {
   /// No flags.
   static const PropertyConditionFlags_None = 0;
@@ -9688,7 +9688,7 @@ class PropertyConditionFlags {
 
 /// Contains values that specify the direction and distance to scroll.
 ///
-/// {@category Enum}
+/// {@category enum}
 class ScrollAmount {
   /// Scrolling is done in large decrements, equivalent to pressing the PAGE UP
   /// key or clicking on a blank part of a scroll bar.
@@ -9713,7 +9713,7 @@ class ScrollAmount {
 /// Contains values that specify the toggle state of a Microsoft UI Automation
 /// element that implements the Toggle control pattern.
 ///
-/// {@category Enum}
+/// {@category enum}
 class ToggleState {
   /// The UI Automation element is not selected, checked, marked or otherwise
   /// activated.
@@ -9756,7 +9756,7 @@ class TreeScope {
 /// The TreeTraversalOptions enumeration defines values that can be used to
 /// customize tree navigation order.
 ///
-/// {@category Enum}
+/// {@category enum}
 class TreeTraversalOptions {
   /// Pre-order, visit children from first to last.
   static const TreeTraversalOptions_Default = 0;
@@ -9771,7 +9771,7 @@ class TreeTraversalOptions {
 /// Contains values that specify the current state of the window for purposes
 /// of user interaction.
 ///
-/// {@category Enum}
+/// {@category enum}
 class WindowInteractionState {
   /// The window is running. This does not guarantee that the window is ready
   /// for user interaction or is responding.
@@ -9792,7 +9792,7 @@ class WindowInteractionState {
 
 /// Contains values that specify the visual state of a window.
 ///
-/// {@category Enum}
+/// {@category enum}
 class WindowVisualState {
   /// The window is normal (restored).
   static const WindowVisualState_Normal = 0;
@@ -10732,7 +10732,7 @@ const UIA_IsWindowPatternAvailablePropertyId = 30044;
 
 /// Possible settings for the Automatic Logon Policy.
 ///
-/// {@category Enum}
+/// {@category enum}
 class WinHttpRequestAutoLogonPolicy {
   /// An authenticated log on, using the default credentials, is performed for
   /// all requests.
@@ -10749,7 +10749,7 @@ class WinHttpRequestAutoLogonPolicy {
 
 /// Options that can be set or retrieved for the current WinHTTP session.
 ///
-/// {@category Enum}
+/// {@category enum}
 class WinHttpRequestOption {
   /// Sets or retrieves a VARIANT that contains the user agent string.
   static const WinHttpRequestOption_UserAgentString = 0;

--- a/lib/src/constants_nodoc.dart
+++ b/lib/src/constants_nodoc.dart
@@ -817,7 +817,7 @@ const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE =
             PROC_THREAD_ATTRIBUTE_NUMBER) |
         PROC_THREAD_ATTRIBUTE_INPUT;
 
-/// {@category Enum}
+/// {@category enum}
 class PROC_THREAD_ATTRIBUTE_NUM {
   static const ProcThreadAttributeParentProcess = 0;
   static const ProcThreadAttributeHandleList = 2;
@@ -1356,7 +1356,7 @@ final TD_ERROR_ICON = Pointer<Utf16>.fromAddress(0xFFFE);
 final TD_INFORMATION_ICON = Pointer<Utf16>.fromAddress(0xFFFD);
 final TD_SHIELD_ICON = Pointer<Utf16>.fromAddress(0xFFFC);
 
-/// {@category Enum}
+/// {@category enum}
 class TASKDIALOG_FLAGS {
   static const int TDF_ENABLE_HYPERLINKS = 0x0001;
   static const int TDF_USE_HICON_MAIN = 0x0002;
@@ -1378,7 +1378,7 @@ class TASKDIALOG_FLAGS {
   static const int TDF_SIZE_TO_CONTENT = 0x01000000;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class TASKDIALOG_COMMON_BUTTON_FLAGS {
   static const int TDCBF_OK_BUTTON = 0x0001;
   static const int TDCBF_YES_BUTTON = 0x0002;
@@ -1388,14 +1388,14 @@ class TASKDIALOG_COMMON_BUTTON_FLAGS {
   static const int TDCBF_CLOSE_BUTTON = 0x0020;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class THEMESIZE {
   static const int TS_MIN = 0;
   static const int TS_TRUE = 1;
   static const int TS_DRAW = 2;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class WINDOWPARTS {
   static const int WP_CAPTION = 1;
   static const int WP_SMALLCAPTION = 2;
@@ -1438,34 +1438,34 @@ class WINDOWPARTS {
   static const int WP_BORDER = 39;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class FRAMESTATES {
   static const int FS_ACTIVE = 1;
   static const int FS_INACTIVE = 2;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class CAPTIONSTATES {
   static const int CS_ACTIVE = 1;
   static const int CS_INACTIVE = 2;
   static const int CS_DISABLED = 3;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class MAXCAPTIONSTATES {
   static const int MXCS_ACTIVE = 1;
   static const int MXCS_INACTIVE = 2;
   static const int MXCS_DISABLED = 3;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class MINCAPTIONSTATES {
   static const int MNCS_ACTIVE = 1;
   static const int MNCS_INACTIVE = 2;
   static const int MNCS_DISABLED = 3;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class HORZSCROLLSTATES {
   static const int HSS_NORMAL = 1;
   static const int HSS_HOT = 2;
@@ -1473,7 +1473,7 @@ class HORZSCROLLSTATES {
   static const int HSS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class HORZTHUMBSTATES {
   static const int HTS_NORMAL = 1;
   static const int HTS_HOT = 2;
@@ -1481,7 +1481,7 @@ class HORZTHUMBSTATES {
   static const int HTS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class VERTSCROLLSTATES {
   static const int VSS_NORMAL = 1;
   static const int VSS_HOT = 2;
@@ -1489,7 +1489,7 @@ class VERTSCROLLSTATES {
   static const int VSS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class VERTTHUMBSTATES {
   static const int VTS_NORMAL = 1;
   static const int VTS_HOT = 2;
@@ -1497,7 +1497,7 @@ class VERTTHUMBSTATES {
   static const int VTS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class SYSBUTTONSTATES {
   static const int SBS_NORMAL = 1;
   static const int SBS_HOT = 2;
@@ -1505,7 +1505,7 @@ class SYSBUTTONSTATES {
   static const int SBS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class MINBUTTONSTATES {
   static const int MINBS_NORMAL = 1;
   static const int MINBS_HOT = 2;
@@ -1513,7 +1513,7 @@ class MINBUTTONSTATES {
   static const int MINBS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class MAXBUTTONSTATES {
   static const int MAXBS_NORMAL = 1;
   static const int MAXBS_HOT = 2;
@@ -1521,7 +1521,7 @@ class MAXBUTTONSTATES {
   static const int MAXBS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class RESTOREBUTTONSTATES {
   static const int RBS_NORMAL = 1;
   static const int RBS_HOT = 2;
@@ -1529,7 +1529,7 @@ class RESTOREBUTTONSTATES {
   static const int RBS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class HELPBUTTONSTATES {
   static const int HBS_NORMAL = 1;
   static const int HBS_HOT = 2;
@@ -1537,7 +1537,7 @@ class HELPBUTTONSTATES {
   static const int HBS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class CLOSEBUTTONSTATES {
   static const int CBS_NORMAL = 1;
   static const int CBS_HOT = 2;
@@ -1545,7 +1545,7 @@ class CLOSEBUTTONSTATES {
   static const int CBS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class SMALLCLOSEBUTTONSTATES {
   static const int SCBS_NORMAL = 1;
   static const int SCBS_HOT = 2;
@@ -1553,50 +1553,50 @@ class SMALLCLOSEBUTTONSTATES {
   static const int SCBS_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class FRAMEBOTTOMSTATES {
   static const int FRB_ACTIVE = 1;
   static const int FRB_INACTIVE = 2;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class FRAMELEFTSTATES {
   static const int FRL_ACTIVE = 1;
   static const int FRL_INACTIVE = 2;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class FRAMERIGHTSTATES {
   static const int FRR_ACTIVE = 1;
   static const int FRR_INACTIVE = 2;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class SMALLCAPTIONSTATES {
   static const int SCS_ACTIVE = 1;
   static const int SCS_INACTIVE = 2;
   static const int SCS_DISABLED = 3;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class SMALLFRAMEBOTTOMSTATES {
   static const int SFRB_ACTIVE = 1;
   static const int SFRB_INACTIVE = 2;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class SMALLFRAMELEFTSTATES {
   static const int SFRL_ACTIVE = 1;
   static const int SFRL_INACTIVE = 2;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class SMALLFRAMERIGHTSTATES {
   static const int SFRR_ACTIVE = 1;
   static const int SFRR_INACTIVE = 2;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class MDICLOSEBUTTONSTATES {
   static const int MDCL_NORMAL = 1;
   static const int MDCL_HOT = 2;
@@ -1604,7 +1604,7 @@ class MDICLOSEBUTTONSTATES {
   static const int MDCL_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class MDIMINBUTTONSTATES {
   static const int MDMI_NORMAL = 1;
   static const int MDMI_HOT = 2;
@@ -1612,7 +1612,7 @@ class MDIMINBUTTONSTATES {
   static const int MDMI_DISABLED = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class MDIRESTOREBUTTONSTATES {
   static const int MDRE_NORMAL = 1;
   static const int MDRE_HOT = 2;
@@ -2022,7 +2022,7 @@ const BLUETOOTH_DEVICE_NAME_SIZE = 256;
 const BTH_MAX_PIN_SIZE = 16;
 const BTH_LINK_KEY_LENGTH = 16;
 
-/// {@category Enum}
+/// {@category enum}
 class POWER_INFORMATION_LEVEL {
   static const SystemPowerPolicyAc = 0;
   static const SystemPowerPolicyDc = 1;
@@ -2123,19 +2123,19 @@ class POWER_INFORMATION_LEVEL {
   static const PowerInformationLevelMaximum = 96;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class FFFP_MODE {
   static const FFFP_EXACTMATCH = 0;
   static const FFFP_NEARESTPARENTMATCH = FFFP_EXACTMATCH + 1;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class FDAP {
   static const FDAP_BOTTOM = 0;
   static const FDAP_TOP = 1;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class KF_CATEGORY {
   static const KF_CATEGORY_VIRTUAL = 1;
   static const KF_CATEGORY_FIXED = 2;
@@ -2143,7 +2143,7 @@ class KF_CATEGORY {
   static const KF_CATEGORY_PERUSER = 4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class KF_DEFINITION_FLAGS {
   static const KFDF_LOCAL_REDIRECT_ONLY = 0x2;
   static const KFDF_ROAMABLE = 0x4;
@@ -2153,7 +2153,7 @@ class KF_DEFINITION_FLAGS {
   static const KFDF_NO_REDIRECT_UI = 0x4;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class KF_REDIRECT_FLAGS {
   static const KF_REDIRECT_USER_EXCLUSIVE = 0x1;
   static const KF_REDIRECT_COPY_SOURCE_DACL = 0x2;
@@ -2170,7 +2170,7 @@ class KF_REDIRECT_FLAGS {
 
 /// Specifies a type of computer name.
 ///
-/// {@category Enum}
+/// {@category enum}
 class COMPUTER_NAME_FORMAT {
   static const ComputerNameNetBIOS = 0;
   static const ComputerNameDnsHostname = 1;
@@ -2183,7 +2183,7 @@ class COMPUTER_NAME_FORMAT {
   static const ComputerNameMax = 8;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class KF_REDIRECTION_CAPABILITIES {
   static const KF_REDIRECTION_CAPABILITIES_ALLOW_ALL = 0xff;
   static const KF_REDIRECTION_CAPABILITIES_REDIRECTABLE = 0x1;
@@ -2193,7 +2193,7 @@ class KF_REDIRECTION_CAPABILITIES {
   static const KF_REDIRECTION_CAPABILITIES_DENY_PERMISSIONS = 0x400;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class SIGDN {
   static const SIGDN_NORMALDISPLAY = 0;
   static const SIGDN_PARENTRELATIVEPARSING = 0x80018001;
@@ -2207,7 +2207,7 @@ class SIGDN {
   static const SIGDN_PARENTRELATIVEFORUI = 0x8009400;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class EOLE_AUTHENTICATION_CAPABILITIES {
   static const EOAC_NONE = 0;
   static const EOAC_MUTUAL_AUTH = 0x1;
@@ -2227,7 +2227,7 @@ class EOLE_AUTHENTICATION_CAPABILITIES {
   static const EOAC_RESERVED1 = 0x4000;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class WBEM_GENERIC_FLAG_TYPE {
   static const WBEM_FLAG_RETURN_IMMEDIATELY = 0x10;
   static const WBEM_FLAG_RETURN_WBEM_COMPLETE = 0;
@@ -2247,19 +2247,19 @@ class WBEM_GENERIC_FLAG_TYPE {
   static const WBEM_FLAG_STRONG_VALIDATION = 0x100000;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class WBEM_REFRESHER_FLAGS {
   static const WBEM_FLAG_REFRESH_AUTO_RECONNECT = 0;
   static const WBEM_FLAG_REFRESH_NO_AUTO_RECONNECT = 1;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class WBEM_TIMEOUT_TYPE {
   static const WBEM_NO_WAIT = 0;
   static const WBEM_INFINITE = 0xffffffff;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class NLM_CONNECTIVITY {
   static const NLM_CONNECTIVITY_DISCONNECTED = 0;
   static const NLM_CONNECTIVITY_IPV4_NOTRAFFIC = 0x1;
@@ -2272,7 +2272,7 @@ class NLM_CONNECTIVITY {
   static const NLM_CONNECTIVITY_IPV6_INTERNET = 0x400;
 }
 
-/// {@category Enum}
+/// {@category enum}
 class NLM_ENUM_NETWORK {
   static const NLM_ENUM_NETWORK_CONNECTED = 0x1;
   static const NLM_ENUM_NETWORK_DISCONNECTED = 0x2;

--- a/lib/src/guid.dart
+++ b/lib/src/guid.dart
@@ -166,7 +166,7 @@ class Guid {
 
 /// Represents a native globally unique identifier (GUID).
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(4)
 base class GUID extends Struct {
   @Uint32()

--- a/lib/src/structs.g.dart
+++ b/lib/src/structs.g.dart
@@ -22,7 +22,7 @@ import 'variant.dart';
 
 /// Defines an accelerator key used in an accelerator table.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ACCEL extends Struct {
   @Uint8()
   external int fVirt;
@@ -38,7 +38,7 @@ base class ACCEL extends Struct {
 /// complete ACL consists of an ACL structure followed by an ordered list of
 /// zero or more access control entries (ACEs).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ACL extends Struct {
   @Uint8()
   external int AclRevision;
@@ -59,7 +59,7 @@ base class ACL extends Struct {
 /// The ACTCTX structure is used by the CreateActCtx function to create the
 /// activation context.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ACTCTX extends Struct {
   @Uint32()
   external int cbSize;
@@ -88,7 +88,7 @@ base class ACTCTX extends Struct {
 /// The ADDJOB_INFO_1 structure identifies a print job as well as the
 /// directory and file in which an application can store that job.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ADDJOB_INFO_1 extends Struct {
   external Pointer<Utf16> Path;
 
@@ -99,7 +99,7 @@ base class ADDJOB_INFO_1 extends Struct {
 /// The addrinfoW structure is used by the GetAddrInfoW function to hold
 /// host address information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ADDRINFO extends Struct {
   @Int32()
   external int ai_flags;
@@ -126,7 +126,7 @@ base class ADDRINFO extends Struct {
 /// Contains status information for the application-switching (ALT+TAB)
 /// window.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ALTTABINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -157,7 +157,7 @@ base class ALTTABINFO extends Struct {
 
 /// Represents package settings used to create a package.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class APPX_PACKAGE_SETTINGS extends Struct {
   @Int32()
   external int forceZip32;
@@ -167,7 +167,7 @@ base class APPX_PACKAGE_SETTINGS extends Struct {
 
 /// Describes an array, its element type, and its dimension.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ARRAYDESC extends Struct {
   external TYPEDESC tdescElem;
 
@@ -182,7 +182,7 @@ base class ARRAYDESC extends Struct {
 /// version and its level of support for locales, processors, and operating
 /// systems.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ASSEMBLYMETADATA extends Struct {
   @Uint16()
   external int usMajorVersion;
@@ -214,7 +214,7 @@ base class ASSEMBLYMETADATA extends Struct {
 
 /// Contains parameters used during a moniker-binding operation.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BIND_OPTS extends Struct {
   @Uint32()
   external int cbStruct;
@@ -232,7 +232,7 @@ base class BIND_OPTS extends Struct {
 /// The BITMAP structure defines the type, width, height, color format, and
 /// bit values of a bitmap.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BITMAP extends Struct {
   @Int32()
   external int bmType;
@@ -258,7 +258,7 @@ base class BITMAP extends Struct {
 /// The BITMAPFILEHEADER structure contains information about the type,
 /// size, and layout of a file that contains a DIB.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(2)
 base class BITMAPFILEHEADER extends Struct {
   @Uint16()
@@ -280,7 +280,7 @@ base class BITMAPFILEHEADER extends Struct {
 /// The BITMAPINFO structure defines the dimensions and color information
 /// for a device-independent bitmap (DIB).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BITMAPINFO extends Struct {
   external BITMAPINFOHEADER bmiHeader;
 
@@ -291,7 +291,7 @@ base class BITMAPINFO extends Struct {
 /// The BITMAPINFOHEADER structure contains information about the dimensions
 /// and color format of a device-independent bitmap (DIB).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BITMAPINFOHEADER extends Struct {
   @Uint32()
   external int biSize;
@@ -330,7 +330,7 @@ base class BITMAPINFOHEADER extends Struct {
 /// The BLENDFUNCTION structure controls blending by specifying the blending
 /// functions for source and destination bitmaps.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLENDFUNCTION extends Struct {
   @Uint8()
   external int BlendOp;
@@ -348,12 +348,12 @@ base class BLENDFUNCTION extends Struct {
 /// The BLUETOOTH_ADDRESS structure provides the address of a Bluetooth
 /// device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_ADDRESS extends Struct {
   external _BLUETOOTH_ADDRESS__Anonymous_e__Union Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _BLUETOOTH_ADDRESS__Anonymous_e__Union extends Union {
   @Uint64()
   external int ullLong;
@@ -373,7 +373,7 @@ extension BLUETOOTH_ADDRESS_Extension on BLUETOOTH_ADDRESS {
 /// The BLUETOOTH_AUTHENTICATE_RESPONSE structure contains information
 /// passed in response to a BTH_REMOTE_AUTHENTICATE_REQUEST event.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_AUTHENTICATE_RESPONSE extends Struct {
   external BLUETOOTH_ADDRESS bthAddressRemote;
 
@@ -386,7 +386,7 @@ base class BLUETOOTH_AUTHENTICATE_RESPONSE extends Struct {
   external int negativeResponse;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _BLUETOOTH_AUTHENTICATE_RESPONSE__Anonymous_e__Union
     extends Union {
   external BLUETOOTH_PIN_INFO pinInfo;
@@ -420,7 +420,7 @@ extension BLUETOOTH_AUTHENTICATE_RESPONSE_Extension
 /// configuration information about the Bluetooth device responding to an
 /// authentication request.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS extends Struct {
   external BLUETOOTH_DEVICE_INFO deviceInfo;
 
@@ -437,7 +437,7 @@ base class BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS extends Struct {
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS__Anonymous_e__Union
     extends Union {
   @Uint32()
@@ -459,7 +459,7 @@ extension BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS_Extension
 /// The BLUETOOTH_COD_PAIRS structure provides for specification and
 /// retrieval of Bluetooth Class Of Device (COD) information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_COD_PAIRS extends Struct {
   @Uint32()
   external int ulCODMask;
@@ -470,7 +470,7 @@ base class BLUETOOTH_COD_PAIRS extends Struct {
 /// The BLUETOOTH_DEVICE_INFO structure provides information about a
 /// Bluetooth device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_DEVICE_INFO extends Struct {
   @Uint32()
   external int dwSize;
@@ -516,7 +516,7 @@ base class BLUETOOTH_DEVICE_INFO extends Struct {
 /// The BLUETOOTH_DEVICE_SEARCH_PARAMS structure specifies search criteria
 /// for Bluetooth device searches.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_DEVICE_SEARCH_PARAMS extends Struct {
   @Uint32()
   external int dwSize;
@@ -546,7 +546,7 @@ base class BLUETOOTH_DEVICE_SEARCH_PARAMS extends Struct {
 /// The BLUETOOTH_FIND_RADIO_PARAMS structure facilitates enumerating
 /// installed Bluetooth radios.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_FIND_RADIO_PARAMS extends Struct {
   @Uint32()
   external int dwSize;
@@ -555,7 +555,7 @@ base class BLUETOOTH_FIND_RADIO_PARAMS extends Struct {
 /// The BLUETOOTH_GATT_VALUE_CHANGED_EVENT structure describes a changed
 /// attribute value.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_GATT_VALUE_CHANGED_EVENT extends Struct {
   @Uint16()
   external int ChangedAttributeHandle;
@@ -569,7 +569,7 @@ base class BLUETOOTH_GATT_VALUE_CHANGED_EVENT extends Struct {
 /// The BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRATION structure describes
 /// one or more characteristics that have changed.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRATION extends Struct {
   @Uint16()
   external int NumCharacteristics;
@@ -581,7 +581,7 @@ base class BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRATION extends Struct {
 /// The BLUETOOTH_NUMERIC_COMPARISON_INFO structure contains the numeric
 /// value used for authentication via numeric comparison.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_NUMERIC_COMPARISON_INFO extends Struct {
   @Uint32()
   external int NumericValue;
@@ -590,7 +590,7 @@ base class BLUETOOTH_NUMERIC_COMPARISON_INFO extends Struct {
 /// The BLUETOOTH_OOB_DATA_INFO structure contains data used to authenticate
 /// prior to establishing an Out-of-Band device pairing.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_OOB_DATA_INFO extends Struct {
   @Array(16)
   external Array<Uint8> C;
@@ -603,7 +603,7 @@ base class BLUETOOTH_OOB_DATA_INFO extends Struct {
 /// authentication. A passkey is similar to a password, except that a
 /// passkey value is used for authentication only once.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_PASSKEY_INFO extends Struct {
   @Uint32()
   external int passkey;
@@ -612,7 +612,7 @@ base class BLUETOOTH_PASSKEY_INFO extends Struct {
 /// The BLUETOOTH_PIN_INFO structure contains information used for
 /// authentication via PIN.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_PIN_INFO extends Struct {
   @Array(16)
   external Array<Uint8> pin;
@@ -624,7 +624,7 @@ base class BLUETOOTH_PIN_INFO extends Struct {
 /// The BLUETOOTH_RADIO_INFO structure provides information about a
 /// Bluetooth radio.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_RADIO_INFO extends Struct {
   @Uint32()
   external int dwSize;
@@ -664,7 +664,7 @@ base class BLUETOOTH_RADIO_INFO extends Struct {
 /// visibility, authentication, and selection of Bluetooth devices and
 /// services.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BLUETOOTH_SELECT_DEVICE_PARAMS extends Struct {
   @Uint32()
   external int dwSize;
@@ -710,7 +710,7 @@ base class BLUETOOTH_SELECT_DEVICE_PARAMS extends Struct {
 /// Contains information about a window that denied a request from
 /// BroadcastSystemMessageEx.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BSMINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -727,7 +727,7 @@ base class BSMINFO extends Struct {
 /// The BTH_DEVICE_INFO structure stores information about a Bluetooth
 /// device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_DEVICE_INFO extends Struct {
   @Uint32()
   external int flags;
@@ -745,7 +745,7 @@ base class BTH_DEVICE_INFO extends Struct {
 /// The BTH_HCI_EVENT_INFO structure is used in connection with obtaining
 /// WM_DEVICECHANGE messages for Bluetooth.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_HCI_EVENT_INFO extends Struct {
   @Uint64()
   external int bthAddress;
@@ -760,7 +760,7 @@ base class BTH_HCI_EVENT_INFO extends Struct {
 /// The BTH_L2CAP_EVENT_INFO structure contains data about events associated
 /// with an L2CAP channel.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_L2CAP_EVENT_INFO extends Struct {
   @Uint64()
   external int bthAddress;
@@ -778,7 +778,7 @@ base class BTH_L2CAP_EVENT_INFO extends Struct {
 /// The BTH_LE_GATT_CHARACTERISTIC structure describes a Bluetooth Low
 /// Energy (LE) generic attribute (GATT) profile characteristic.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_LE_GATT_CHARACTERISTIC extends Struct {
   @Uint16()
   external int ServiceHandle;
@@ -819,7 +819,7 @@ base class BTH_LE_GATT_CHARACTERISTIC extends Struct {
 /// The BTH_LE_GATT_CHARACTERISTIC_VALUE structure describes a Bluetooth Low
 /// Energy (LE) generic attribute (GATT) profile characteristic value.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_LE_GATT_CHARACTERISTIC_VALUE extends Struct {
   @Uint32()
   external int DataSize;
@@ -831,7 +831,7 @@ base class BTH_LE_GATT_CHARACTERISTIC_VALUE extends Struct {
 /// The BTH_LE_GATT_DESCRIPTOR structure describes a Bluetooth Low Energy
 /// (LE) generic attribute (GATT) profile descriptor.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_LE_GATT_DESCRIPTOR extends Struct {
   @Uint16()
   external int ServiceHandle;
@@ -851,7 +851,7 @@ base class BTH_LE_GATT_DESCRIPTOR extends Struct {
 /// The BTH_LE_GATT_DESCRIPTOR_VALUE structure describes a parent
 /// characteristic.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_LE_GATT_DESCRIPTOR_VALUE extends Struct {
   @Int32()
   external int DescriptorType;
@@ -867,7 +867,7 @@ base class BTH_LE_GATT_DESCRIPTOR_VALUE extends Struct {
   external Array<Uint8> Data;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _BTH_LE_GATT_DESCRIPTOR_VALUE__Anonymous_e__Union extends Union {
   external _BTH_LE_GATT_DESCRIPTOR_VALUE__Anonymous_e__Union__CharacteristicExtendedProperties_e__Struct
       CharacteristicExtendedProperties;
@@ -882,7 +882,7 @@ sealed class _BTH_LE_GATT_DESCRIPTOR_VALUE__Anonymous_e__Union extends Union {
       CharacteristicFormat;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _BTH_LE_GATT_DESCRIPTOR_VALUE__Anonymous_e__Union__CharacteristicExtendedProperties_e__Struct
     extends Struct {
   @Uint8()
@@ -907,7 +907,7 @@ extension BTH_LE_GATT_DESCRIPTOR_VALUE__Anonymous_e__Union_Extension
           value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _BTH_LE_GATT_DESCRIPTOR_VALUE__Anonymous_e__Union__ClientCharacteristicConfiguration_e__Struct
     extends Struct {
   @Uint8()
@@ -935,7 +935,7 @@ extension BTH_LE_GATT_DESCRIPTOR_VALUE__Anonymous_e__Union_Extension_1
           value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _BTH_LE_GATT_DESCRIPTOR_VALUE__Anonymous_e__Union__ServerCharacteristicConfiguration_e__Struct
     extends Struct {
   @Uint8()
@@ -950,7 +950,7 @@ extension BTH_LE_GATT_DESCRIPTOR_VALUE__Anonymous_e__Union_Extension_2
       this.Anonymous.ServerCharacteristicConfiguration.IsBroadcast = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _BTH_LE_GATT_DESCRIPTOR_VALUE__Anonymous_e__Union__CharacteristicFormat_e__Struct
     extends Struct {
   @Uint8()
@@ -1027,7 +1027,7 @@ extension BTH_LE_GATT_DESCRIPTOR_VALUE_Extension
 /// The BTH_LE_GATT_SERVICE structure describes a Bluetooth Low Energy (LE)
 /// generic attribute (GATT) profile service.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_LE_GATT_SERVICE extends Struct {
   external BTH_LE_UUID ServiceUuid;
 
@@ -1038,7 +1038,7 @@ base class BTH_LE_GATT_SERVICE extends Struct {
 /// The BTH_LE_UUID structure contains information about a Bluetooth Low
 /// Energy (LE) Universally Unique Identifier (UUID).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_LE_UUID extends Struct {
   @Uint8()
   external int IsShortUuid;
@@ -1046,7 +1046,7 @@ base class BTH_LE_UUID extends Struct {
   external _BTH_LE_UUID__Value_e__Union Value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _BTH_LE_UUID__Value_e__Union extends Union {
   @Uint16()
   external int ShortUuid;
@@ -1065,7 +1065,7 @@ extension BTH_LE_UUID_Extension on BTH_LE_UUID {
 /// The BTH_QUERY_DEVICE structure is used when querying for the presence of
 /// a Bluetooth device.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class BTH_QUERY_DEVICE extends Struct {
   @Uint32()
@@ -1077,7 +1077,7 @@ base class BTH_QUERY_DEVICE extends Struct {
 
 /// The BTH_QUERY_SERVICE structure is used to query a Bluetooth service.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_QUERY_SERVICE extends Struct {
   @Uint32()
   external int type;
@@ -1098,7 +1098,7 @@ base class BTH_QUERY_SERVICE extends Struct {
 /// The BTH_RADIO_IN_RANGE structure stores data about Bluetooth devices
 /// within communication range.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BTH_RADIO_IN_RANGE extends Struct {
   external BTH_DEVICE_INFO deviceInfo;
 
@@ -1109,7 +1109,7 @@ base class BTH_RADIO_IN_RANGE extends Struct {
 /// The BTH_SET_SERVICE structure provides service information for the
 /// specified Bluetooth service.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class BTH_SET_SERVICE extends Struct {
   external Pointer<Uint32> pSdpVersion;
@@ -1132,7 +1132,7 @@ base class BTH_SET_SERVICE extends Struct {
 /// Contains information that the GetFileInformationByHandle function
 /// retrieves.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class BY_HANDLE_FILE_INFORMATION extends Struct {
   @Uint32()
   external int dwFileAttributes;
@@ -1164,7 +1164,7 @@ base class BY_HANDLE_FILE_INFORMATION extends Struct {
 
 /// Describes the cache attributes.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CACHE_DESCRIPTOR extends Struct {
   @Uint8()
   external int Level;
@@ -1185,7 +1185,7 @@ base class CACHE_DESCRIPTOR extends Struct {
 /// Contains information passed to a WH_CBT hook procedure, CBTProc, before
 /// a window is activated.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CBTACTIVATESTRUCT extends Struct {
   @Int32()
   external int fMouse;
@@ -1197,7 +1197,7 @@ base class CBTACTIVATESTRUCT extends Struct {
 /// Contains information passed to a WH_CBT hook procedure, CBTProc, before
 /// a window is created.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CBT_CREATEWND extends Struct {
   external Pointer<CREATESTRUCT> lpcs;
 
@@ -1212,7 +1212,7 @@ base class CBT_CREATEWND extends Struct {
 /// function can be called to make a duplicate copy (which also must be
 /// freed by calling CertFreeCertificateContext).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CERT_CONTEXT extends Struct {
   @Uint32()
   external int dwCertEncodingType;
@@ -1231,7 +1231,7 @@ base class CERT_CONTEXT extends Struct {
 /// certificate, Certificate Revocation List (CRL) or Certificate Trust List
 /// (CTL).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CERT_EXTENSION extends Struct {
   external Pointer<Utf8> pszObjId;
 
@@ -1243,7 +1243,7 @@ base class CERT_EXTENSION extends Struct {
 
 /// The CERT_INFO structure contains the information of a certificate.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CERT_INFO extends Struct {
   @Uint32()
   external int dwVersion;
@@ -1275,7 +1275,7 @@ base class CERT_INFO extends Struct {
 /// The CERT_PUBLIC_KEY_INFO structure contains a public key and its
 /// algorithm.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CERT_PUBLIC_KEY_INFO extends Struct {
   external CRYPT_ALGORITHM_IDENTIFIER Algorithm;
 
@@ -1285,7 +1285,7 @@ base class CERT_PUBLIC_KEY_INFO extends Struct {
 /// Contains extended result information obtained by calling the
 /// ChangeWindowMessageFilterEx function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CHANGEFILTERSTRUCT extends Struct {
   @Uint32()
   external int cbSize;
@@ -1298,7 +1298,7 @@ base class CHANGEFILTERSTRUCT extends Struct {
 /// is used by console functions to read from and write to a console screen
 /// buffer.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CHAR_INFO extends Struct {
   external _CHAR_INFO__Char_e__Union Char;
 
@@ -1306,7 +1306,7 @@ base class CHAR_INFO extends Struct {
   external int Attributes;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _CHAR_INFO__Char_e__Union extends Union {
   @Uint16()
   external int UnicodeChar;
@@ -1327,7 +1327,7 @@ extension CHAR_INFO_Extension on CHAR_INFO {
 /// Color dialog box. After the user closes the dialog box, the system
 /// returns information about the user's selection in this structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CHOOSECOLOR extends Struct {
   @Uint32()
   external int lStructSize;
@@ -1358,7 +1358,7 @@ base class CHOOSECOLOR extends Struct {
 /// Font dialog box. After the user closes the dialog box, the system
 /// returns information about the user's selection in this structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CHOOSEFONT extends Struct {
   @Uint32()
   external int lStructSize;
@@ -1410,7 +1410,7 @@ base class CHOOSEFONT extends Struct {
 /// HALFTONE. You can set the color adjustment values by calling the
 /// SetColorAdjustment function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class COLORADJUSTMENT extends Struct {
   @Uint16()
   external int caSize;
@@ -1451,7 +1451,7 @@ base class COLORADJUSTMENT extends Struct {
 
 /// Used generically to filter elements.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class COMDLG_FILTERSPEC extends Struct {
   external Pointer<Utf16> pszName;
 
@@ -1461,7 +1461,7 @@ base class COMDLG_FILTERSPEC extends Struct {
 /// Contains information about the configuration state of a communications
 /// device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class COMMCONFIG extends Struct {
   @Uint32()
   external int dwSize;
@@ -1505,7 +1505,7 @@ base class COMMCONFIG extends Struct {
 
 /// Contains information about a communications driver.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class COMMPROP extends Struct {
   @Uint16()
   external int wPacketLength;
@@ -1582,7 +1582,7 @@ base class COMMPROP extends Struct {
 /// parameters determine the behavior of ReadFile, WriteFile, ReadFileEx,
 /// and WriteFileEx operations on the device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class COMMTIMEOUTS extends Struct {
   @Uint32()
   external int ReadIntervalTimeout;
@@ -1603,7 +1603,7 @@ base class COMMTIMEOUTS extends Struct {
 /// Contains information about a communications device. This structure is
 /// filled by the ClearCommError function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class COMSTAT extends Struct {
   @Uint32()
   external int bitfield;
@@ -1617,7 +1617,7 @@ base class COMSTAT extends Struct {
 
 /// Contains information about the console cursor.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CONSOLE_CURSOR_INFO extends Struct {
   @Uint32()
   external int dwSize;
@@ -1628,7 +1628,7 @@ base class CONSOLE_CURSOR_INFO extends Struct {
 
 /// Contains information for a console read operation.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CONSOLE_READCONSOLE_CONTROL extends Struct {
   @Uint32()
   external int nLength;
@@ -1645,7 +1645,7 @@ base class CONSOLE_READCONSOLE_CONTROL extends Struct {
 
 /// Contains information about a console screen buffer.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CONSOLE_SCREEN_BUFFER_INFO extends Struct {
   external COORD dwSize;
 
@@ -1661,7 +1661,7 @@ base class CONSOLE_SCREEN_BUFFER_INFO extends Struct {
 
 /// Contains information for a console selection.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CONSOLE_SELECTION_INFO extends Struct {
   @Uint32()
   external int dwFlags;
@@ -1675,7 +1675,7 @@ base class CONSOLE_SELECTION_INFO extends Struct {
 /// The origin of the coordinate system (0,0) is at the top, left cell of
 /// the buffer.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class COORD extends Struct {
   @Int16()
   external int X;
@@ -1686,7 +1686,7 @@ base class COORD extends Struct {
 
 /// Stores the offset, within a class, of the specified field.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class COR_FIELD_OFFSET extends Struct {
   @Uint32()
   external int ridOfField;
@@ -1697,7 +1697,7 @@ base class COR_FIELD_OFFSET extends Struct {
 
 /// Contains optional extended parameters for CreateFile2.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CREATEFILE2_EXTENDED_PARAMETERS extends Struct {
   @Uint32()
   external int dwSize;
@@ -1721,7 +1721,7 @@ base class CREATEFILE2_EXTENDED_PARAMETERS extends Struct {
 /// an application. These members are identical to the parameters of the
 /// CreateWindowEx function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CREATESTRUCT extends Struct {
   external Pointer lpCreateParams;
 
@@ -1759,7 +1759,7 @@ base class CREATESTRUCT extends Struct {
 
 /// The CREDENTIAL structure contains an individual credential.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CREDENTIAL extends Struct {
   @Uint32()
   external int Flags;
@@ -1795,7 +1795,7 @@ base class CREDENTIAL extends Struct {
 /// attribute of the credential. An attribute is a keyword-value pair. It is
 /// up to the application to define the meaning of the attribute.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CREDENTIAL_ATTRIBUTE extends Struct {
   external Pointer<Utf16> Keyword;
 
@@ -1812,7 +1812,7 @@ base class CREDENTIAL_ATTRIBUTE extends Struct {
 /// and information about when and where that prompt is to be displayed when
 /// using the CryptProtectData and CryptUnprotectData functions.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CRYPTPROTECT_PROMPTSTRUCT extends Struct {
   @Uint32()
   external int cbSize;
@@ -1831,7 +1831,7 @@ base class CRYPTPROTECT_PROMPTSTRUCT extends Struct {
 /// (OID) of the algorithm and any needed parameters for that algorithm. The
 /// parameters contained in its CRYPT_OBJID_BLOB are encoded.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CRYPT_ALGORITHM_IDENTIFIER extends Struct {
   external Pointer<Utf8> pszObjId;
 
@@ -1841,7 +1841,7 @@ base class CRYPT_ALGORITHM_IDENTIFIER extends Struct {
 /// The CRYPT_BIT_BLOB structure contains a set of bits represented by an
 /// array of bytes.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CRYPT_BIT_BLOB extends Struct {
   @Uint32()
   external int cbData;
@@ -1855,7 +1855,7 @@ base class CRYPT_BIT_BLOB extends Struct {
 /// Contains an arbitrary array of bytes. The structure definition includes
 /// aliases appropriate to the various functions that use it.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CRYPT_INTEGER_BLOB extends Struct {
   @Uint32()
   external int cbData;
@@ -1865,7 +1865,7 @@ base class CRYPT_INTEGER_BLOB extends Struct {
 
 /// Contains global cursor information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CURSORINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -1882,7 +1882,7 @@ base class CURSORINFO extends Struct {
 /// Defines the message parameters passed to a WH_CALLWNDPROCRET hook
 /// procedure, CallWndRetProc.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CWPRETSTRUCT extends Struct {
   @IntPtr()
   external int lResult;
@@ -1903,7 +1903,7 @@ base class CWPRETSTRUCT extends Struct {
 /// Defines the message parameters passed to a WH_CALLWNDPROC hook
 /// procedure, CallWndProc.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CWPSTRUCT extends Struct {
   @IntPtr()
   external int lParam;
@@ -1924,7 +1924,7 @@ base class CWPSTRUCT extends Struct {
 /// representation provides a range of 922337203685477.5807 to
 /// -922337203685477.5808.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class CY extends Union {
   external _CY__Anonymous_e__Struct Anonymous;
 
@@ -1932,7 +1932,7 @@ base class CY extends Union {
   external int int64;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _CY__Anonymous_e__Struct extends Struct {
   @Uint32()
   external int Lo;
@@ -1951,7 +1951,7 @@ extension CY_Extension on CY {
 
 /// Defines the control setting for a serial communications device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DCB extends Struct {
   @Uint32()
   external int DCBlength;
@@ -2002,7 +2002,7 @@ base class DCB extends Struct {
 /// Contains debugging information passed to a WH_DEBUG hook procedure,
 /// DebugProc.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DEBUGHOOKINFO extends Struct {
   @Uint32()
   external int idThread;
@@ -2026,7 +2026,7 @@ base class DEBUGHOOKINFO extends Struct {
 /// of 10 scaling factor specifies the number of digits to the right of the
 /// decimal point, and ranges from 0 to 28.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DECIMAL extends Struct {
   @Uint16()
   external int wReserved;
@@ -2039,7 +2039,7 @@ base class DECIMAL extends Struct {
   external _DECIMAL__Anonymous2_e__Union Anonymous2;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DECIMAL__Anonymous1_e__Union extends Union {
   external _DECIMAL__Anonymous1_e__Union__Anonymous_e__Struct Anonymous;
 
@@ -2047,7 +2047,7 @@ sealed class _DECIMAL__Anonymous1_e__Union extends Union {
   external int signscale;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DECIMAL__Anonymous1_e__Union__Anonymous_e__Struct extends Struct {
   @Uint8()
   external int scale;
@@ -2074,7 +2074,7 @@ extension DECIMAL_Extension on DECIMAL {
   set signscale(int value) => this.Anonymous1.signscale = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DECIMAL__Anonymous2_e__Union extends Union {
   external _DECIMAL__Anonymous2_e__Union__Anonymous_e__Struct Anonymous;
 
@@ -2082,7 +2082,7 @@ sealed class _DECIMAL__Anonymous2_e__Union extends Union {
   external int Lo64;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DECIMAL__Anonymous2_e__Union__Anonymous_e__Struct extends Struct {
   @Uint32()
   external int Lo32;
@@ -2112,7 +2112,7 @@ extension DECIMAL_Extension_1 on DECIMAL {
 /// The DESIGNVECTOR structure is used by an application to specify values
 /// for the axes of a multiple master font.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DESIGNVECTOR extends Struct {
   @Uint32()
   external int dvReserved;
@@ -2127,7 +2127,7 @@ base class DESIGNVECTOR extends Struct {
 /// The DEVMODE data structure contains information about the initialization
 /// and environment of a printer or a display device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DEVMODE extends Struct {
   @Array(32)
   external Array<Uint16> _dmDeviceName;
@@ -2241,14 +2241,14 @@ base class DEVMODE extends Struct {
   external int dmPanningHeight;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DEVMODEW__Anonymous1_e__Union extends Union {
   external _DEVMODEW__Anonymous1_e__Union__Anonymous1_e__Struct Anonymous1;
 
   external _DEVMODEW__Anonymous1_e__Union__Anonymous2_e__Struct Anonymous2;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DEVMODEW__Anonymous1_e__Union__Anonymous1_e__Struct
     extends Struct {
   @Int16()
@@ -2307,7 +2307,7 @@ extension DEVMODEW__Anonymous1_e__Union_Extension on DEVMODE {
       this.Anonymous1.Anonymous1.dmPrintQuality = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DEVMODEW__Anonymous1_e__Union__Anonymous2_e__Struct
     extends Struct {
   external POINTL dmPosition;
@@ -2346,7 +2346,7 @@ extension DEVMODEW_Extension on DEVMODE {
       this.Anonymous1.Anonymous2 = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DEVMODEW__Anonymous2_e__Union extends Union {
   @Uint32()
   external int dmDisplayFlags;
@@ -2370,7 +2370,7 @@ extension DEVMODEW_Extension_1 on DEVMODE {
 /// application can obtain a filled-in DIBSECTION structure for a given DIB
 /// by calling the GetObject function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DIBSECTION extends Struct {
   external BITMAP dsBm;
 
@@ -2388,7 +2388,7 @@ base class DIBSECTION extends Struct {
 
 /// Represents a disk extent.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISK_EXTENT extends Struct {
   @Uint32()
   external int DiskNumber;
@@ -2402,7 +2402,7 @@ base class DISK_EXTENT extends Struct {
 
 /// Describes the geometry of disk devices and media.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISK_GEOMETRY extends Struct {
   @Int64()
   external int Cylinders;
@@ -2422,7 +2422,7 @@ base class DISK_GEOMETRY extends Struct {
 
 /// Describes the extended geometry of disk devices and media.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISK_GEOMETRY_EX extends Struct {
   external DISK_GEOMETRY Geometry;
 
@@ -2436,7 +2436,7 @@ base class DISK_GEOMETRY_EX extends Struct {
 /// The DISPLAYCONFIG_2DREGION structure represents a point or an offset in
 /// a two-dimensional space.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_2DREGION extends Struct {
   @Uint32()
   external int cx;
@@ -2448,7 +2448,7 @@ base class DISPLAYCONFIG_2DREGION extends Struct {
 /// The DISPLAYCONFIG_DESKTOP_IMAGE_INFO structure contains information
 /// about the image displayed on the desktop.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_DESKTOP_IMAGE_INFO extends Struct {
   external POINTL PathSourceSize;
 
@@ -2460,7 +2460,7 @@ base class DISPLAYCONFIG_DESKTOP_IMAGE_INFO extends Struct {
 /// The DISPLAYCONFIG_DEVICE_INFO_HEADER structure contains display
 /// information about the device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_DEVICE_INFO_HEADER extends Struct {
   @Int32()
   external int type;
@@ -2477,7 +2477,7 @@ base class DISPLAYCONFIG_DEVICE_INFO_HEADER extends Struct {
 /// The DISPLAYCONFIG_MODE_INFO structure contains either source mode or
 /// target mode information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_MODE_INFO extends Struct {
   @Int32()
   external int infoType;
@@ -2490,7 +2490,7 @@ base class DISPLAYCONFIG_MODE_INFO extends Struct {
   external _DISPLAYCONFIG_MODE_INFO__Anonymous_e__Union Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DISPLAYCONFIG_MODE_INFO__Anonymous_e__Union extends Union {
   external DISPLAYCONFIG_TARGET_MODE targetMode;
 
@@ -2517,7 +2517,7 @@ extension DISPLAYCONFIG_MODE_INFO_Extension on DISPLAYCONFIG_MODE_INFO {
 /// The DISPLAYCONFIG_PATH_INFO structure is used to describe a single path
 /// from a target to a source.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_PATH_INFO extends Struct {
   external DISPLAYCONFIG_PATH_SOURCE_INFO sourceInfo;
 
@@ -2530,7 +2530,7 @@ base class DISPLAYCONFIG_PATH_INFO extends Struct {
 /// The DISPLAYCONFIG_PATH_SOURCE_INFO structure contains source information
 /// for a single path.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_PATH_SOURCE_INFO extends Struct {
   external LUID adapterId;
 
@@ -2543,7 +2543,7 @@ base class DISPLAYCONFIG_PATH_SOURCE_INFO extends Struct {
   external int statusFlags;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DISPLAYCONFIG_PATH_SOURCE_INFO__Anonymous_e__Union extends Union {
   @Uint32()
   external int modeInfoIdx;
@@ -2552,7 +2552,7 @@ sealed class _DISPLAYCONFIG_PATH_SOURCE_INFO__Anonymous_e__Union extends Union {
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DISPLAYCONFIG_PATH_SOURCE_INFO__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -2581,7 +2581,7 @@ extension DISPLAYCONFIG_PATH_SOURCE_INFO_Extension
 /// The DISPLAYCONFIG_PATH_TARGET_INFO structure contains target information
 /// for a single path.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_PATH_TARGET_INFO extends Struct {
   external LUID adapterId;
 
@@ -2611,7 +2611,7 @@ base class DISPLAYCONFIG_PATH_TARGET_INFO extends Struct {
   external int statusFlags;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DISPLAYCONFIG_PATH_TARGET_INFO__Anonymous_e__Union extends Union {
   @Uint32()
   external int modeInfoIdx;
@@ -2620,7 +2620,7 @@ sealed class _DISPLAYCONFIG_PATH_TARGET_INFO__Anonymous_e__Union extends Union {
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DISPLAYCONFIG_PATH_TARGET_INFO__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -2650,7 +2650,7 @@ extension DISPLAYCONFIG_PATH_TARGET_INFO_Extension
 /// represents vertical and horizontal frequencies of a video mode (that is,
 /// vertical sync and horizontal sync).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_RATIONAL extends Struct {
   @Uint32()
   external int Numerator;
@@ -2662,7 +2662,7 @@ base class DISPLAYCONFIG_RATIONAL extends Struct {
 /// The DISPLAYCONFIG_SOURCE_MODE structure represents a point or an offset
 /// in a two-dimensional space.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_SOURCE_MODE extends Struct {
   @Uint32()
   external int width;
@@ -2679,7 +2679,7 @@ base class DISPLAYCONFIG_SOURCE_MODE extends Struct {
 /// The DISPLAYCONFIG_TARGET_MODE structure describes a display path target
 /// mode.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_TARGET_MODE extends Struct {
   external DISPLAYCONFIG_VIDEO_SIGNAL_INFO targetVideoSignalInfo;
 }
@@ -2687,7 +2687,7 @@ base class DISPLAYCONFIG_TARGET_MODE extends Struct {
 /// The DISPLAYCONFIG_VIDEO_SIGNAL_INFO structure contains information about
 /// the video signal for a display.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAYCONFIG_VIDEO_SIGNAL_INFO extends Struct {
   @Uint64()
   external int pixelRate;
@@ -2706,7 +2706,7 @@ base class DISPLAYCONFIG_VIDEO_SIGNAL_INFO extends Struct {
   external int scanLineOrdering;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DISPLAYCONFIG_VIDEO_SIGNAL_INFO__Anonymous_e__Union
     extends Union {
   external _DISPLAYCONFIG_VIDEO_SIGNAL_INFO__Anonymous_e__Union__AdditionalSignalInfo_e__Struct
@@ -2716,7 +2716,7 @@ sealed class _DISPLAYCONFIG_VIDEO_SIGNAL_INFO__Anonymous_e__Union
   external int videoStandard;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _DISPLAYCONFIG_VIDEO_SIGNAL_INFO__Anonymous_e__Union__AdditionalSignalInfo_e__Struct
     extends Struct {
   @Uint32()
@@ -2747,7 +2747,7 @@ extension DISPLAYCONFIG_VIDEO_SIGNAL_INFO_Extension
 /// device specified by the iDevNum parameter of the EnumDisplayDevices
 /// function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPLAY_DEVICE extends Struct {
   @Uint32()
   external int cb;
@@ -2834,7 +2834,7 @@ base class DISPLAY_DEVICE extends Struct {
 
 /// Contains the arguments passed to a method or property.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DISPPARAMS extends Struct {
   external Pointer<VARIANT> rgvarg;
 
@@ -2851,7 +2851,7 @@ base class DISPPARAMS extends Struct {
 /// more of these structures are combined with a DLGTEMPLATE structure to
 /// form a standard template for a dialog box.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(2)
 base class DLGITEMTEMPLATE extends Struct {
   @Uint32()
@@ -2881,7 +2881,7 @@ base class DLGITEMTEMPLATE extends Struct {
 /// number of controls in the dialog box and therefore specifies the number
 /// of subsequent DLGITEMTEMPLATE structures in the template.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(2)
 base class DLGTEMPLATE extends Struct {
   @Uint32()
@@ -2909,7 +2909,7 @@ base class DLGTEMPLATE extends Struct {
 /// Receives DLL-specific version information. It is used with the
 /// DllGetVersion function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DLLVERSIONINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -2929,7 +2929,7 @@ base class DLLVERSIONINFO extends Struct {
 
 /// The DOC_INFO_1 structure describes a document that will be printed.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DOC_INFO_1 extends Struct {
   external Pointer<Utf16> pDocName;
 
@@ -2942,7 +2942,7 @@ base class DOC_INFO_1 extends Struct {
 /// authentication and cipher algorithms that can be enabled at the same
 /// time on the 802.11 station.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DOT11_AUTH_CIPHER_PAIR extends Struct {
   @Int32()
   external int AuthAlgoId;
@@ -2954,7 +2954,7 @@ base class DOT11_AUTH_CIPHER_PAIR extends Struct {
 /// The DOT11_BSSID_LIST structure contains a list of basic service set
 /// (BSS) identifiers.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DOT11_BSSID_LIST extends Struct {
   external NDIS_OBJECT_HEADER Header;
 
@@ -2971,7 +2971,7 @@ base class DOT11_BSSID_LIST extends Struct {
 /// The DOT11_NETWORK structure contains information about an available
 /// wireless network.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DOT11_NETWORK extends Struct {
   external DOT11_SSID dot11Ssid;
 
@@ -2982,7 +2982,7 @@ base class DOT11_NETWORK extends Struct {
 /// The DOT11_NETWORK_LIST structure contains a list of 802.11 wireless
 /// networks.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DOT11_NETWORK_LIST extends Struct {
   @Uint32()
   external int dwNumberOfItems;
@@ -2996,7 +2996,7 @@ base class DOT11_NETWORK_LIST extends Struct {
 
 /// A DOT11_SSID structure contains the SSID of an interface.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DOT11_SSID extends Struct {
   @Uint32()
   external int uSSIDLength;
@@ -3008,7 +3008,7 @@ base class DOT11_SSID extends Struct {
 /// The DRAWTEXTPARAMS structure contains extended formatting options for
 /// the DrawTextEx function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DRAWTEXTPARAMS extends Struct {
   @Uint32()
   external int cbSize;
@@ -3029,7 +3029,7 @@ base class DRAWTEXTPARAMS extends Struct {
 /// Contains information about how a device is joined to Microsoft Azure
 /// Active Directory.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DSREG_JOIN_INFO extends Struct {
   @Int32()
   external int joinType;
@@ -3060,7 +3060,7 @@ base class DSREG_JOIN_INFO extends Struct {
 /// Contains information about a user account that is used to join a device
 /// to Microsoft Azure Active Directory.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DSREG_USER_INFO extends Struct {
   external Pointer<Utf16> pszUserEmail;
 
@@ -3071,7 +3071,7 @@ base class DSREG_USER_INFO extends Struct {
 
 /// Defines the options for the DrawThemeBackgroundEx function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DTBGOPTS extends Struct {
   @Uint32()
   external int dwSize;
@@ -3084,7 +3084,7 @@ base class DTBGOPTS extends Struct {
 
 /// Defines the options for the DrawThemeTextEx function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class DTTOPTS extends Struct {
   @Uint32()
   external int dwSize;
@@ -3133,7 +3133,7 @@ base class DTTOPTS extends Struct {
 /// Specifies Desktop Window Manager (DWM) blur-behind properties. Used by
 /// the DwmEnableBlurBehindWindow function.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class DWM_BLURBEHIND extends Struct {
   @Uint32()
@@ -3152,7 +3152,7 @@ base class DWM_BLURBEHIND extends Struct {
 /// The EAP_METHOD_TYPE structure contains type, identification, and author
 /// information about an EAP method.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class EAP_METHOD_TYPE extends Struct {
   external EAP_TYPE eapType;
 
@@ -3163,7 +3163,7 @@ base class EAP_METHOD_TYPE extends Struct {
 /// The EAP_TYPE structure contains type and vendor identification
 /// information for an EAP method.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class EAP_TYPE extends Struct {
   @Uint8()
   external int type;
@@ -3178,14 +3178,14 @@ base class EAP_TYPE extends Struct {
 /// Contains the type description and process-transfer information for a
 /// variable, a function, or a function parameter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ELEMDESC extends Struct {
   external TYPEDESC tdesc;
 
   external _ELEMDESC__Anonymous_e__Union Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _ELEMDESC__Anonymous_e__Union extends Union {
   external IDLDESC idldesc;
 
@@ -3203,7 +3203,7 @@ extension ELEMDESC_Extension on ELEMDESC {
 /// The ENUMLOGFONTEX structure contains information about an enumerated
 /// font.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ENUMLOGFONTEX extends Struct {
   external LOGFONT elfLogFont;
 
@@ -3267,7 +3267,7 @@ base class ENUMLOGFONTEX extends Struct {
 
 /// Contains information about a pagefile.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ENUM_PAGE_FILE_INFORMATION extends Struct {
   @Uint32()
   external int cb;
@@ -3289,7 +3289,7 @@ base class ENUM_PAGE_FILE_INFORMATION extends Struct {
 /// information about that service. It is used by the EnumDependentServices
 /// and EnumServicesStatus functions.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ENUM_SERVICE_STATUS extends Struct {
   external Pointer<Utf16> lpServiceName;
 
@@ -3302,7 +3302,7 @@ base class ENUM_SERVICE_STATUS extends Struct {
 /// information about the service. It is used by the EnumServicesStatusEx
 /// function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ENUM_SERVICE_STATUS_PROCESS extends Struct {
   external Pointer<Utf16> lpServiceName;
 
@@ -3315,7 +3315,7 @@ base class ENUM_SERVICE_STATUS_PROCESS extends Struct {
 /// queue. This structure is used to store message information for the
 /// JournalPlaybackProc callback function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class EVENTMSG extends Struct {
   @Uint32()
   external int message;
@@ -3335,7 +3335,7 @@ base class EVENTMSG extends Struct {
 
 /// Describes an exception that occurred during IDispatch::Invoke.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class EXCEPINFO extends Struct {
   @Uint16()
   external int wCode;
@@ -3362,7 +3362,7 @@ base class EXCEPINFO extends Struct {
 
 /// Contains information about an extended property.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ExtendedProperty extends Struct {
   external Pointer<Utf16> PropertyName;
 
@@ -3374,7 +3374,7 @@ base class ExtendedProperty extends Struct {
 /// set for various purposes, such as testing a given socket for readability
 /// using the readfds parameter of the select function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class FD_SET extends Struct {
   @Uint32()
   external int fd_count;
@@ -3386,7 +3386,7 @@ base class FD_SET extends Struct {
 /// Contains a 64-bit value representing the number of 100-nanosecond
 /// intervals since January 1, 1601 (UTC).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class FILETIME extends Struct {
   @Uint32()
   external int dwLowDateTime;
@@ -3397,7 +3397,7 @@ base class FILETIME extends Struct {
 
 /// Union that contains a 64-bit value that points to a page of data.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class FILE_SEGMENT_ELEMENT extends Union {
   external Pointer Buffer;
 
@@ -3410,7 +3410,7 @@ base class FILE_SEGMENT_ELEMENT extends Union {
 /// registered message uses this structure to pass the user's search or
 /// replacement input to the owner window of a Find or Replace dialog box.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class FINDREPLACE extends Struct {
   @Uint32()
   external int lStructSize;
@@ -3445,7 +3445,7 @@ base class FINDREPLACE extends Struct {
 /// Describes a focus event in a console INPUT_RECORD structure. These
 /// events are used internally and should be ignored.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class FOCUS_EVENT_RECORD extends Struct {
   @Int32()
   external int bSetFocus;
@@ -3453,7 +3453,7 @@ base class FOCUS_EVENT_RECORD extends Struct {
 
 /// Describes a function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class FUNCDESC extends Struct {
   @Int32()
   external int memid;
@@ -3492,7 +3492,7 @@ base class FUNCDESC extends Struct {
 /// Gets and sets the configuration for enabling gesture messages and the
 /// type of this configuration.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class GESTURECONFIG extends Struct {
   @Uint32()
   external int dwID;
@@ -3506,7 +3506,7 @@ base class GESTURECONFIG extends Struct {
 
 /// Stores information about a gesture.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class GESTUREINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -3538,7 +3538,7 @@ base class GESTUREINFO extends Struct {
 /// When transmitted with WM_GESTURENOTIFY messages, passes information
 /// about a gesture.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class GESTURENOTIFYSTRUCT extends Struct {
   @Uint32()
   external int cbSize;
@@ -3557,7 +3557,7 @@ base class GESTURENOTIFYSTRUCT extends Struct {
 
 /// Contains information about a GUI thread.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class GUITHREADINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -3589,7 +3589,7 @@ base class GUITHREADINFO extends Struct {
 /// Contains information about a simulated message generated by an input
 /// device other than a keyboard or mouse.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class HARDWAREINPUT extends Struct {
   @Uint32()
   external int uMsg;
@@ -3609,7 +3609,7 @@ base class HARDWAREINPUT extends Struct {
 /// information that it needs before issuing any other Windows Sockets API
 /// calls.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class HOSTENT extends Struct {
   external Pointer<Utf8> h_name;
 
@@ -3626,7 +3626,7 @@ base class HOSTENT extends Struct {
 
 /// Handle of an open waveform-audio input device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class HWAVEIN extends Struct {
   @IntPtr()
   external int Value;
@@ -3634,7 +3634,7 @@ base class HWAVEIN extends Struct {
 
 /// Contains information about an icon or a cursor.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ICONINFO extends Struct {
   @Int32()
   external int fIcon;
@@ -3655,7 +3655,7 @@ base class ICONINFO extends Struct {
 /// Contains information about an icon or a cursor. Extends ICONINFO. Used
 /// by GetIconInfoEx.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class ICONINFOEX extends Struct {
   @Uint32()
   external int cbSize;
@@ -3719,7 +3719,7 @@ base class ICONINFOEX extends Struct {
 
 /// Contains the IDL attributes of a type.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IDLDESC extends Struct {
   @IntPtr()
   external int dwReserved;
@@ -3732,7 +3732,7 @@ base class IDLDESC extends Struct {
 /// dynamic-link library (DLL). This structure is used with the
 /// InitCommonControlsEx function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class INITCOMMONCONTROLSEX extends Struct {
   @Uint32()
   external int dwSize;
@@ -3744,7 +3744,7 @@ base class INITCOMMONCONTROLSEX extends Struct {
 /// Used by SendInput to store information for synthesizing input events
 /// such as keystrokes, mouse movement, and mouse clicks.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class INPUT extends Struct {
   @Uint32()
   external int type;
@@ -3752,7 +3752,7 @@ base class INPUT extends Struct {
   external _INPUT__Anonymous_e__Union Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _INPUT__Anonymous_e__Union extends Union {
   external MOUSEINPUT mi;
 
@@ -3777,7 +3777,7 @@ extension INPUT_Extension on INPUT {
 /// PeekConsoleInput function, or written to the input buffer by using the
 /// WriteConsoleInput function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class INPUT_RECORD extends Struct {
   @Uint16()
   external int EventType;
@@ -3785,7 +3785,7 @@ base class INPUT_RECORD extends Struct {
   external _INPUT_RECORD__Event_e__Union Event;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _INPUT_RECORD__Event_e__Union extends Union {
   external KEY_EVENT_RECORD KeyEvent;
 
@@ -3823,12 +3823,12 @@ extension INPUT_RECORD_Extension on INPUT_RECORD {
 /// transform pointer input data from screen coordinates to client
 /// coordinates.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class INPUT_TRANSFORM extends Struct {
   external _INPUT_TRANSFORM__Anonymous_e__Union Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _INPUT_TRANSFORM__Anonymous_e__Union extends Union {
   external _INPUT_TRANSFORM__Anonymous_e__Union__Anonymous_e__Struct Anonymous;
 
@@ -3836,7 +3836,7 @@ sealed class _INPUT_TRANSFORM__Anonymous_e__Union extends Union {
   external Array<Float> m;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _INPUT_TRANSFORM__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Float()
@@ -3951,12 +3951,12 @@ extension INPUT_TRANSFORM_Extension on INPUT_TRANSFORM {
 
 /// The IN_ADDR structure represents an IPv4 Internet address.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IN_ADDR extends Struct {
   external _IN_ADDR__S_un_e__Union S_un;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IN_ADDR__S_un_e__Union extends Union {
   external _IN_ADDR__S_un_e__Union__S_un_b_e__Struct S_un_b;
 
@@ -3966,7 +3966,7 @@ sealed class _IN_ADDR__S_un_e__Union extends Union {
   external int S_addr;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IN_ADDR__S_un_e__Union__S_un_b_e__Struct extends Struct {
   @Uint8()
   external int s_b1;
@@ -3995,7 +3995,7 @@ extension IN_ADDR__S_un_e__Union_Extension on IN_ADDR {
   set s_b4(int value) => this.S_un.S_un_b.s_b4 = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IN_ADDR__S_un_e__Union__S_un_w_e__Struct extends Struct {
   @Uint16()
   external int s_w1;
@@ -4029,7 +4029,7 @@ extension IN_ADDR_Extension on IN_ADDR {
 /// of addresses for a particular adapter. This structure can simultaneously
 /// be used as part of a linked list of IP_ADAPTER_ADDRESSES structures.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADAPTER_ADDRESSES_LH extends Struct {
   external _IP_ADAPTER_ADDRESSES_LH__Anonymous1_e__Union Anonymous1;
 
@@ -4121,7 +4121,7 @@ base class IP_ADAPTER_ADDRESSES_LH extends Struct {
   external Pointer<IP_ADAPTER_DNS_SUFFIX> FirstDnsSuffix;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_ADDRESSES_LH__Anonymous1_e__Union extends Union {
   @Uint64()
   external int Alignment;
@@ -4130,7 +4130,7 @@ sealed class _IP_ADAPTER_ADDRESSES_LH__Anonymous1_e__Union extends Union {
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_ADDRESSES_LH__Anonymous1_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -4161,7 +4161,7 @@ extension IP_ADAPTER_ADDRESSES_LH_Extension on IP_ADAPTER_ADDRESSES_LH {
       this.Anonymous1.Anonymous = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_ADDRESSES_LH__Anonymous2_e__Union extends Union {
   @Uint32()
   external int Flags;
@@ -4170,7 +4170,7 @@ sealed class _IP_ADAPTER_ADDRESSES_LH__Anonymous2_e__Union extends Union {
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_ADDRESSES_LH__Anonymous2_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -4198,7 +4198,7 @@ extension IP_ADAPTER_ADDRESSES_LH_Extension_1 on IP_ADAPTER_ADDRESSES_LH {
 /// The IP_ADAPTER_ANYCAST_ADDRESS structure stores a single anycast IP
 /// address in a linked list of addresses for a particular adapter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADAPTER_ANYCAST_ADDRESS_XP extends Struct {
   external _IP_ADAPTER_ANYCAST_ADDRESS_XP__Anonymous_e__Union Anonymous;
 
@@ -4207,7 +4207,7 @@ base class IP_ADAPTER_ANYCAST_ADDRESS_XP extends Struct {
   external SOCKET_ADDRESS Address;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_ANYCAST_ADDRESS_XP__Anonymous_e__Union extends Union {
   @Uint64()
   external int Alignment;
@@ -4216,7 +4216,7 @@ sealed class _IP_ADAPTER_ANYCAST_ADDRESS_XP__Anonymous_e__Union extends Union {
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_ANYCAST_ADDRESS_XP__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -4252,7 +4252,7 @@ extension IP_ADAPTER_ANYCAST_ADDRESS_XP_Extension
 /// address in a linked list of DNS server addresses for a particular
 /// adapter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADAPTER_DNS_SERVER_ADDRESS_XP extends Struct {
   external _IP_ADAPTER_DNS_SERVER_ADDRESS_XP__Anonymous_e__Union Anonymous;
 
@@ -4261,7 +4261,7 @@ base class IP_ADAPTER_DNS_SERVER_ADDRESS_XP extends Struct {
   external SOCKET_ADDRESS Address;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_DNS_SERVER_ADDRESS_XP__Anonymous_e__Union
     extends Union {
   @Uint64()
@@ -4271,7 +4271,7 @@ sealed class _IP_ADAPTER_DNS_SERVER_ADDRESS_XP__Anonymous_e__Union
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_DNS_SERVER_ADDRESS_XP__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -4306,7 +4306,7 @@ extension IP_ADAPTER_DNS_SERVER_ADDRESS_XP_Extension
 /// The IP_ADAPTER_DNS_SUFFIX structure stores a DNS suffix in a linked list
 /// of DNS suffixes for a particular adapter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADAPTER_DNS_SUFFIX extends Struct {
   external Pointer<IP_ADAPTER_DNS_SUFFIX> Next;
 
@@ -4333,7 +4333,7 @@ base class IP_ADAPTER_DNS_SUFFIX extends Struct {
 /// The IP_ADAPTER_GATEWAY_ADDRESS structure stores a single gateway address
 /// in a linked list of gateway addresses for a particular adapter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADAPTER_GATEWAY_ADDRESS_LH extends Struct {
   external _IP_ADAPTER_GATEWAY_ADDRESS_LH__Anonymous_e__Union Anonymous;
 
@@ -4342,7 +4342,7 @@ base class IP_ADAPTER_GATEWAY_ADDRESS_LH extends Struct {
   external SOCKET_ADDRESS Address;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_GATEWAY_ADDRESS_LH__Anonymous_e__Union extends Union {
   @Uint64()
   external int Alignment;
@@ -4351,7 +4351,7 @@ sealed class _IP_ADAPTER_GATEWAY_ADDRESS_LH__Anonymous_e__Union extends Union {
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_GATEWAY_ADDRESS_LH__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -4387,7 +4387,7 @@ extension IP_ADAPTER_GATEWAY_ADDRESS_LH_Extension
 /// with a network adapter with IPv4 enabled together with the name of the
 /// network adapter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADAPTER_INDEX_MAP extends Struct {
   @Uint32()
   external int Index;
@@ -4415,7 +4415,7 @@ base class IP_ADAPTER_INDEX_MAP extends Struct {
 /// The IP_ADAPTER_MULTICAST_ADDRESS structure stores a single multicast
 /// address in a linked-list of addresses for a particular adapter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADAPTER_MULTICAST_ADDRESS_XP extends Struct {
   external _IP_ADAPTER_MULTICAST_ADDRESS_XP__Anonymous_e__Union Anonymous;
 
@@ -4424,7 +4424,7 @@ base class IP_ADAPTER_MULTICAST_ADDRESS_XP extends Struct {
   external SOCKET_ADDRESS Address;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_MULTICAST_ADDRESS_XP__Anonymous_e__Union
     extends Union {
   @Uint64()
@@ -4434,7 +4434,7 @@ sealed class _IP_ADAPTER_MULTICAST_ADDRESS_XP__Anonymous_e__Union
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_MULTICAST_ADDRESS_XP__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -4468,7 +4468,7 @@ extension IP_ADAPTER_MULTICAST_ADDRESS_XP_Extension
 
 /// The IP_ADAPTER_PREFIX structure stores an IP address prefix.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADAPTER_PREFIX_XP extends Struct {
   external _IP_ADAPTER_PREFIX_XP__Anonymous_e__Union Anonymous;
 
@@ -4480,7 +4480,7 @@ base class IP_ADAPTER_PREFIX_XP extends Struct {
   external int PrefixLength;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_PREFIX_XP__Anonymous_e__Union extends Union {
   @Uint64()
   external int Alignment;
@@ -4489,7 +4489,7 @@ sealed class _IP_ADAPTER_PREFIX_XP__Anonymous_e__Union extends Union {
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_PREFIX_XP__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -4523,7 +4523,7 @@ extension IP_ADAPTER_PREFIX_XP_Extension on IP_ADAPTER_PREFIX_XP {
 /// The IP_ADAPTER_UNICAST_ADDRESS structure stores a single unicast IP
 /// address in a linked list of IP addresses for a particular adapter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADAPTER_UNICAST_ADDRESS_LH extends Struct {
   external _IP_ADAPTER_UNICAST_ADDRESS_LH__Anonymous_e__Union Anonymous;
 
@@ -4553,7 +4553,7 @@ base class IP_ADAPTER_UNICAST_ADDRESS_LH extends Struct {
   external int OnLinkPrefixLength;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_UNICAST_ADDRESS_LH__Anonymous_e__Union extends Union {
   @Uint64()
   external int Alignment;
@@ -4562,7 +4562,7 @@ sealed class _IP_ADAPTER_UNICAST_ADDRESS_LH__Anonymous_e__Union extends Union {
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_UNICAST_ADDRESS_LH__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -4598,7 +4598,7 @@ extension IP_ADAPTER_UNICAST_ADDRESS_LH_Extension
 /// Internet Name Service (WINS) server address in a linked list of WINS
 /// server addresses for a particular adapter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADAPTER_WINS_SERVER_ADDRESS_LH extends Struct {
   external _IP_ADAPTER_WINS_SERVER_ADDRESS_LH__Anonymous_e__Union Anonymous;
 
@@ -4607,7 +4607,7 @@ base class IP_ADAPTER_WINS_SERVER_ADDRESS_LH extends Struct {
   external SOCKET_ADDRESS Address;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_WINS_SERVER_ADDRESS_LH__Anonymous_e__Union
     extends Union {
   @Uint64()
@@ -4617,7 +4617,7 @@ sealed class _IP_ADAPTER_WINS_SERVER_ADDRESS_LH__Anonymous_e__Union
       Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _IP_ADAPTER_WINS_SERVER_ADDRESS_LH__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -4653,7 +4653,7 @@ extension IP_ADAPTER_WINS_SERVER_ADDRESS_LH_Extension
 /// notation. The IP_ADDRESS_STRING structure definition is also the type
 /// definition for the IP_MASK_STRING structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADDRESS_STRING extends Struct {
   @Array(16)
   external Array<Uint8> String_;
@@ -4662,7 +4662,7 @@ base class IP_ADDRESS_STRING extends Struct {
 /// The IP_ADDR_STRING structure represents a node in a linked-list of IPv4
 /// addresses.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_ADDR_STRING extends Struct {
   external Pointer<IP_ADDR_STRING> Next;
 
@@ -4677,7 +4677,7 @@ base class IP_ADDR_STRING extends Struct {
 /// The IP_INTERFACE_INFO structure contains a list of the network interface
 /// adapters with IPv4 enabled on the local system.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_INTERFACE_INFO extends Struct {
   @Int32()
   external int NumAdapters;
@@ -4689,7 +4689,7 @@ base class IP_INTERFACE_INFO extends Struct {
 /// The IP_PER_ADAPTER_INFO structure contains information specific to a
 /// particular adapter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class IP_PER_ADAPTER_INFO_W2KSP1 extends Struct {
   @Uint32()
   external int AutoconfigEnabled;
@@ -4704,7 +4704,7 @@ base class IP_PER_ADAPTER_INFO_W2KSP1 extends Struct {
 
 /// Contains a list of item identifiers.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class ITEMIDLIST extends Struct {
   external SHITEMID mkid;
@@ -4712,7 +4712,7 @@ base class ITEMIDLIST extends Struct {
 
 /// Contains information used to control the I/O rate for a job.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class JOBOBJECT_IO_RATE_CONTROL_INFORMATION extends Struct {
   @Int64()
   external int MaxIops;
@@ -4737,7 +4737,7 @@ base class JOBOBJECT_IO_RATE_CONTROL_INFORMATION extends Struct {
 /// spooled, the name of the machine that created the print job, the name of
 /// the user that owns the print job, and so on.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class JOB_INFO_1 extends Struct {
   @Uint32()
   external int JobId;
@@ -4774,7 +4774,7 @@ base class JOB_INFO_1 extends Struct {
 
 /// Contains information about a low-level keyboard input event.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class KBDLLHOOKSTRUCT extends Struct {
   @Uint32()
   external int vkCode;
@@ -4794,7 +4794,7 @@ base class KBDLLHOOKSTRUCT extends Struct {
 
 /// Contains information about a simulated keyboard event.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class KEYBDINPUT extends Struct {
   @Uint16()
   external int wVk;
@@ -4814,7 +4814,7 @@ base class KEYBDINPUT extends Struct {
 
 /// Describes a keyboard input event in a console INPUT_RECORD structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class KEY_EVENT_RECORD extends Struct {
   @Int32()
   external int bKeyDown;
@@ -4834,7 +4834,7 @@ base class KEY_EVENT_RECORD extends Struct {
   external int dwControlKeyState;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _KEY_EVENT_RECORD__uChar_e__Union extends Union {
   @Uint16()
   external int UnicodeChar;
@@ -4853,7 +4853,7 @@ extension KEY_EVENT_RECORD_Extension on KEY_EVENT_RECORD {
 
 /// Defines the specifics of a known folder.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class KNOWNFOLDER_DEFINITION extends Struct {
   @Int32()
   external int category;
@@ -4889,7 +4889,7 @@ base class KNOWNFOLDER_DEFINITION extends Struct {
 /// send notifications to any service or applications that has registered
 /// for the notification.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class L2_NOTIFICATION_DATA extends Struct {
   @Uint32()
   external int NotificationSource;
@@ -4907,7 +4907,7 @@ base class L2_NOTIFICATION_DATA extends Struct {
 
 /// Contains the time of the last input.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class LASTINPUTINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -4920,7 +4920,7 @@ base class LASTINPUTINFO extends Struct {
 /// physical brush. It is used by the CreateBrushIndirect and ExtCreatePen
 /// functions.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class LOGBRUSH extends Struct {
   @Uint32()
   external int lbStyle;
@@ -4934,7 +4934,7 @@ base class LOGBRUSH extends Struct {
 
 /// The LOGFONT structure defines the attributes of a font.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class LOGFONT extends Struct {
   @Int32()
   external int lfHeight;
@@ -4997,7 +4997,7 @@ base class LOGFONT extends Struct {
 
 /// The LOGPALETTE structure defines a logical palette.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class LOGPALETTE extends Struct {
   @Uint16()
   external int palVersion;
@@ -5014,7 +5014,7 @@ base class LOGPALETTE extends Struct {
 /// locally unique identifier is guaranteed only until the system is
 /// restarted.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class LUID extends Struct {
   @Uint32()
   external int LowPart;
@@ -5026,7 +5026,7 @@ base class LUID extends Struct {
 /// Describes a color transformation matrix that a magnifier control uses to
 /// apply a color effect to magnified screen content.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MAGCOLOREFFECT extends Struct {
   @Array(25)
   external Array<Float> transform;
@@ -5034,7 +5034,7 @@ base class MAGCOLOREFFECT extends Struct {
 
 /// Describes an image format.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MAGIMAGEHEADER extends Struct {
   @Uint32()
   external int width;
@@ -5057,7 +5057,7 @@ base class MAGIMAGEHEADER extends Struct {
 /// Describes a transformation matrix that a magnifier control uses to
 /// magnify screen content.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MAGTRANSFORM extends Struct {
   @Array(9)
   external Array<Float> v;
@@ -5066,7 +5066,7 @@ base class MAGTRANSFORM extends Struct {
 /// Returned by the GetThemeMargins function to define the margins of
 /// windows that have visual styles applied.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MARGINS extends Struct {
   @Int32()
   external int cxLeftWidth;
@@ -5084,7 +5084,7 @@ base class MARGINS extends Struct {
 /// The MCI_OPEN_PARMS structure contains information for the MCI_OPEN
 /// command.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MCI_OPEN_PARMS extends Struct {
   @IntPtr()
@@ -5103,7 +5103,7 @@ base class MCI_OPEN_PARMS extends Struct {
 /// The MCI_PLAY_PARMS structure contains positioning information for the
 /// MCI_PLAY command.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MCI_PLAY_PARMS extends Struct {
   @IntPtr()
@@ -5119,7 +5119,7 @@ base class MCI_PLAY_PARMS extends Struct {
 /// The MCI_SEEK_PARMS structure contains positioning information for the
 /// MCI_SEEK command.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MCI_SEEK_PARMS extends Struct {
   @IntPtr()
@@ -5132,7 +5132,7 @@ base class MCI_SEEK_PARMS extends Struct {
 /// The MCI_STATUS_PARMS structure contains information for the MCI_STATUS
 /// command.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MCI_STATUS_PARMS extends Struct {
   @IntPtr()
@@ -5152,7 +5152,7 @@ base class MCI_STATUS_PARMS extends Struct {
 /// virtual memory, including extended memory. The GlobalMemoryStatusEx
 /// function stores information in this structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MEMORYSTATUSEX extends Struct {
   @Uint32()
   external int dwLength;
@@ -5186,7 +5186,7 @@ base class MEMORYSTATUSEX extends Struct {
 /// of a process. The VirtualQuery and VirtualQueryEx functions use this
 /// structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MEMORY_BASIC_INFORMATION extends Struct {
   external Pointer BaseAddress;
 
@@ -5213,7 +5213,7 @@ base class MEMORY_BASIC_INFORMATION extends Struct {
 
 /// Contains menu bar information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MENUBARINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -5232,7 +5232,7 @@ base class MENUBARINFO extends Struct {
 
 /// Contains information about a menu.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MENUINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -5258,7 +5258,7 @@ base class MENUINFO extends Struct {
 
 /// Contains information about a menu item.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MENUITEMINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -5298,7 +5298,7 @@ base class MENUITEMINFO extends Struct {
 
 /// Defines a menu item in a menu template.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MENUITEMTEMPLATE extends Struct {
   @Uint16()
   external int mtOption;
@@ -5329,7 +5329,7 @@ base class MENUITEMTEMPLATE extends Struct {
 /// Defines the header for a menu template. A complete menu template
 /// consists of a header and one or more menu item lists.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MENUITEMTEMPLATEHEADER extends Struct {
   @Uint16()
   external int versionNumber;
@@ -5341,7 +5341,7 @@ base class MENUITEMTEMPLATEHEADER extends Struct {
 /// Describes a menu event in a console INPUT_RECORD structure. These events
 /// are used internally and should be ignored.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MENU_EVENT_RECORD extends Struct {
   @Uint32()
   external int dwCommandId;
@@ -5350,7 +5350,7 @@ base class MENU_EVENT_RECORD extends Struct {
 /// Defines the metafile picture format used for exchanging metafile data
 /// through the clipboard.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class METAFILEPICT extends Struct {
   @Int32()
   external int mm;
@@ -5367,7 +5367,7 @@ base class METAFILEPICT extends Struct {
 
 /// The MIDIEVENT structure describes a MIDI event in a stream buffer.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MIDIEVENT extends Struct {
   @Uint32()
@@ -5386,7 +5386,7 @@ base class MIDIEVENT extends Struct {
 /// The MIDIHDR structure defines the header used to identify a MIDI
 /// system-exclusive or stream buffer.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MIDIHDR extends Struct {
   external Pointer<Utf8> lpData;
@@ -5418,7 +5418,7 @@ base class MIDIHDR extends Struct {
 /// The MIDIINCAPS structure describes the capabilities of a MIDI input
 /// device.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MIDIINCAPS extends Struct {
   @Uint16()
@@ -5456,7 +5456,7 @@ base class MIDIINCAPS extends Struct {
 /// The MIDIOUTCAPS structure describes the capabilities of a MIDI output
 /// device.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MIDIOUTCAPS extends Struct {
   @Uint16()
@@ -5505,7 +5505,7 @@ base class MIDIOUTCAPS extends Struct {
 
 /// The MIDIPROPTEMPO structure contains the tempo property for a stream.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MIDIPROPTEMPO extends Struct {
   @Uint32()
@@ -5518,7 +5518,7 @@ base class MIDIPROPTEMPO extends Struct {
 /// The MIDIPROPTIMEDIV structure contains the time division property for a
 /// stream.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MIDIPROPTIMEDIV extends Struct {
   @Uint32()
@@ -5531,7 +5531,7 @@ base class MIDIPROPTIMEDIV extends Struct {
 /// The MIDISTRMBUFFVER structure contains version information for a long
 /// MIDI event of the MEVT_VERSION type.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class MIDISTRMBUFFVER extends Struct {
   @Uint32()
@@ -5547,7 +5547,7 @@ base class MIDISTRMBUFFVER extends Struct {
 /// Contains information about a window's maximized size and position and
 /// its minimum and maximum tracking size.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MINMAXINFO extends Struct {
   external POINT ptReserved;
 
@@ -5563,7 +5563,7 @@ base class MINMAXINFO extends Struct {
 /// The MMTIME structure contains timing information for different types of
 /// multimedia data.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MMTIME extends Struct {
   @Uint32()
   external int wType;
@@ -5571,7 +5571,7 @@ base class MMTIME extends Struct {
   external _MMTIME__u_e__Union u;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _MMTIME__u_e__Union extends Union {
   @Uint32()
   external int ms;
@@ -5590,7 +5590,7 @@ sealed class _MMTIME__u_e__Union extends Union {
   external _MMTIME__u_e__Union__midi_e__Struct midi;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _MMTIME__u_e__Union__smpte_e__Struct extends Struct {
   @Uint8()
   external int hour;
@@ -5637,7 +5637,7 @@ extension MMTIME__u_e__Union_Extension on MMTIME {
   set pad(Array<Uint8> value) => this.u.smpte.pad = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 sealed class _MMTIME__u_e__Union__midi_e__Struct extends Struct {
   @Uint32()
@@ -5671,7 +5671,7 @@ extension MMTIME_Extension on MMTIME {
 
 /// Contains information about the capabilities of a modem.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MODEMDEVCAPS extends Struct {
   @Uint32()
   external int dwActualSize;
@@ -5736,7 +5736,7 @@ base class MODEMDEVCAPS extends Struct {
 
 /// Contains information about a modem's configuration.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MODEMSETTINGS extends Struct {
   @Uint32()
   external int dwActualSize;
@@ -5777,7 +5777,7 @@ base class MODEMSETTINGS extends Struct {
 
 /// Contains module data.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MODLOAD_DATA extends Struct {
   @Uint32()
   external int ssize;
@@ -5796,7 +5796,7 @@ base class MODLOAD_DATA extends Struct {
 
 /// Contains the module load address, size, and entry point.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MODULEINFO extends Struct {
   external Pointer lpBaseOfDll;
 
@@ -5808,7 +5808,7 @@ base class MODULEINFO extends Struct {
 
 /// The MONITORINFO structure contains information about a display monitor.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MONITORINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -5824,7 +5824,7 @@ base class MONITORINFO extends Struct {
 /// The MONITORINFOEX structure contains information about a display
 /// monitor.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MONITORINFOEX extends Struct {
   external MONITORINFO monitorInfo;
 
@@ -5851,7 +5851,7 @@ base class MONITORINFOEX extends Struct {
 /// Contains information about a mouse event passed to a WH_MOUSE hook
 /// procedure, MouseProc.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MOUSEHOOKSTRUCT extends Struct {
   external POINT pt;
 
@@ -5870,7 +5870,7 @@ base class MOUSEHOOKSTRUCT extends Struct {
 /// structure that includes information about wheel movement or the use of
 /// the X button.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MOUSEHOOKSTRUCTEX extends Struct {
   external MOUSEHOOKSTRUCT Base;
 
@@ -5880,7 +5880,7 @@ base class MOUSEHOOKSTRUCTEX extends Struct {
 
 /// Contains information about a simulated mouse event.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MOUSEINPUT extends Struct {
   @Int32()
   external int dx;
@@ -5903,7 +5903,7 @@ base class MOUSEINPUT extends Struct {
 
 /// Contains information about the mouse's location in screen coordinates.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MOUSEMOVEPOINT extends Struct {
   @Int32()
   external int x;
@@ -5920,7 +5920,7 @@ base class MOUSEMOVEPOINT extends Struct {
 
 /// Describes a mouse input event in a console INPUT_RECORD structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MOUSE_EVENT_RECORD extends Struct {
   external COORD dwMousePosition;
 
@@ -5936,7 +5936,7 @@ base class MOUSE_EVENT_RECORD extends Struct {
 
 /// Contains message information from a thread's message queue.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MSG extends Struct {
   @IntPtr()
   external int hwnd;
@@ -5958,7 +5958,7 @@ base class MSG extends Struct {
 
 /// Contains information about a low-level mouse input event.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class MSLLHOOKSTRUCT extends Struct {
   external POINT pt;
 
@@ -5979,7 +5979,7 @@ base class MSLLHOOKSTRUCT extends Struct {
 /// WM_NCCALCSIZE message to calculate the size, position, and valid
 /// contents of the client area of a window.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class NCCALCSIZE_PARAMS extends Struct {
   @Array(3)
   external Array<RECT> rgrc;
@@ -5990,7 +5990,7 @@ base class NCCALCSIZE_PARAMS extends Struct {
 /// The NDIS_OBJECT_HEADER structure packages the object type, version, and
 /// size information that is required in many NDIS 6.0 structures.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class NDIS_OBJECT_HEADER extends Struct {
   @Uint8()
   external int Type;
@@ -6005,7 +6005,7 @@ base class NDIS_OBJECT_HEADER extends Struct {
 /// The NET_LUID union is the locally unique identifier (LUID) for a network
 /// interface.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class NET_LUID_LH extends Union {
   @Uint64()
   external int Value;
@@ -6013,7 +6013,7 @@ base class NET_LUID_LH extends Union {
   external _NET_LUID_LH__Info_e__Struct Info;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _NET_LUID_LH__Info_e__Struct extends Struct {
   @Uint64()
   external int bitfield;
@@ -6027,7 +6027,7 @@ extension NET_LUID_LH_Extension on NET_LUID_LH {
 /// The NEWTEXTMETRIC structure contains data that describes a physical
 /// font.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class NEWTEXTMETRIC extends Struct {
   @Int32()
   external int tmHeight;
@@ -6107,7 +6107,7 @@ base class NEWTEXTMETRIC extends Struct {
 /// Session to support the simulation of specific metered internet
 /// connection conditions.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class NLM_SIMULATED_PROFILE_INFO extends Struct {
   @Array(256)
   external Array<Uint16> _ProfileName;
@@ -6143,7 +6143,7 @@ base class NLM_SIMULATED_PROFILE_INFO extends Struct {
 /// SPI_GETNONCLIENTMETRICS and SPI_SETNONCLIENTMETRICS actions of the
 /// SystemParametersInfo function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class NONCLIENTMETRICS extends Struct {
   @Uint32()
   external int cbSize;
@@ -6192,7 +6192,7 @@ base class NONCLIENTMETRICS extends Struct {
 /// Contains information that the system needs to display notifications in
 /// the notification area. Used by Shell_NotifyIcon.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class NOTIFYICONDATA extends Struct {
   @Uint32()
   external int cbSize;
@@ -6286,7 +6286,7 @@ base class NOTIFYICONDATA extends Struct {
   external int hBalloonIcon;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _NOTIFYICONDATAW__Anonymous_e__Union extends Union {
   @Uint32()
   external int uTimeout;
@@ -6309,7 +6309,7 @@ extension NOTIFYICONDATAW_Extension on NOTIFYICONDATA {
 /// recommended over calling GetOpenCardName with OPENCARDNAME. OPENCARDNAME
 /// is provided for backward compatibility.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class OPENCARDNAME extends Struct {
   @Uint32()
   external int dwStructSize;
@@ -6375,7 +6375,7 @@ base class OPENCARDNAME extends Struct {
 /// SCardUIDlgSelectCard function uses to initialize a smart card Select
 /// Card dialog box.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class OPENCARDNAME_EX extends Struct {
   @Uint32()
   external int dwStructSize;
@@ -6430,7 +6430,7 @@ base class OPENCARDNAME_EX extends Struct {
 /// requirements set forth by the caller. You can, however, call
 /// SCardUIDlgSelectCard without using this structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class OPENCARD_SEARCH_CRITERIA extends Struct {
   @Uint32()
   external int dwStructSize;
@@ -6470,7 +6470,7 @@ base class OPENCARD_SEARCH_CRITERIA extends Struct {
 /// user closes the dialog box, the system returns information about the
 /// user's selection in this structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class OPENFILENAME extends Struct {
   @Uint32()
   external int lStructSize;
@@ -6534,7 +6534,7 @@ base class OPENFILENAME extends Struct {
 
 /// Contains details about the operating system for an assembly or module.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class OSINFO extends Struct {
   @Uint32()
   external int dwOSPlatformId;
@@ -6552,7 +6552,7 @@ base class OSINFO extends Struct {
 /// installed on the system. This structure is used with the GetVersionEx
 /// and VerifyVersionInfo functions.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class OSVERSIONINFOEX extends Struct {
   @Uint32()
   external int dwOSVersionInfoSize;
@@ -6609,7 +6609,7 @@ base class OSVERSIONINFOEX extends Struct {
 /// and descriptive text about the operating system. This structure is used
 /// with the GetVersionEx function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class OSVERSIONINFO extends Struct {
   @Uint32()
   external int dwOSVersionInfoSize;
@@ -6649,7 +6649,7 @@ base class OSVERSIONINFO extends Struct {
 /// Contains information used in asynchronous (or overlapped) input and
 /// output (I/O).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class OVERLAPPED extends Struct {
   @IntPtr()
   external int Internal;
@@ -6663,14 +6663,14 @@ base class OVERLAPPED extends Struct {
   external int hEvent;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _OVERLAPPED__Anonymous_e__Union extends Union {
   external _OVERLAPPED__Anonymous_e__Union__Anonymous_e__Struct Anonymous;
 
   external Pointer Pointer_;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _OVERLAPPED__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint32()
@@ -6701,7 +6701,7 @@ extension OVERLAPPED_Extension on OVERLAPPED {
 /// Contains the information returned by a call to the
 /// GetQueuedCompletionStatusEx function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class OVERLAPPED_ENTRY extends Struct {
   @IntPtr()
   external int lpCompletionKey;
@@ -6719,7 +6719,7 @@ base class OVERLAPPED_ENTRY extends Struct {
 /// information can be used to paint the client area of a window owned by
 /// that application.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PAINTSTRUCT extends Struct {
   @IntPtr()
   external int hdc;
@@ -6743,7 +6743,7 @@ base class PAINTSTRUCT extends Struct {
 /// a logical palette. A logical palette is defined by a LOGPALETTE
 /// structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PALETTEENTRY extends Struct {
   @Uint8()
   external int peRed;
@@ -6761,7 +6761,7 @@ base class PALETTEENTRY extends Struct {
 /// Contains information needed for transferring a structure element,
 /// parameter, or function return value between processes.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PARAMDESC extends Struct {
   external Pointer<PARAMDESCEX> pparamdescex;
 
@@ -6771,7 +6771,7 @@ base class PARAMDESC extends Struct {
 
 /// Contains information about the default value of a parameter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PARAMDESCEX extends Struct {
   @Uint32()
   external int cBytes;
@@ -6781,7 +6781,7 @@ base class PARAMDESCEX extends Struct {
 
 /// Contains performance information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PERFORMANCE_INFORMATION extends Struct {
   @Uint32()
   external int cb;
@@ -6829,7 +6829,7 @@ base class PERFORMANCE_INFORMATION extends Struct {
 /// Contains a handle and text description corresponding to a physical
 /// monitor.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class PHYSICAL_MONITOR extends Struct {
   @IntPtr()
@@ -6857,7 +6857,7 @@ base class PHYSICAL_MONITOR extends Struct {
 
 /// The POINT structure defines the x- and y-coordinates of a point.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class POINT extends Struct {
   @Int32()
   external int x;
@@ -6871,7 +6871,7 @@ base class POINT extends Struct {
 /// GetPointerFrameInfo, GetPointerInfoHistory and
 /// GetPointerFrameInfoHistory functions.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class POINTER_INFO extends Struct {
   @Int32()
   external int pointerType;
@@ -6920,7 +6920,7 @@ base class POINTER_INFO extends Struct {
 
 /// Defines basic pen information common to all pointer types.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class POINTER_PEN_INFO extends Struct {
   external POINTER_INFO pointerInfo;
 
@@ -6945,7 +6945,7 @@ base class POINTER_PEN_INFO extends Struct {
 
 /// Defines basic touch information common to all pointer types.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class POINTER_TOUCH_INFO extends Struct {
   external POINTER_INFO pointerInfo;
 
@@ -6968,7 +6968,7 @@ base class POINTER_TOUCH_INFO extends Struct {
 
 /// The POINTL structure defines the x- and y-coordinates of a point.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class POINTL extends Struct {
   @Int32()
   external int x;
@@ -6979,7 +6979,7 @@ base class POINTL extends Struct {
 
 /// The POINTS structure defines the x- and y-coordinates of a point.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class POINTS extends Struct {
   @Int16()
   external int x;
@@ -6991,7 +6991,7 @@ base class POINTS extends Struct {
 /// The POLYTEXT structure describes how the PolyTextOut function should
 /// draw a string of text.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class POLYTEXT extends Struct {
   @Int32()
   external int x;
@@ -7014,14 +7014,14 @@ base class POLYTEXT extends Struct {
 
 /// The PORT_INFO_1 structure identifies a supported printer port.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PORT_INFO_1 extends Struct {
   external Pointer<Utf16> pName;
 }
 
 /// The PORT_INFO_2 structure identifies a supported printer port.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PORT_INFO_2 extends Struct {
   external Pointer<Utf16> pPortName;
 
@@ -7039,7 +7039,7 @@ base class PORT_INFO_2 extends Struct {
 /// Sent with a power setting event and contains data about the specific
 /// change.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class POWERBROADCAST_SETTING extends Struct {
   external GUID PowerSetting;
 
@@ -7053,7 +7053,7 @@ base class POWERBROADCAST_SETTING extends Struct {
 /// The PRINTER_DEFAULTS structure specifies the default data type,
 /// environment, initialization data, and access rights for a printer.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINTER_DEFAULTS extends Struct {
   external Pointer<Utf16> pDatatype;
 
@@ -7065,7 +7065,7 @@ base class PRINTER_DEFAULTS extends Struct {
 
 /// The PRINTER_INFO_1 structure specifies general printer information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINTER_INFO_1 extends Struct {
   @Uint32()
   external int Flags;
@@ -7079,7 +7079,7 @@ base class PRINTER_INFO_1 extends Struct {
 
 /// The PRINTER_INFO_2 structure specifies detailed printer information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINTER_INFO_2 extends Struct {
   external Pointer<Utf16> pServerName;
 
@@ -7134,7 +7134,7 @@ base class PRINTER_INFO_2 extends Struct {
 
 /// The PRINTER_INFO_3 structure specifies printer security information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINTER_INFO_3 extends Struct {
   external Pointer pSecurityDescriptor;
 }
@@ -7145,7 +7145,7 @@ base class PRINTER_INFO_3 extends Struct {
 /// names and attributes of all locally installed printers on a system and
 /// all remote printer connections that a user has established.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINTER_INFO_4 extends Struct {
   external Pointer<Utf16> pPrinterName;
 
@@ -7157,7 +7157,7 @@ base class PRINTER_INFO_4 extends Struct {
 
 /// The PRINTER_INFO_5 structure specifies detailed printer information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINTER_INFO_5 extends Struct {
   external Pointer<Utf16> pPrinterName;
 
@@ -7175,7 +7175,7 @@ base class PRINTER_INFO_5 extends Struct {
 
 /// The PRINTER_INFO_6 specifies the status value of a printer.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINTER_INFO_6 extends Struct {
   @Uint32()
   external int dwStatus;
@@ -7186,7 +7186,7 @@ base class PRINTER_INFO_6 extends Struct {
 /// this information after a wait operation on a printer change notification
 /// object has been satisfied.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINTER_NOTIFY_INFO extends Struct {
   @Uint32()
   external int Version;
@@ -7204,7 +7204,7 @@ base class PRINTER_NOTIFY_INFO extends Struct {
 /// The PRINTER_NOTIFY_INFO_DATA structure identifies a job or printer
 /// information field and provides the current data for that field.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINTER_NOTIFY_INFO_DATA extends Struct {
   @Uint16()
   external int Type;
@@ -7221,7 +7221,7 @@ base class PRINTER_NOTIFY_INFO_DATA extends Struct {
   external _PRINTER_NOTIFY_INFO_DATA__NotifyData_e__Union NotifyData;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _PRINTER_NOTIFY_INFO_DATA__NotifyData_e__Union extends Union {
   @Array(2)
   external Array<Uint32> adwData;
@@ -7229,7 +7229,7 @@ sealed class _PRINTER_NOTIFY_INFO_DATA__NotifyData_e__Union extends Union {
   external _PRINTER_NOTIFY_INFO_DATA__NotifyData_e__Union__Data_e__Struct Data;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _PRINTER_NOTIFY_INFO_DATA__NotifyData_e__Union__Data_e__Struct
     extends Struct {
   @Uint32()
@@ -7261,7 +7261,7 @@ extension PRINTER_NOTIFY_INFO_DATA_Extension on PRINTER_NOTIFY_INFO_DATA {
 
 /// Represents printer options.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINTER_OPTIONS extends Struct {
   @Uint32()
   external int cbSize;
@@ -7273,7 +7273,7 @@ base class PRINTER_OPTIONS extends Struct {
 /// Contains the execution context of the printer driver that calls
 /// GetPrintExecutionData.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PRINT_EXECUTION_DATA extends Struct {
   @Int32()
   external int context;
@@ -7285,7 +7285,7 @@ base class PRINT_EXECUTION_DATA extends Struct {
 /// Contains information about a heap element. The HeapWalk function uses a
 /// PROCESS_HEAP_ENTRY structure to enumerate the elements of a heap.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PROCESS_HEAP_ENTRY extends Struct {
   external Pointer lpData;
 
@@ -7304,14 +7304,14 @@ base class PROCESS_HEAP_ENTRY extends Struct {
   external _PROCESS_HEAP_ENTRY__Anonymous_e__Union Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _PROCESS_HEAP_ENTRY__Anonymous_e__Union extends Union {
   external _PROCESS_HEAP_ENTRY__Anonymous_e__Union__Block_e__Struct Block;
 
   external _PROCESS_HEAP_ENTRY__Anonymous_e__Union__Region_e__Struct Region;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _PROCESS_HEAP_ENTRY__Anonymous_e__Union__Block_e__Struct
     extends Struct {
   @IntPtr()
@@ -7331,7 +7331,7 @@ extension PROCESS_HEAP_ENTRY__Anonymous_e__Union_Extension
       this.Anonymous.Block.dwReserved = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _PROCESS_HEAP_ENTRY__Anonymous_e__Union__Region_e__Struct
     extends Struct {
   @Uint32()
@@ -7378,7 +7378,7 @@ extension PROCESS_HEAP_ENTRY_Extension on PROCESS_HEAP_ENTRY {
 /// thread. It is used with the CreateProcess, CreateProcessAsUser,
 /// CreateProcessWithLogonW, or CreateProcessWithTokenW function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PROCESS_INFORMATION extends Struct {
   @IntPtr()
   external int hProcess;
@@ -7396,7 +7396,7 @@ base class PROCESS_INFORMATION extends Struct {
 /// Specifies the FMTID/PID identifier that programmatically identifies a
 /// property.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PROPERTYKEY extends Struct {
   external GUID fmtid;
 
@@ -7408,7 +7408,7 @@ base class PROPERTYKEY extends Struct {
 /// IPropertyStorage to specify a property either by its property identifier
 /// (ID) or the associated string name.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PROPSPEC extends Struct {
   @Uint32()
   external int ulKind;
@@ -7416,7 +7416,7 @@ base class PROPSPEC extends Struct {
   external _PROPSPEC__Anonymous_e__Union Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _PROPSPEC__Anonymous_e__Union extends Union {
   @Uint32()
   external int propid;
@@ -7439,7 +7439,7 @@ extension PROPSPEC_Extension on PROPSPEC {
 /// the application should copy any information it needs before issuing any
 /// other Windows Sockets function calls.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PROTOENT extends Struct {
   external Pointer<Utf8> p_name;
 
@@ -7452,7 +7452,7 @@ base class PROTOENT extends Struct {
 /// Contains configuration information for an installed service. It is used
 /// by the QueryServiceConfig function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class QUERY_SERVICE_CONFIG extends Struct {
   @Uint32()
   external int dwServiceType;
@@ -7480,7 +7480,7 @@ base class QUERY_SERVICE_CONFIG extends Struct {
 /// Contains information about the lock status of a service control manager
 /// database. It is used by the QueryServiceLockStatus function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class QUERY_SERVICE_LOCK_STATUS extends Struct {
   @Uint32()
   external int fIsLocked;
@@ -7494,7 +7494,7 @@ base class QUERY_SERVICE_LOCK_STATUS extends Struct {
 /// Describes the format of the raw input from a Human Interface Device
 /// (HID).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class RAWHID extends Struct {
   @Uint32()
   external int dwSizeHid;
@@ -7508,14 +7508,14 @@ base class RAWHID extends Struct {
 
 /// Contains the raw input from a device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class RAWINPUT extends Struct {
   external RAWINPUTHEADER header;
 
   external _RAWINPUT__data_e__Union data;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _RAWINPUT__data_e__Union extends Union {
   external RAWMOUSE mouse;
 
@@ -7537,7 +7537,7 @@ extension RAWINPUT_Extension on RAWINPUT {
 
 /// Defines information for the raw input devices.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class RAWINPUTDEVICE extends Struct {
   @Uint16()
   external int usUsagePage;
@@ -7554,7 +7554,7 @@ base class RAWINPUTDEVICE extends Struct {
 
 /// Contains information about a raw input device.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class RAWINPUTDEVICELIST extends Struct {
   @IntPtr()
   external int hDevice;
@@ -7565,7 +7565,7 @@ base class RAWINPUTDEVICELIST extends Struct {
 
 /// Contains the header information that is part of the raw input data.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class RAWINPUTHEADER extends Struct {
   @Uint32()
   external int dwType;
@@ -7582,7 +7582,7 @@ base class RAWINPUTHEADER extends Struct {
 
 /// Contains information about the state of the keyboard.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class RAWKEYBOARD extends Struct {
   @Uint16()
   external int MakeCode;
@@ -7605,7 +7605,7 @@ base class RAWKEYBOARD extends Struct {
 
 /// Contains information about the state of the mouse.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class RAWMOUSE extends Struct {
   @Uint16()
   external int usFlags;
@@ -7625,7 +7625,7 @@ base class RAWMOUSE extends Struct {
   external int ulExtraInformation;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _RAWMOUSE__Anonymous_e__Union extends Union {
   @Uint32()
   external int ulButtons;
@@ -7633,7 +7633,7 @@ sealed class _RAWMOUSE__Anonymous_e__Union extends Union {
   external _RAWMOUSE__Anonymous_e__Union__Anonymous_e__Struct Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _RAWMOUSE__Anonymous_e__Union__Anonymous_e__Struct extends Struct {
   @Uint16()
   external int usButtonFlags;
@@ -7664,7 +7664,7 @@ extension RAWMOUSE_Extension on RAWMOUSE {
 /// The RECT structure defines a rectangle by the coordinates of its
 /// upper-left and lower-right corners.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class RECT extends Struct {
   @Int32()
   external int left;
@@ -7682,7 +7682,7 @@ base class RECT extends Struct {
 /// The RECTL structure defines a rectangle by the coordinates of its
 /// upper-left and lower-right corners.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class RECTL extends Struct {
   @Int32()
   external int left;
@@ -7700,7 +7700,7 @@ base class RECTL extends Struct {
 /// The RGBQUAD structure describes a color consisting of relative
 /// intensities of red, green, and blue.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class RGBQUAD extends Struct {
   @Uint8()
   external int rgbBlue;
@@ -7717,7 +7717,7 @@ base class RGBQUAD extends Struct {
 
 /// Represents a safe array.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SAFEARRAY extends Struct {
   @Uint16()
   external int cDims;
@@ -7739,7 +7739,7 @@ base class SAFEARRAY extends Struct {
 
 /// Represents the bounds of one dimension of the array.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SAFEARRAYBOUND extends Struct {
   @Uint32()
   external int cElements;
@@ -7751,7 +7751,7 @@ base class SAFEARRAYBOUND extends Struct {
 /// The SCARD_ATRMASK structure is used by the SCardLocateCardsByATR
 /// function to locate cards.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SCARD_ATRMASK extends Struct {
   @Uint32()
   external int cbAtr;
@@ -7770,7 +7770,7 @@ base class SCARD_ATRMASK extends Struct {
 /// the length of any PCI information must be a multiple of four bytes so
 /// that it aligns on a 32-bit boundary.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SCARD_IO_REQUEST extends Struct {
   @Uint32()
   external int dwProtocol;
@@ -7782,7 +7782,7 @@ base class SCARD_IO_REQUEST extends Struct {
 /// The SCARD_READERSTATE structure is used by functions for tracking smart
 /// cards within readers.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SCARD_READERSTATE extends Struct {
   external Pointer<Utf16> szReader;
 
@@ -7803,7 +7803,7 @@ base class SCARD_READERSTATE extends Struct {
 
 /// The SCROLLBARINFO structure contains scroll bar information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SCROLLBARINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -7830,7 +7830,7 @@ base class SCROLLBARINFO extends Struct {
 /// SetScrollInfo function (or SBM_SETSCROLLINFO message), or retrieved by
 /// the GetScrollInfo function (or SBM_GETSCROLLINFO message)
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SCROLLINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -7856,7 +7856,7 @@ base class SCROLLINFO extends Struct {
 
 /// Represents an action that the service control manager can perform.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SC_ACTION extends Struct {
   @Int32()
   external int Type;
@@ -7867,7 +7867,7 @@ base class SC_ACTION extends Struct {
 
 /// The SDP_ELEMENT_DATA structure stores SDP element data.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SDP_ELEMENT_DATA extends Struct {
   @Int32()
   external int type;
@@ -7878,7 +7878,7 @@ base class SDP_ELEMENT_DATA extends Struct {
   external _SDP_ELEMENT_DATA__data_e__Union data;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SDP_ELEMENT_DATA__data_e__Union extends Union {
   external SDP_LARGE_INTEGER_16 int128;
 
@@ -7928,7 +7928,7 @@ sealed class _SDP_ELEMENT_DATA__data_e__Union extends Union {
   external _SDP_ELEMENT_DATA__data_e__Union__alternative_e__Struct alternative;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SDP_ELEMENT_DATA__data_e__Union__string_e__Struct extends Struct {
   external Pointer<Uint8> value;
 
@@ -7944,7 +7944,7 @@ extension SDP_ELEMENT_DATA__data_e__Union_Extension on SDP_ELEMENT_DATA {
   set length(int value) => this.data.string.length = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SDP_ELEMENT_DATA__data_e__Union__url_e__Struct extends Struct {
   external Pointer<Uint8> value;
 
@@ -7960,7 +7960,7 @@ extension SDP_ELEMENT_DATA__data_e__Union_Extension_1 on SDP_ELEMENT_DATA {
   set length(int value) => this.data.url.length = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SDP_ELEMENT_DATA__data_e__Union__sequence_e__Struct
     extends Struct {
   external Pointer<Uint8> value;
@@ -7977,7 +7977,7 @@ extension SDP_ELEMENT_DATA__data_e__Union_Extension_2 on SDP_ELEMENT_DATA {
   set length(int value) => this.data.sequence.length = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SDP_ELEMENT_DATA__data_e__Union__alternative_e__Struct
     extends Struct {
   external Pointer<Uint8> value;
@@ -8060,7 +8060,7 @@ extension SDP_ELEMENT_DATA_Extension on SDP_ELEMENT_DATA {
 
 /// The union member for a 128-bit integer.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SDP_LARGE_INTEGER_16 extends Struct {
   @Uint64()
   external int LowPart;
@@ -8072,7 +8072,7 @@ base class SDP_LARGE_INTEGER_16 extends Struct {
 /// The SDP_STRING_TYPE_DATA structure stores information about SDP string
 /// types.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SDP_STRING_TYPE_DATA extends Struct {
   @Uint16()
   external int encoding;
@@ -8086,7 +8086,7 @@ base class SDP_STRING_TYPE_DATA extends Struct {
 
 /// The union member for a 128-bit unsigned integer.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SDP_ULARGE_INTEGER_16 extends Struct {
   @Uint64()
   external int LowPart;
@@ -8101,7 +8101,7 @@ base class SDP_ULARGE_INTEGER_16 extends Struct {
 /// objects created by various functions, such as CreateFile, CreatePipe,
 /// CreateProcess, RegCreateKeyEx, or RegSaveKeyEx.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SECURITY_ATTRIBUTES extends Struct {
   @Uint32()
   external int nLength;
@@ -8116,7 +8116,7 @@ base class SECURITY_ATTRIBUTES extends Struct {
 /// associated with an object. Applications use this structure to set and
 /// query an object's security status.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SECURITY_DESCRIPTOR extends Struct {
   @Uint8()
   external int Revision;
@@ -8139,7 +8139,7 @@ base class SECURITY_DESCRIPTOR extends Struct {
 /// The servent structure is used to store or return the name and service
 /// number for a given service name.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVENT extends Struct {
   external Pointer<Utf8> s_name;
 
@@ -8153,7 +8153,7 @@ base class SERVENT extends Struct {
 
 /// Contains service control parameters.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_CONTROL_STATUS_REASON_PARAMS extends Struct {
   @Uint32()
   external int dwReason;
@@ -8165,7 +8165,7 @@ base class SERVICE_CONTROL_STATUS_REASON_PARAMS extends Struct {
 
 /// Contains the delayed auto-start setting of an auto-start service.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_DELAYED_AUTO_START_INFO extends Struct {
   @Int32()
   external int fDelayedAutostart;
@@ -8173,7 +8173,7 @@ base class SERVICE_DELAYED_AUTO_START_INFO extends Struct {
 
 /// Contains a service description.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_DESCRIPTION extends Struct {
   external Pointer<Utf16> lpDescription;
 }
@@ -8182,7 +8182,7 @@ base class SERVICE_DESCRIPTION extends Struct {
 /// of a service. A service is considered failed when it terminates without
 /// reporting a status of SERVICE_STOPPED to the service controller.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_FAILURE_ACTIONS extends Struct {
   @Uint32()
   external int dwResetPeriod;
@@ -8200,7 +8200,7 @@ base class SERVICE_FAILURE_ACTIONS extends Struct {
 /// Contains the failure actions flag setting of a service. This setting
 /// determines when failure actions are to be executed.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_FAILURE_ACTIONS_FLAG extends Struct {
   @Int32()
   external int fFailureActionsOnNonCrashFailures;
@@ -8208,7 +8208,7 @@ base class SERVICE_FAILURE_ACTIONS_FLAG extends Struct {
 
 /// Indicates a service protection type.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_LAUNCH_PROTECTED_INFO extends Struct {
   @Uint32()
   external int dwLaunchProtected;
@@ -8217,7 +8217,7 @@ base class SERVICE_LAUNCH_PROTECTED_INFO extends Struct {
 /// Represents service status notification information. It is used by the
 /// NotifyServiceStatusChange function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_NOTIFY_2 extends Struct {
   @Uint32()
   external int dwVersion;
@@ -8240,7 +8240,7 @@ base class SERVICE_NOTIFY_2 extends Struct {
 
 /// Represents the preferred node on which to run a service.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_PREFERRED_NODE_INFO extends Struct {
   @Uint16()
   external int usPreferredNode;
@@ -8251,7 +8251,7 @@ base class SERVICE_PREFERRED_NODE_INFO extends Struct {
 
 /// Contains preshutdown settings.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_PRESHUTDOWN_INFO extends Struct {
   @Uint32()
   external int dwPreshutdownTimeout;
@@ -8259,14 +8259,14 @@ base class SERVICE_PRESHUTDOWN_INFO extends Struct {
 
 /// Represents the required privileges for a service.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_REQUIRED_PRIVILEGES_INFO extends Struct {
   external Pointer<Utf16> pmszRequiredPrivileges;
 }
 
 /// Represents a service security identifier (SID).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_SID_INFO extends Struct {
   @Uint32()
   external int dwServiceSidType;
@@ -8278,7 +8278,7 @@ base class SERVICE_SID_INFO extends Struct {
 /// SetServiceStatus function to report its current status to the service
 /// control manager.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_STATUS extends Struct {
   @Uint32()
   external int dwServiceType;
@@ -8306,7 +8306,7 @@ base class SERVICE_STATUS extends Struct {
 /// EnumServicesStatusEx, NotifyServiceStatusChange, and
 /// QueryServiceStatusEx functions use this structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_STATUS_PROCESS extends Struct {
   @Uint32()
   external int dwServiceType;
@@ -8339,7 +8339,7 @@ base class SERVICE_STATUS_PROCESS extends Struct {
 /// Specifies the ServiceMain function for a service that can run in the
 /// calling process. It is used by the StartServiceCtrlDispatcher function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_TABLE_ENTRY extends Struct {
   external Pointer<Utf16> lpServiceName;
 
@@ -8348,7 +8348,7 @@ base class SERVICE_TABLE_ENTRY extends Struct {
 
 /// Contains system time change settings.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_TIMECHANGE_INFO extends Struct {
   @Int64()
   external int liNewTime;
@@ -8360,7 +8360,7 @@ base class SERVICE_TIMECHANGE_INFO extends Struct {
 /// Represents a service trigger event. This structure is used by the
 /// SERVICE_TRIGGER_INFO structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_TRIGGER extends Struct {
   @Uint32()
   external int dwTriggerType;
@@ -8379,7 +8379,7 @@ base class SERVICE_TRIGGER extends Struct {
 /// Contains trigger event information for a service. This structure is used
 /// by the ChangeServiceConfig2 and QueryServiceConfig2 functions.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_TRIGGER_INFO extends Struct {
   @Uint32()
   external int cTriggers;
@@ -8395,7 +8395,7 @@ base class SERVICE_TRIGGER_INFO extends Struct {
 /// SERVICE_TRIGGER_TYPE_FIREWALL_PORT_EVENT, or
 /// SERVICE_TRIGGER_TYPE_NETWORK_ENDPOINT trigger events.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SERVICE_TRIGGER_SPECIFIC_DATA_ITEM extends Struct {
   @Uint32()
   external int dwDataType;
@@ -8408,7 +8408,7 @@ base class SERVICE_TRIGGER_SPECIFIC_DATA_ITEM extends Struct {
 
 /// Contains information used by ShellExecuteEx.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SHELLEXECUTEINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -8449,7 +8449,7 @@ base class SHELLEXECUTEINFO extends Struct {
   external int hProcess;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SHELLEXECUTEINFOW__Anonymous_e__Union extends Union {
   @IntPtr()
   external int hIcon;
@@ -8468,7 +8468,7 @@ extension SHELLEXECUTEINFOW_Extension on SHELLEXECUTEINFO {
 
 /// Defines Shell item resource.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SHELL_ITEM_RESOURCE extends Struct {
   external GUID guidType;
 
@@ -8494,7 +8494,7 @@ base class SHELL_ITEM_RESOURCE extends Struct {
 
 /// Contains information about a file object.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SHFILEINFO extends Struct {
   @IntPtr()
   external int hIcon;
@@ -8547,7 +8547,7 @@ base class SHFILEINFO extends Struct {
 /// Contains information that the SHFileOperation function uses to perform
 /// file operations.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SHFILEOPSTRUCT extends Struct {
   @IntPtr()
   external int hwnd;
@@ -8572,7 +8572,7 @@ base class SHFILEOPSTRUCT extends Struct {
 
 /// Defines an item identifier.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class SHITEMID extends Struct {
   @Uint16()
@@ -8585,7 +8585,7 @@ base class SHITEMID extends Struct {
 /// Contains the size and item count information retrieved by the
 /// SHQueryRecycleBin function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SHQUERYRBINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -8599,7 +8599,7 @@ base class SHQUERYRBINFO extends Struct {
 
 /// The SIZE structure defines the width and height of a rectangle.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SIZE extends Struct {
   @Int32()
   external int cx;
@@ -8611,7 +8611,7 @@ base class SIZE extends Struct {
 /// Defines the coordinates of the upper left and lower right corners of a
 /// rectangle.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SMALL_RECT extends Struct {
   @Int16()
   external int Left;
@@ -8628,7 +8628,7 @@ base class SMALL_RECT extends Struct {
 
 /// The SOCKADDR structure stores socket address information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SOCKADDR extends Struct {
   @Uint16()
   external int sa_family;
@@ -8640,7 +8640,7 @@ base class SOCKADDR extends Struct {
 /// The SOCKADDR_BTH structure is used in conjunction with Bluetooth socket
 /// operations, defined by address family AF_BTH.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class SOCKADDR_BTH extends Struct {
   @Uint16()
@@ -8658,7 +8658,7 @@ base class SOCKADDR_BTH extends Struct {
 /// The SOCKET_ADDRESS structure stores protocol-specific address
 /// information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SOCKET_ADDRESS extends Struct {
   external Pointer<SOCKADDR> lpSockaddr;
 
@@ -8669,7 +8669,7 @@ base class SOCKET_ADDRESS extends Struct {
 /// Identifies an authentication service that a server is willing to use to
 /// communicate to a client.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SOLE_AUTHENTICATION_SERVICE extends Struct {
   @Uint32()
   external int dwAuthnSvc;
@@ -8687,7 +8687,7 @@ base class SOLE_AUTHENTICATION_SERVICE extends Struct {
 /// text-to-speech (TTS) or speech recognition (SR) engines or audio devices
 /// back to applications.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SPEVENT extends Struct {
   @Int32()
   external int bitfield;
@@ -8709,7 +8709,7 @@ base class SPEVENT extends Struct {
 /// information about the event source. Event sources contain a queue, which
 /// hold events until a caller retrieves the events using ::GetEvents.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SPEVENTSOURCEINFO extends Struct {
   @Uint64()
   external int ullEventInterest;
@@ -8724,7 +8724,7 @@ base class SPEVENTSOURCEINFO extends Struct {
 /// SPVOICESTATUS contains voice status information. This structure is
 /// returned by ISpVoice::GetStatus.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SPVOICESTATUS extends Struct {
   @Uint32()
   external int ulCurrentStream;
@@ -8769,7 +8769,7 @@ base class SPVOICESTATUS extends Struct {
 /// An SP_DEVICE_INTERFACE_DATA structure defines a device interface in a
 /// device information set.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SP_DEVICE_INTERFACE_DATA extends Struct {
   @Uint32()
   external int cbSize;
@@ -8786,7 +8786,7 @@ base class SP_DEVICE_INTERFACE_DATA extends Struct {
 /// An SP_DEVICE_INTERFACE_DATA structure defines a device interface in a
 /// device information set.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SP_DEVICE_INTERFACE_DETAIL_DATA_ extends Struct {
   @Uint32()
   external int cbSize;
@@ -8814,7 +8814,7 @@ base class SP_DEVICE_INTERFACE_DETAIL_DATA_ extends Struct {
 /// An SP_DEVINFO_DATA structure defines a device instance that is a member
 /// of a device information set.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SP_DEVINFO_DATA extends Struct {
   @Uint32()
   external int cbSize;
@@ -8832,7 +8832,7 @@ base class SP_DEVINFO_DATA extends Struct {
 /// for a new process. It is used with the CreateProcess and
 /// CreateProcessAsUser functions.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class STARTUPINFOEX extends Struct {
   external STARTUPINFO StartupInfo;
 
@@ -8842,7 +8842,7 @@ base class STARTUPINFOEX extends Struct {
 /// Specifies the window station, desktop, standard handles, and appearance
 /// of the main window for a process at creation time.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class STARTUPINFO extends Struct {
   @Uint32()
   external int cb;
@@ -8897,7 +8897,7 @@ base class STARTUPINFO extends Struct {
 
 /// The STATPROPSETSTG structure contains information about a property set.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class STATPROPSETSTG extends Struct {
   external GUID fmtid;
 
@@ -8920,7 +8920,7 @@ base class STATPROPSETSTG extends Struct {
 /// property set. This data is the property ID and type tag, and the
 /// optional string name that may be associated with the property.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class STATPROPSTG extends Struct {
   external Pointer<Utf16> lpwstrName;
 
@@ -8935,7 +8935,7 @@ base class STATPROPSTG extends Struct {
 /// stream, or byte-array object. This structure is used in the
 /// IEnumSTATSTG, ILockBytes, IStorage, and IStream interfaces.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class STATSTG extends Struct {
   external Pointer<Utf16> pwcsName;
 
@@ -8969,7 +8969,7 @@ base class STATSTG extends Struct {
 /// Contains information about a device. This structure is used by the
 /// IOCTL_STORAGE_GET_DEVICE_NUMBER control code.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class STORAGE_DEVICE_NUMBER extends Struct {
   @Uint32()
   external int DeviceType;
@@ -8983,7 +8983,7 @@ base class STORAGE_DEVICE_NUMBER extends Struct {
 
 /// Contains strings returned from the IShellFolder interface methods.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class STRRET extends Struct {
   @Uint32()
   external int uType;
@@ -8991,7 +8991,7 @@ base class STRRET extends Struct {
   external _STRRET__Anonymous_e__Union Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _STRRET__Anonymous_e__Union extends Union {
   external Pointer<Utf16> pOleStr;
 
@@ -9015,7 +9015,7 @@ extension STRRET_Extension on STRRET {
 
 /// Contains the styles for a window.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class STYLESTRUCT extends Struct {
   @Uint32()
   external int styleOld;
@@ -9026,7 +9026,7 @@ base class STYLESTRUCT extends Struct {
 
 /// Contains symbol information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SYMBOL_INFO extends Struct {
   @Uint32()
   external int SizeOfStruct;
@@ -9095,7 +9095,7 @@ base class SYMBOL_INFO extends Struct {
 /// in coordinated universal time (UTC) or local time, depending on the
 /// function that is being called.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SYSTEMTIME extends Struct {
   @Uint16()
   external int wYear;
@@ -9124,7 +9124,7 @@ base class SYSTEMTIME extends Struct {
 
 /// Contains information about the current state of the system battery.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SYSTEM_BATTERY_STATE extends Struct {
   @Uint8()
   external int AcOnLine;
@@ -9167,7 +9167,7 @@ base class SYSTEM_BATTERY_STATE extends Struct {
 /// the architecture and type of the processor, the number of processors in
 /// the system, the page size, and other such information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SYSTEM_INFO extends Struct {
   external _SYSTEM_INFO__Anonymous_e__Union Anonymous;
 
@@ -9197,7 +9197,7 @@ base class SYSTEM_INFO extends Struct {
   external int wProcessorRevision;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SYSTEM_INFO__Anonymous_e__Union extends Union {
   @Uint32()
   external int dwOemId;
@@ -9205,7 +9205,7 @@ sealed class _SYSTEM_INFO__Anonymous_e__Union extends Union {
   external _SYSTEM_INFO__Anonymous_e__Union__Anonymous_e__Struct Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SYSTEM_INFO__Anonymous_e__Union__Anonymous_e__Struct
     extends Struct {
   @Uint16()
@@ -9238,7 +9238,7 @@ extension SYSTEM_INFO_Extension on SYSTEM_INFO {
 /// Describes the relationship between the specified processor set. This
 /// structure is used with the GetLogicalProcessorInformation function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SYSTEM_LOGICAL_PROCESSOR_INFORMATION extends Struct {
   @IntPtr()
   external int ProcessorMask;
@@ -9249,7 +9249,7 @@ base class SYSTEM_LOGICAL_PROCESSOR_INFORMATION extends Struct {
   external _SYSTEM_LOGICAL_PROCESSOR_INFORMATION__Anonymous_e__Union Anonymous;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SYSTEM_LOGICAL_PROCESSOR_INFORMATION__Anonymous_e__Union
     extends Union {
   external _SYSTEM_LOGICAL_PROCESSOR_INFORMATION__Anonymous_e__Union__ProcessorCore_e__Struct
@@ -9264,7 +9264,7 @@ sealed class _SYSTEM_LOGICAL_PROCESSOR_INFORMATION__Anonymous_e__Union
   external Array<Uint64> Reserved;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SYSTEM_LOGICAL_PROCESSOR_INFORMATION__Anonymous_e__Union__ProcessorCore_e__Struct
     extends Struct {
   @Uint8()
@@ -9277,7 +9277,7 @@ extension SYSTEM_LOGICAL_PROCESSOR_INFORMATION__Anonymous_e__Union_Extension
   set Flags(int value) => this.Anonymous.ProcessorCore.Flags = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _SYSTEM_LOGICAL_PROCESSOR_INFORMATION__Anonymous_e__Union__NumaNode_e__Struct
     extends Struct {
   @Uint32()
@@ -9315,7 +9315,7 @@ extension SYSTEM_LOGICAL_PROCESSOR_INFORMATION_Extension
 
 /// Contains information about the power status of the system.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SYSTEM_POWER_STATUS extends Struct {
   @Uint8()
   external int ACLineStatus;
@@ -9339,7 +9339,7 @@ base class SYSTEM_POWER_STATUS extends Struct {
 /// The SdpAttributeRange structure is used in a Bluetooth query to
 /// constrain the set of attributes to return in the query.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SdpAttributeRange extends Struct {
   @Uint16()
   external int minAttribute;
@@ -9350,7 +9350,7 @@ base class SdpAttributeRange extends Struct {
 
 /// The SdpQueryUuid structure facilitates searching for UUIDs.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SdpQueryUuid extends Struct {
   external SdpQueryUuidUnion u;
 
@@ -9361,7 +9361,7 @@ base class SdpQueryUuid extends Struct {
 /// The SdpQueryUuidUnion union contains the UUID on which to perform an SDP
 /// query. Used in conjunction with the SdpQueryUuid structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class SdpQueryUuidUnion extends Union {
   external GUID uuid128;
 
@@ -9375,7 +9375,7 @@ base class SdpQueryUuidUnion extends Union {
 /// The TASKDIALOGCONFIG structure contains information used to display a
 /// task dialog. The TaskDialogIndirect function uses this structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class TASKDIALOGCONFIG extends Struct {
   @Uint32()
@@ -9438,7 +9438,7 @@ base class TASKDIALOGCONFIG extends Struct {
   external int cxWidth;
 }
 
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 sealed class _TASKDIALOGCONFIG__Anonymous1_e__Union extends Union {
   @IntPtr()
@@ -9455,7 +9455,7 @@ extension TASKDIALOGCONFIG_Extension on TASKDIALOGCONFIG {
   set pszMainIcon(Pointer<Utf16> value) => this.Anonymous1.pszMainIcon = value;
 }
 
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 sealed class _TASKDIALOGCONFIG__Anonymous2_e__Union extends Union {
   @IntPtr()
@@ -9477,7 +9477,7 @@ extension TASKDIALOGCONFIG_Extension_1 on TASKDIALOGCONFIG {
 /// button in a task dialog. The TASKDIALOGCONFIG structure uses this
 /// structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class TASKDIALOG_BUTTON extends Struct {
   @Int32()
@@ -9490,7 +9490,7 @@ base class TASKDIALOG_BUTTON extends Struct {
 /// font. All sizes are specified in logical units; that is, they depend on
 /// the current mapping mode of the display context.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class TEXTMETRIC extends Struct {
   @Int32()
   external int tmHeight;
@@ -9557,7 +9557,7 @@ base class TEXTMETRIC extends Struct {
 /// associated with the Berkeley Software Distribution (BSD) Time.h header
 /// file.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class TIMEVAL extends Struct {
   @Int32()
   external int tv_sec;
@@ -9568,7 +9568,7 @@ base class TIMEVAL extends Struct {
 
 /// Contains title bar information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class TITLEBARINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -9583,7 +9583,7 @@ base class TITLEBARINFO extends Struct {
 /// including the coordinates of each element of the title bar. This
 /// structure is sent with the WM_GETTITLEBARINFOEX message.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class TITLEBARINFOEX extends Struct {
   @Uint32()
   external int cbSize;
@@ -9600,14 +9600,14 @@ base class TITLEBARINFOEX extends Struct {
 /// The TOKEN_APPCONTAINER_INFORMATION structure specifies all the
 /// information in a token that is necessary for an app container.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class TOKEN_APPCONTAINER_INFORMATION extends Struct {
   external Pointer TokenAppContainer;
 }
 
 /// Encapsulates data for touch input.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class TOUCHINPUT extends Struct {
   @Int32()
   external int x;
@@ -9644,7 +9644,7 @@ base class TOUCHINPUT extends Struct {
 /// targets and help compensate for hardware latency when processing touch
 /// and gesture input that contains distance and velocity data.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class TOUCHPREDICTIONPARAMETERS extends Struct {
   @Uint32()
   external int cbSize;
@@ -9661,7 +9661,7 @@ base class TOUCHPREDICTIONPARAMETERS extends Struct {
 
 /// Contains extended parameters for the TrackPopupMenuEx function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class TPMPARAMS extends Struct {
   @Uint32()
   external int cbSize;
@@ -9671,7 +9671,7 @@ base class TPMPARAMS extends Struct {
 
 /// Contains attributes of a type.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class TYPEATTR extends Struct {
   external GUID guid;
 
@@ -9727,7 +9727,7 @@ base class TYPEATTR extends Struct {
 /// Describes the type of a variable, the return type of a function, or the
 /// type of a function parameter.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class TYPEDESC extends Struct {
   external _TYPEDESC__Anonymous_e__Union Anonymous;
 
@@ -9735,7 +9735,7 @@ base class TYPEDESC extends Struct {
   external int vt;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _TYPEDESC__Anonymous_e__Union extends Union {
   external Pointer<TYPEDESC> lptdesc;
 
@@ -9760,7 +9760,7 @@ extension TYPEDESC_Extension on TYPEDESC {
 /// represents a generic ratio and is used for different purposes and units
 /// even within a single API.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class UNSIGNED_RATIO extends Struct {
   @Uint32()
@@ -9773,7 +9773,7 @@ base class UNSIGNED_RATIO extends Struct {
 /// Used by UpdateLayeredWindowIndirect to provide position, size, shape,
 /// content, and translucency information for a layered window.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class UPDATELAYEREDWINDOWINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -9804,7 +9804,7 @@ base class UPDATELAYEREDWINDOWINFO extends Struct {
 /// Contains information about a registry value. The RegQueryMultipleValues
 /// function uses this structure.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class VALENT extends Struct {
   external Pointer<Utf16> ve_valuename;
 
@@ -9820,7 +9820,7 @@ base class VALENT extends Struct {
 
 /// Describes a variable, constant, or data member.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class VARDESC extends Struct {
   @Int32()
   external int memid;
@@ -9838,7 +9838,7 @@ base class VARDESC extends Struct {
   external int varkind;
 }
 
-/// {@category Struct}
+/// {@category struct}
 sealed class _VARDESC__Anonymous_e__Union extends Union {
   @Uint32()
   external int oInst;
@@ -9857,7 +9857,7 @@ extension VARDESC_Extension on VARDESC {
 /// Represents a physical location on a disk. It is the output buffer for
 /// the IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS control code.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class VOLUME_DISK_EXTENTS extends Struct {
   @Uint32()
   external int NumberOfDiskExtents;
@@ -9869,7 +9869,7 @@ base class VOLUME_DISK_EXTENTS extends Struct {
 /// Contains version information for a file. This information is language
 /// and code page independent.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class VS_FIXEDFILEINFO extends Struct {
   @Uint32()
   external int dwSignature;
@@ -9917,7 +9917,7 @@ base class VS_FIXEDFILEINFO extends Struct {
 /// information, this structure is included as the first member in another
 /// structure, along with the additional information.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class WAVEFORMATEX extends Struct {
   @Uint16()
@@ -9947,7 +9947,7 @@ base class WAVEFORMATEX extends Struct {
 /// resolutions than allowed by WAVEFORMATEX. It can also be used to define
 /// any format that can be defined by WAVEFORMATEX.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class WAVEFORMATEXTENSIBLE extends Struct {
   external WAVEFORMATEX Format;
@@ -9960,7 +9960,7 @@ base class WAVEFORMATEXTENSIBLE extends Struct {
   external GUID SubFormat;
 }
 
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 sealed class _WAVEFORMATEXTENSIBLE__Samples_e__Union extends Union {
   @Uint16()
@@ -9988,7 +9988,7 @@ extension WAVEFORMATEXTENSIBLE_Extension on WAVEFORMATEXTENSIBLE {
 /// The WAVEHDR structure defines the header used to identify a
 /// waveform-audio buffer.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class WAVEHDR extends Struct {
   external Pointer<Utf8> lpData;
@@ -10017,7 +10017,7 @@ base class WAVEHDR extends Struct {
 /// The WAVEINCAPS structure describes the capabilities of a waveform-audio
 /// input device.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class WAVEINCAPS extends Struct {
   @Uint16()
@@ -10061,7 +10061,7 @@ base class WAVEINCAPS extends Struct {
 /// The WAVEOUTCAPS structure describes the capabilities of a waveform-audio
 /// output device.
 ///
-/// {@category Struct}
+/// {@category struct}
 @Packed(1)
 base class WAVEOUTCAPS extends Struct {
   @Uint16()
@@ -10108,7 +10108,7 @@ base class WAVEOUTCAPS extends Struct {
 /// Contains information about the file that is found by the FindFirstFile,
 /// FindFirstFileEx, or FindNextFile function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WIN32_FIND_DATA extends Struct {
   @Uint32()
   external int dwFileAttributes;
@@ -10172,7 +10172,7 @@ base class WIN32_FIND_DATA extends Struct {
 
 /// Contains window information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WINDOWINFO extends Struct {
   @Uint32()
   external int cbSize;
@@ -10205,7 +10205,7 @@ base class WINDOWINFO extends Struct {
 
 /// Contains information about the placement of a window on the screen.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WINDOWPLACEMENT extends Struct {
   @Uint32()
   external int length;
@@ -10225,7 +10225,7 @@ base class WINDOWPLACEMENT extends Struct {
 
 /// Contains information about the size and position of a window.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WINDOWPOS extends Struct {
   @IntPtr()
   external int hwnd;
@@ -10251,7 +10251,7 @@ base class WINDOWPOS extends Struct {
 
 /// Describes a change in the size of the console screen buffer.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WINDOW_BUFFER_SIZE_RECORD extends Struct {
   external COORD dwSize;
 }
@@ -10259,7 +10259,7 @@ base class WINDOW_BUFFER_SIZE_RECORD extends Struct {
 /// The WLAN_ASSOCIATION_ATTRIBUTES structure contains association
 /// attributes for a connection.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_ASSOCIATION_ATTRIBUTES extends Struct {
   external DOT11_SSID dot11Ssid;
 
@@ -10288,7 +10288,7 @@ base class WLAN_ASSOCIATION_ATTRIBUTES extends Struct {
 /// The WLAN_AUTH_CIPHER_PAIR_LIST structure contains a list of
 /// authentication and cipher algorithm pairs.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_AUTH_CIPHER_PAIR_LIST extends Struct {
   @Uint32()
   external int dwNumberOfItems;
@@ -10300,7 +10300,7 @@ base class WLAN_AUTH_CIPHER_PAIR_LIST extends Struct {
 /// The WLAN_AVAILABLE_NETWORK structure contains information about an
 /// available wireless network.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_AVAILABLE_NETWORK extends Struct {
   @Array(256)
   external Array<Uint16> _strProfileName;
@@ -10366,7 +10366,7 @@ base class WLAN_AVAILABLE_NETWORK extends Struct {
 /// The WLAN_AVAILABLE_NETWORK_LIST structure contains an array of
 /// information about available networks.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_AVAILABLE_NETWORK_LIST extends Struct {
   @Uint32()
   external int dwNumberOfItems;
@@ -10381,7 +10381,7 @@ base class WLAN_AVAILABLE_NETWORK_LIST extends Struct {
 /// The WLAN_BSS_ENTRY structure contains information about a basic service
 /// set (BSS).
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_BSS_ENTRY extends Struct {
   external DOT11_SSID dot11Ssid;
 
@@ -10433,7 +10433,7 @@ base class WLAN_BSS_ENTRY extends Struct {
 /// The WLAN_BSS_LIST structure contains a list of basic service set (BSS)
 /// entries.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_BSS_LIST extends Struct {
   @Uint32()
   external int dwTotalSize;
@@ -10448,7 +10448,7 @@ base class WLAN_BSS_LIST extends Struct {
 /// The WLAN_CONNECTION_ATTRIBUTES structure defines the attributes of a
 /// wireless connection.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_CONNECTION_ATTRIBUTES extends Struct {
   @Int32()
   external int isState;
@@ -10483,7 +10483,7 @@ base class WLAN_CONNECTION_ATTRIBUTES extends Struct {
 /// The WLAN_CONNECTION_NOTIFICATION_DATA structure contains information
 /// about connection related notifications.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_CONNECTION_NOTIFICATION_DATA extends Struct {
   @Int32()
   external int wlanConnectionMode;
@@ -10544,7 +10544,7 @@ base class WLAN_CONNECTION_NOTIFICATION_DATA extends Struct {
 /// The WLAN_CONNECTION_PARAMETERS structure specifies the parameters used
 /// when using the WlanConnect function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_CONNECTION_PARAMETERS extends Struct {
   @Int32()
   external int wlanConnectionMode;
@@ -10565,7 +10565,7 @@ base class WLAN_CONNECTION_PARAMETERS extends Struct {
 /// A WLAN_COUNTRY_OR_REGION_STRING_LIST structure contains a list of
 /// supported country or region strings.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_COUNTRY_OR_REGION_STRING_LIST extends Struct {
   @Uint32()
   external int dwNumberOfItems;
@@ -10576,7 +10576,7 @@ base class WLAN_COUNTRY_OR_REGION_STRING_LIST extends Struct {
 
 /// Contains an array of device service GUIDs.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_DEVICE_SERVICE_GUID_LIST extends Struct {
   @Uint32()
   external int dwNumberOfItems;
@@ -10590,7 +10590,7 @@ base class WLAN_DEVICE_SERVICE_GUID_LIST extends Struct {
 
 /// A structure that represents a device service notification.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_DEVICE_SERVICE_NOTIFICATION_DATA extends Struct {
   external GUID DeviceService;
 
@@ -10608,7 +10608,7 @@ base class WLAN_DEVICE_SERVICE_NOTIFICATION_DATA extends Struct {
 /// information about the connection settings on the wireless Hosted
 /// Network.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_HOSTED_NETWORK_CONNECTION_SETTINGS extends Struct {
   external DOT11_SSID hostedNetworkSSID;
 
@@ -10620,7 +10620,7 @@ base class WLAN_HOSTED_NETWORK_CONNECTION_SETTINGS extends Struct {
 /// information about a network state change for a data peer on the wireless
 /// Hosted Network.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_HOSTED_NETWORK_DATA_PEER_STATE_CHANGE extends Struct {
   external WLAN_HOSTED_NETWORK_PEER_STATE OldState;
 
@@ -10633,7 +10633,7 @@ base class WLAN_HOSTED_NETWORK_DATA_PEER_STATE_CHANGE extends Struct {
 /// The WLAN_HOSTED_NETWORK_PEER_STATE structure contains information about
 /// the peer state for a peer on the wireless Hosted Network.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_HOSTED_NETWORK_PEER_STATE extends Struct {
   @Array(6)
   external Array<Uint8> PeerMacAddress;
@@ -10645,7 +10645,7 @@ base class WLAN_HOSTED_NETWORK_PEER_STATE extends Struct {
 /// The WLAN_HOSTED_NETWORK_RADIO_STATE structure contains information about
 /// the radio state on the wireless Hosted Network.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_HOSTED_NETWORK_RADIO_STATE extends Struct {
   @Int32()
   external int dot11SoftwareRadioState;
@@ -10657,7 +10657,7 @@ base class WLAN_HOSTED_NETWORK_RADIO_STATE extends Struct {
 /// The WLAN_HOSTED_NETWORK_SECURITY_SETTINGS structure contains information
 /// about the security settings on the wireless Hosted Network.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_HOSTED_NETWORK_SECURITY_SETTINGS extends Struct {
   @Int32()
   external int dot11AuthAlgo;
@@ -10669,7 +10669,7 @@ base class WLAN_HOSTED_NETWORK_SECURITY_SETTINGS extends Struct {
 /// The WLAN_HOSTED_NETWORK_STATE_CHANGE structure contains information
 /// about a network state change on the wireless Hosted Network.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_HOSTED_NETWORK_STATE_CHANGE extends Struct {
   @Int32()
   external int OldState;
@@ -10684,7 +10684,7 @@ base class WLAN_HOSTED_NETWORK_STATE_CHANGE extends Struct {
 /// The WLAN_HOSTED_NETWORK_STATUS structure contains information about the
 /// status of the wireless Hosted Network.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_HOSTED_NETWORK_STATUS extends Struct {
   @Int32()
   external int HostedNetworkState;
@@ -10710,7 +10710,7 @@ base class WLAN_HOSTED_NETWORK_STATUS extends Struct {
 /// The WLAN_INTERFACE_CAPABILITY structure contains information about the
 /// capabilities of an interface.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_INTERFACE_CAPABILITY extends Struct {
   @Int32()
   external int interfaceType;
@@ -10734,7 +10734,7 @@ base class WLAN_INTERFACE_CAPABILITY extends Struct {
 /// The WLAN_INTERFACE_INFO structure contains information about a wireless
 /// LAN interface.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_INTERFACE_INFO extends Struct {
   external GUID InterfaceGuid;
 
@@ -10764,7 +10764,7 @@ base class WLAN_INTERFACE_INFO extends Struct {
 /// The WLAN_INTERFACE_INFO_LIST structure contains an array of NIC
 /// interface information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_INTERFACE_INFO_LIST extends Struct {
   @Uint32()
   external int dwNumberOfItems;
@@ -10779,7 +10779,7 @@ base class WLAN_INTERFACE_INFO_LIST extends Struct {
 /// The WLAN_MAC_FRAME_STATISTICS structure contains information about sent
 /// and received MAC frames.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_MAC_FRAME_STATISTICS extends Struct {
   @Uint64()
   external int ullTransmittedFrameCount;
@@ -10821,7 +10821,7 @@ base class WLAN_MAC_FRAME_STATISTICS extends Struct {
 /// The WLAN_MSM_NOTIFICATION_DATA structure contains information about
 /// media specific module (MSM) connection related notifications.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_MSM_NOTIFICATION_DATA extends Struct {
   @Int32()
   external int wlanConnectionMode;
@@ -10869,7 +10869,7 @@ base class WLAN_MSM_NOTIFICATION_DATA extends Struct {
 /// The WLAN_PHY_FRAME_STATISTICS structure contains information about sent
 /// and received PHY frames.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_PHY_FRAME_STATISTICS extends Struct {
   @Uint64()
   external int ullTransmittedFrameCount;
@@ -10929,7 +10929,7 @@ base class WLAN_PHY_FRAME_STATISTICS extends Struct {
 /// The WLAN_PHY_RADIO_STATE structure specifies the radio state on a
 /// specific physical layer (PHY) type.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_PHY_RADIO_STATE extends Struct {
   @Uint32()
   external int dwPhyIndex;
@@ -10944,7 +10944,7 @@ base class WLAN_PHY_RADIO_STATE extends Struct {
 /// The WLAN_PROFILE_INFO structure contains basic information about a
 /// profile.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_PROFILE_INFO extends Struct {
   @Array(256)
   external Array<Uint16> _strProfileName;
@@ -10972,7 +10972,7 @@ base class WLAN_PROFILE_INFO extends Struct {
 /// The WLAN_PROFILE_INFO_LIST structure contains a list of wireless profile
 /// information.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_PROFILE_INFO_LIST extends Struct {
   @Uint32()
   external int dwNumberOfItems;
@@ -10987,7 +10987,7 @@ base class WLAN_PROFILE_INFO_LIST extends Struct {
 /// The WLAN_RADIO_STATE structure specifies the radio state on a list of
 /// physical layer (PHY) types.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_RADIO_STATE extends Struct {
   @Uint32()
   external int dwNumberOfPhys;
@@ -10998,7 +10998,7 @@ base class WLAN_RADIO_STATE extends Struct {
 
 /// The set of supported data rates.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_RATE_SET extends Struct {
   @Uint32()
   external int uRateSetLength;
@@ -11010,7 +11010,7 @@ base class WLAN_RATE_SET extends Struct {
 /// The WLAN_RAW_DATA structure contains raw data in the form of a blob that
 /// is used by some Native Wifi functions.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_RAW_DATA extends Struct {
   @Uint32()
   external int dwDataSize;
@@ -11022,7 +11022,7 @@ base class WLAN_RAW_DATA extends Struct {
 /// The WLAN_RAW_DATA_LIST structure contains raw data in the form of an
 /// array of data blobs that are used by some Native Wifi functions.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_RAW_DATA_LIST extends Struct {
   @Uint32()
   external int dwTotalSize;
@@ -11034,7 +11034,7 @@ base class WLAN_RAW_DATA_LIST extends Struct {
   external Array<_WLAN_RAW_DATA_LIST__Anonymous_e__Struct> DataList;
 }
 
-/// {@category Struct}
+/// {@category struct}
 base class _WLAN_RAW_DATA_LIST__Anonymous_e__Struct extends Struct {
   @Uint32()
   external int dwDataOffset;
@@ -11046,7 +11046,7 @@ base class _WLAN_RAW_DATA_LIST__Anonymous_e__Struct extends Struct {
 /// The WLAN_SECURITY_ATTRIBUTES structure defines the security attributes
 /// for a wireless connection.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_SECURITY_ATTRIBUTES extends Struct {
   @Int32()
   external int bSecurityEnabled;
@@ -11064,7 +11064,7 @@ base class WLAN_SECURITY_ATTRIBUTES extends Struct {
 /// The WLAN_STATISTICS structure contains assorted statistics about an
 /// interface.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WLAN_STATISTICS extends Struct {
   @Uint64()
   external int ullFourWayHandshakeFailures;
@@ -11093,7 +11093,7 @@ base class WLAN_STATISTICS extends Struct {
 /// hIconSm member, which contains a handle to a small icon associated with
 /// the window class.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WNDCLASSEX extends Struct {
   @Uint32()
   external int cbSize;
@@ -11132,7 +11132,7 @@ base class WNDCLASSEX extends Struct {
 /// Contains the window class attributes that are registered by the
 /// RegisterClass function.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WNDCLASS extends Struct {
   @Uint32()
   external int style;
@@ -11164,7 +11164,7 @@ base class WNDCLASS extends Struct {
 
 /// Defines options that are used to set window visual style attributes.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class WTA_OPTIONS extends Struct {
   @Uint32()
   external int dwFlags;
@@ -11176,7 +11176,7 @@ base class WTA_OPTIONS extends Struct {
 /// The XFORM structure specifies a world-space to page-space
 /// transformation.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class XFORM extends Struct {
   @Float()
   external double eM11;
@@ -11199,7 +11199,7 @@ base class XFORM extends Struct {
 
 /// Contains information on battery type and charge state.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class XINPUT_BATTERY_INFORMATION extends Struct {
   @Uint8()
   external int BatteryType;
@@ -11211,7 +11211,7 @@ base class XINPUT_BATTERY_INFORMATION extends Struct {
 /// Describes the capabilities of a connected controller. The
 /// XInputGetCapabilities function returns XINPUT_CAPABILITIES.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class XINPUT_CAPABILITIES extends Struct {
   @Uint8()
   external int Type;
@@ -11229,7 +11229,7 @@ base class XINPUT_CAPABILITIES extends Struct {
 
 /// Describes the current state of the controller.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class XINPUT_GAMEPAD extends Struct {
   @Uint16()
   external int wButtons;
@@ -11255,7 +11255,7 @@ base class XINPUT_GAMEPAD extends Struct {
 
 /// Specifies keystroke data returned by XInputGetKeystroke.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class XINPUT_KEYSTROKE extends Struct {
   @Uint16()
   external int VirtualKey;
@@ -11275,7 +11275,7 @@ base class XINPUT_KEYSTROKE extends Struct {
 
 /// Represents the state of a controller.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class XINPUT_STATE extends Struct {
   @Uint32()
   external int dwPacketNumber;
@@ -11285,7 +11285,7 @@ base class XINPUT_STATE extends Struct {
 
 /// Specifies motor speed levels for the vibration function of a controller.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class XINPUT_VIBRATION extends Struct {
   @Uint16()
   external int wLeftMotorSpeed;

--- a/lib/src/variant.dart
+++ b/lib/src/variant.dart
@@ -129,7 +129,7 @@ sealed class _VARIANT_Anonymous_0 extends Union {
 ///
 /// VARIANTs must be initialized with [VariantInit] before their use.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class VARIANT extends Struct {
   external _VARIANT_Anonymous_0 __VARIANT_NAME_1;
 
@@ -406,7 +406,7 @@ base class VARIANT extends Struct {
 /// methods of IPropertyStorage to define the type tag and the value of a
 /// property in a property set.
 ///
-/// {@category Struct}
+/// {@category struct}
 base class PROPVARIANT extends Struct {
   @Uint16()
   external int vt;

--- a/lib/src/winmd_constants.dart
+++ b/lib/src/winmd_constants.dart
@@ -12,7 +12,7 @@ const CLSID_CorMetaDataDispenser = '{E5CB7A31-7512-11D2-89CE-0080C792E5D8}';
 /// Contains flag values that control metadata behavior upon opening manifest
 /// files.
 ///
-/// {@category Enum}
+/// {@category enum}
 class CorOpenFlags {
   /// Indicates that the file should be opened for reading only.
   static const ofRead = 0x00000000;

--- a/tool/win32gen/lib/src/projection/com_class.dart
+++ b/tool/win32gen/lib/src/projection/com_class.dart
@@ -49,9 +49,6 @@ class ComClassProjection extends ComInterfaceProjection {
   }
 
   @override
-  String get classType => '';
-
-  @override
   String get guidConstants => '''
   /// @nodoc
   const CLSID_$shortName = '${typeDef.guid}';

--- a/tool/win32gen/lib/src/projection/com_interface.dart
+++ b/tool/win32gen/lib/src/projection/com_interface.dart
@@ -177,13 +177,9 @@ class ComInterfaceProjection {
 
   String get category => 'com';
 
-  String get classType => 'Interface';
-
   String get classPreamble {
     final wrappedComment = wrapCommentText(comment);
-    final categoryComment = classType.isNotEmpty
-        ? '/// {@category $classType}\n/// {@category $category}'
-        : '/// {@category $category}';
+    final categoryComment = '/// {@category $category}';
 
     return wrappedComment.isNotEmpty
         ? '$wrappedComment\n///\n$categoryComment'

--- a/tool/win32gen/lib/src/projection/struct.dart
+++ b/tool/win32gen/lib/src/projection/struct.dart
@@ -32,7 +32,7 @@ class StructProjection {
   }
 
   String get classPreamble {
-    const structCategoryComment = '/// {@category Struct}';
+    const structCategoryComment = '/// {@category struct}';
     final classComment = wrapCommentText(comment);
     final docComment = classComment.isEmpty
         ? structCategoryComment

--- a/tool/win32gen/test/goldens/inetwork.golden
+++ b/tool/win32gen/test/goldens/inetwork.golden
@@ -30,7 +30,6 @@ const IID_INetwork = '{dcb00002-570f-4a9b-8d69-199fdba5723b}';
 /// also represent a collection of network connections with a similar
 /// network signature.
 ///
-/// {@category Interface}
 /// {@category com}
 class INetwork extends IDispatch {
   // vtable begins at 7, is 13 entries long.


### PR DESCRIPTION
Fixed the `dartdoc` category references related to enumerations and structures in the codebase. The correct definitions for these categories are specified as `enum` and `struct` (not `Enum` and `Struct`) in the dartdoc_options.yaml file: https://github.com/dart-windows/win32/blob/f5f77d16684662f2191657b64f60dac11dac2a28/dartdoc_options.yaml#L63-L68

Additionally, removed the `/// @category Interface` comments from the generated COM interfaces. Figured it didn't contribute much, especially considering there is no dedicated documentation file for it.

Before:
![image](https://github.com/dart-windows/win32/assets/45524029/a343fad2-f1e9-47ab-a92e-7d09d0076c74)

After:
![image](https://github.com/dart-windows/win32/assets/45524029/8808f6a5-d7c7-4bea-9248-bcce1fcfe028)
