### PR TITLE
Migrate to `NativeCallable.isolateLocal`

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -49,14 +49,15 @@ following location:
 
 ## Windows shell manipulation (shell32)
 
-| Example            | Description                                             |
-| ------------------ | ------------------------------------------------------- |
-| `knownfolder.dart` | Retrieves known folders from the current user profile   |
-| `magnifier.dart`   | Provides a magnifier window using the Magnification API |
-| `recycle_bin.dart` | Queries the recycle bin and adds an item to it          |
-| `screenshot.dart`  | Takes snapshots of all connected displays               |
-| `shortcut.dart`    | Demonstrates creating a Windows shell link              |
-| `wallpaper.dart`   | Shows what wallpaper and background color are set       |
+| Example              | Description                                             |
+| -------------------- | ------------------------------------------------------- |
+| `knownfolder.dart`   | Retrieves known folders from the current user profile   |
+| `magnifier.dart`     | Provides a magnifier window using the Magnification API |
+| `recycle_bin.dart`   | Queries the recycle bin and adds an item to it          |
+| `screenshot.dart`    | Takes snapshots of all connected displays               |
+| `shell_notify_icon\` | Demonstrates adding an icon to the system tray          |
+| `shortcut.dart`      | Demonstrates creating a Windows shell link              |
+| `wallpaper.dart`     | Shows what wallpaper and background color are set       |
 
 ## Win32-style UI development (user32, gdi32, commdlg32)
 

--- a/example/customtitlebar.dart
+++ b/example/customtitlebar.dart
@@ -517,12 +517,17 @@ void main() {
   // Register the window class.
   final windowClassName = 'WIN32_CUSTOM_TITLEBAR_EXAMPLE'.toNativeUtf16();
 
+  final lpfnWndProc = NativeCallable<WindowProc>.isolateLocal(
+    mainWindowProc,
+    exceptionalReturn: 0,
+  );
+
   final windowClass = calloc<WNDCLASSEX>()
     ..ref.cbSize = sizeOf<WNDCLASSEX>()
     ..ref.lpszClassName = windowClassName
     ..ref.style = CS_HREDRAW | CS_VREDRAW
     ..ref.hCursor = LoadCursor(NULL, IDC_ARROW)
-    ..ref.lpfnWndProc = Pointer.fromFunction<WindowProc>(mainWindowProc, 0);
+    ..ref.lpfnWndProc = lpfnWndProc.nativeFunction;
 
   RegisterClassEx(windowClass);
 
@@ -544,6 +549,7 @@ void main() {
     DispatchMessage(msg);
   }
 
+  lpfnWndProc.close();
   free(msg);
   free(windowCaption);
   free(windowClass);

--- a/example/customwin.dart
+++ b/example/customwin.dart
@@ -5,8 +5,8 @@
 // Draw a circular window
 
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 
+import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
 int mainWindowProc(int hWnd, int uMsg, int wParam, int lParam) {
@@ -60,9 +60,14 @@ void winMain(int hInstance, List<String> args, int nShowCmd) {
   // Register the window class.
   final className = TEXT('Sample Window Class');
 
+  final lpfnWndProc = NativeCallable<WindowProc>.isolateLocal(
+    mainWindowProc,
+    exceptionalReturn: 0,
+  );
+
   final wc = calloc<WNDCLASS>()
     ..ref.style = CS_HREDRAW | CS_VREDRAW
-    ..ref.lpfnWndProc = Pointer.fromFunction<WindowProc>(mainWindowProc, 0)
+    ..ref.lpfnWndProc = lpfnWndProc.nativeFunction
     ..ref.hInstance = hInstance
     ..ref.lpszClassName = className
     ..ref.hCursor = LoadCursor(NULL, IDC_ARROW)
@@ -105,5 +110,6 @@ void winMain(int hInstance, List<String> args, int nShowCmd) {
     DispatchMessage(msg);
   }
 
+  lpfnWndProc.close();
   free(className);
 }

--- a/example/dialogbox.dart
+++ b/example/dialogbox.dart
@@ -87,16 +87,21 @@ void main() {
       windowSystemClass: 0x0081, // edit
       text: 'Enter text');
 
-  final lpDialogFunc = Pointer.fromFunction<DlgProc>(dialogReturnProc, 0);
+  final lpDialogFunc = NativeCallable<DlgProc>.isolateLocal(
+    dialogReturnProc,
+    exceptionalReturn: 0,
+  );
 
   final nResult = DialogBoxIndirectParam(
-      hInstance, ptr.cast<DLGTEMPLATE>(), NULL, lpDialogFunc, 0);
+      hInstance, ptr.cast<DLGTEMPLATE>(), NULL, lpDialogFunc.nativeFunction, 0);
 
   if (nResult <= 0) {
     print('Error: $nResult');
   } else {
     print('Entered: $textEntered');
   }
+
+  lpDialogFunc.close();
   free(ptr);
 }
 

--- a/example/dump.dart
+++ b/example/dump.dart
@@ -47,16 +47,19 @@ Map<String, int> getExports(int hProcess, String module) {
   }
 
   final mask = '*'.toNativeUtf16();
+
+  final callback = NativeCallable<SymEnumSymbolsProc>.isolateLocal(
+    _enumSymbolProc,
+    exceptionalReturn: 0,
+  );
+
   if (SymEnumSymbols(
-          hProcess,
-          baseOfDll,
-          mask,
-          Pointer.fromFunction<SymEnumSymbolsProc>(_enumSymbolProc, 0),
-          nullptr) ==
+          hProcess, baseOfDll, mask, callback.nativeFunction, nullptr) ==
       FALSE) {
     print('SymEnumSymbols failed.');
   }
 
+  callback.close();
   SymCleanup(hProcess);
   free(modulePtr);
   free(mask);

--- a/example/fonts.dart
+++ b/example/fonts.dart
@@ -23,9 +23,13 @@ int enumerateFonts(
 void main() {
   final hDC = GetDC(NULL);
   final searchFont = calloc<LOGFONT>()..ref.lfCharSet = ANSI_CHARSET;
-  final callback = Pointer.fromFunction<EnumFontFamExProc>(enumerateFonts, 0);
+  final lpProc = NativeCallable<EnumFontFamExProc>.isolateLocal(
+    enumerateFonts,
+    exceptionalReturn: 0,
+  );
 
-  EnumFontFamiliesEx(hDC, searchFont, callback, 0, 0);
+  EnumFontFamiliesEx(hDC, searchFont, lpProc.nativeFunction, 0, 0);
+  lpProc.close();
   fontNames.sort();
 
   print('${fontNames.length} font families discovered.');

--- a/example/hello.dart
+++ b/example/hello.dart
@@ -5,8 +5,8 @@
 // Basic Petzoldian "hello world" Win32 app
 
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 
+import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
 int mainWindowProc(int hWnd, int uMsg, int wParam, int lParam) {
@@ -42,9 +42,15 @@ void main() => initApp(winMain);
 void winMain(int hInstance, List<String> args, int nShowCmd) {
   // Register the window class.
   final className = TEXT('Sample Window Class');
+
+  final lpfnWndProc = NativeCallable<WindowProc>.isolateLocal(
+    mainWindowProc,
+    exceptionalReturn: 0,
+  );
+
   final wc = calloc<WNDCLASS>()
     ..ref.style = CS_HREDRAW | CS_VREDRAW
-    ..ref.lpfnWndProc = Pointer.fromFunction<WindowProc>(mainWindowProc, 0)
+    ..ref.lpfnWndProc = lpfnWndProc.nativeFunction
     ..ref.hInstance = hInstance
     ..ref.lpszClassName = className
     ..ref.hCursor = LoadCursor(NULL, IDC_ARROW)
@@ -87,5 +93,6 @@ void winMain(int hInstance, List<String> args, int nShowCmd) {
     DispatchMessage(msg);
   }
 
+  lpfnWndProc.close();
   free(msg);
 }

--- a/example/monitor.dart
+++ b/example/monitor.dart
@@ -93,16 +93,21 @@ void printMonitorCapabilities(int capabilitiesBitmask) {
 void main() {
   var result = FALSE;
 
+  final lpfnEnum = NativeCallable<MonitorEnumProc>.isolateLocal(
+    enumMonitorCallback,
+    exceptionalReturn: 0,
+  );
+
   result = EnumDisplayMonitors(
       NULL, // all displays
       nullptr, // no clipping region
-      Pointer.fromFunction<MonitorEnumProc>(
-          enumMonitorCallback, // dwData
-          0),
+      lpfnEnum.nativeFunction,
       NULL);
   if (result == FALSE) {
     throw WindowsException(result);
   }
+
+  lpfnEnum.close();
 
   print('Number of monitors: ${monitors.length}');
 

--- a/example/paint.dart
+++ b/example/paint.dart
@@ -54,9 +54,14 @@ void winMain(int hInstance, List<String> args, int nShowCmd) {
   // Register the window class.
   final className = TEXT('Simple Paint Sample');
 
+  final lpfnWndProc = NativeCallable<WindowProc>.isolateLocal(
+    mainWindowProc,
+    exceptionalReturn: 0,
+  );
+
   final wc = calloc<WNDCLASS>()
     ..ref.style = CS_HREDRAW | CS_VREDRAW
-    ..ref.lpfnWndProc = Pointer.fromFunction<WindowProc>(mainWindowProc, 0)
+    ..ref.lpfnWndProc = lpfnWndProc.nativeFunction
     ..ref.hInstance = hInstance
     ..ref.lpszClassName = className
     ..ref.hCursor = LoadCursor(NULL, IDC_ARROW)
@@ -97,5 +102,6 @@ void winMain(int hInstance, List<String> args, int nShowCmd) {
     DispatchMessage(msg);
   }
 
+  lpfnWndProc.close();
   free(className);
 }

--- a/example/scroll.dart
+++ b/example/scroll.dart
@@ -261,9 +261,14 @@ void winMain(int hInstance, List<String> args, int nShowCmd) {
   // Register the window class.
   final className = TEXT('Scrollbar Sample');
 
+  final lpfnWndProc = NativeCallable<WindowProc>.isolateLocal(
+    mainWindowProc,
+    exceptionalReturn: 0,
+  );
+
   final wc = calloc<WNDCLASS>()
     ..ref.style = CS_HREDRAW | CS_VREDRAW
-    ..ref.lpfnWndProc = Pointer.fromFunction<WindowProc>(mainWindowProc, 0)
+    ..ref.lpfnWndProc = lpfnWndProc.nativeFunction
     ..ref.hInstance = hInstance
     ..ref.lpszClassName = className
     ..ref.hCursor = LoadCursor(NULL, IDC_ARROW)
@@ -304,4 +309,6 @@ void winMain(int hInstance, List<String> args, int nShowCmd) {
     TranslateMessage(msg);
     DispatchMessage(msg);
   }
+
+  lpfnWndProc.close();
 }

--- a/example/shell_notify_icon/_app.dart
+++ b/example/shell_notify_icon/_app.dart
@@ -14,7 +14,10 @@ const EVENT_TRAY_NOTIFY = WM_APP + 1;
 typedef LocalWndProc = bool Function(
     int hWnd, int uMsg, int wParam, int lParam);
 
-final wndProc = Pointer.fromFunction<WindowProc>(_appWndProc, 0);
+final lpfnWndProc = NativeCallable<WindowProc>.isolateLocal(
+  _appWndProc,
+  exceptionalReturn: 0,
+);
 
 void exec() {
   final msg = calloc<MSG>();

--- a/example/shell_notify_icon/_tray.dart
+++ b/example/shell_notify_icon/_tray.dart
@@ -4,6 +4,7 @@ import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
 import '_app.dart' as app;
+import '_app.dart';
 import '_menu.dart' as menu;
 
 final _guid = Guid.generate().toNativeGUID();
@@ -49,4 +50,5 @@ void removeIcon() {
   free(_guid);
   free(_nid);
   app.deregisterWndProc(_trayWndProc);
+  lpfnWndProc.close();
 }

--- a/example/shell_notify_icon/_window.dart
+++ b/example/shell_notify_icon/_window.dart
@@ -39,7 +39,7 @@ String _regWinClass() {
   const windowClass = 'Tray_Callback_Window';
   final pWndClass = calloc<WNDCLASS>()
     ..ref.style = CS_HREDRAW | CS_VREDRAW
-    ..ref.lpfnWndProc = app.wndProc
+    ..ref.lpfnWndProc = app.lpfnWndProc.nativeFunction
     ..ref.hInstance = app.hInst
     ..ref.hIcon = app.loadDartIcon()
     ..ref.hCursor = LoadCursor(NULL, IDC_ARROW)

--- a/example/snake.dart
+++ b/example/snake.dart
@@ -539,16 +539,19 @@ void main() => initApp(winMain);
 
 void winMain(int hInstance, List<String> args, int nShowCmd) {
   // Register the window class.
-
   final className = TEXT('WinSnakeWindowClass');
 
+  final lpfnWndProc = NativeCallable<WindowProc>.isolateLocal(
+    mainWindowProc,
+    exceptionalReturn: 0,
+  );
+
   final wc = calloc<WNDCLASS>()
-    ..ref.lpfnWndProc = Pointer.fromFunction<WindowProc>(mainWindowProc, 0)
+    ..ref.lpfnWndProc = lpfnWndProc.nativeFunction
     ..ref.hInstance = hInstance
     ..ref.lpszClassName = className;
   if (RegisterClass(wc) != 0) {
     // Create the window.
-
     hWnd = CreateWindowEx(
         0, // Optional window styles.
         className, // Window class
@@ -596,6 +599,8 @@ void winMain(int hInstance, List<String> args, int nShowCmd) {
         ReleaseDC(hWnd, dc);
         free(rect);
       }
+
+      lpfnWndProc.close();
     } else {
       MessageBox(0, TEXT('Failed to create window'), TEXT('Error'),
           MB_ICONEXCLAMATION | MB_OK);

--- a/example/tetris/main.dart
+++ b/example/tetris/main.dart
@@ -23,9 +23,14 @@ late Canvas canvas;
 void main() {
   final szAppName = 'Tetris'.toNativeUtf16();
 
+  final lpfnWndProc = NativeCallable<WindowProc>.isolateLocal(
+    mainWindowProc,
+    exceptionalReturn: 0,
+  );
+
   final wc = calloc<WNDCLASS>()
     ..ref.style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC
-    ..ref.lpfnWndProc = Pointer.fromFunction<WindowProc>(mainWindowProc, 0)
+    ..ref.lpfnWndProc = lpfnWndProc.nativeFunction
     ..ref.hInstance = hInstance
     ..ref.hIcon = LoadIcon(NULL, IDI_APPLICATION)
     ..ref.hCursor = LoadCursor(NULL, IDC_ARROW)
@@ -59,13 +64,13 @@ void main() {
   UpdateWindow(hWnd);
 
   // Run the message loop.
-
   final msg = calloc<MSG>();
   while (GetMessage(msg, NULL, 0, 0) != 0) {
     TranslateMessage(msg);
     DispatchMessage(msg);
   }
 
+  lpfnWndProc.close();
   free(szAppName);
 }
 

--- a/example/window.dart
+++ b/example/window.dart
@@ -5,8 +5,8 @@
 // Enumerates open windows and demonstrates basic window manipulation
 
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 
+import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
 // Callback for each window found
@@ -30,9 +30,12 @@ int enumWindowsProc(int hWnd, int lParam) {
 /// List the window handle and text for all top-level desktop windows
 /// in the current session.
 void enumerateWindows() {
-  final wndProc = Pointer.fromFunction<EnumWindowsProc>(enumWindowsProc, 0);
-
-  EnumWindows(wndProc, 0);
+  final lpEnumFunc = NativeCallable<EnumWindowsProc>.isolateLocal(
+    enumWindowsProc,
+    exceptionalReturn: 0,
+  );
+  EnumWindows(lpEnumFunc.nativeFunction, 0);
+  lpEnumFunc.close();
 }
 
 /// Find the first open Notepad window and maximize it

--- a/test/window_test.dart
+++ b/test/window_test.dart
@@ -19,12 +19,15 @@ void main() {
 
   test('RegisterClass()', () {
     final hInstance = GetModuleHandle(nullptr);
-
     final pClassName = 'CLASS_NAME'.toNativeUtf16();
+    final lpfnWndProc = NativeCallable<WindowProc>.isolateLocal(
+      MainWindowProc,
+      exceptionalReturn: 0,
+    );
 
     final wc = calloc<WNDCLASS>()
       ..ref.style = CS_HREDRAW | CS_VREDRAW
-      ..ref.lpfnWndProc = Pointer.fromFunction<WindowProc>(MainWindowProc, 0)
+      ..ref.lpfnWndProc = lpfnWndProc.nativeFunction
       ..ref.hInstance = hInstance
       ..ref.lpszClassName = pClassName
       ..ref.hCursor = LoadCursor(NULL, IDC_ARROW)
@@ -34,8 +37,9 @@ void main() {
       final result = RegisterClass(wc);
       expect(result, isNot(0));
     } finally {
-      free(pClassName);
+      lpfnWndProc.close();
       free(wc);
+      free(pClassName);
     }
   });
 }

--- a/tool/win32gen/example/whatsleft.dart
+++ b/tool/win32gen/example/whatsleft.dart
@@ -46,16 +46,18 @@ Map<String, int> getExports(String module) {
     exit(1);
   }
 
+  final callback = NativeCallable<SymEnumSymbolsProc>.isolateLocal(
+    _enumSymbolProc,
+    exceptionalReturn: 0,
+  );
+
   if (SymEnumSymbols(
-          hProcess,
-          baseOfDll,
-          mask,
-          Pointer.fromFunction<SymEnumSymbolsProc>(_enumSymbolProc, 0),
-          nullptr) ==
+          hProcess, baseOfDll, mask, callback.nativeFunction, nullptr) ==
       FALSE) {
     print('SymEnumSymbols failed.');
   }
 
+  callback.close();
   SymCleanup(hProcess);
   free(modulePtr);
   free(mask);


### PR DESCRIPTION
[Pointer.fromFunction](https://api.dart.dev/stable/3.2.2/dart-ffi/Pointer/fromFunction.html) will be [deprecated and removed](https://github.com/dart-lang/sdk/issues/53524) in the future.

Also added an entry to example/README.md for the `shell_notify_icon` example.