### PR TITLE
Fix flaky crashes related to Finalizers in tests

### DIFF
--- a/lib/src/com/iunknown.dart
+++ b/lib/src/com/iunknown.dart
@@ -34,10 +34,13 @@ class IUnknown {
   }
 
   static final _finalizer = Finalizer<Pointer<COMObject>>((ptr) {
-    _release(ptr);
+    // Decrement the reference count of the object only when COM is initialized,
+    // otherwise this will cause the program to crash.
+    if (isCOMInitialized) _release(ptr);
     free(ptr);
   });
 
+  /// Decrements the reference count of the object referenced by [ptr].
   static int _release(Pointer<COMObject> ptr) => ptr.ref.vtable
       .elementAt(2)
       .cast<Pointer<NativeFunction<Uint32 Function(VTablePointer lpVtbl)>>>()

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -19,6 +19,7 @@ import 'structs.g.dart';
 import 'types.dart';
 import 'win32/api_ms_win_core_winrt_string_l1_1_0.g.dart';
 import 'win32/kernel32.g.dart';
+import 'win32/ole32.g.dart';
 import 'win32/shell32.g.dart';
 import 'win32/user32.g.dart';
 
@@ -81,8 +82,21 @@ void initApp(Function winMain) {
   }
 }
 
-/// Detects whether the Windows Runtime is available by attempting to open its
-/// core library.
+/// Determines whether the Component Object Model (COM) is initialized on the
+/// current thread.
+bool get isCOMInitialized {
+  final pAptType = calloc<Int32>();
+  final pAptQualifier = calloc<Int32>();
+  try {
+    return CoGetApartmentType(pAptType, pAptQualifier) == S_OK;
+  } finally {
+    free(pAptType);
+    free(pAptQualifier);
+  }
+}
+
+/// Detects whether the Windows Runtime (WinRT) is available by attempting to
+/// open its core library.
 bool isWindowsRuntimeAvailable() {
   try {
     DynamicLibrary.open('api-ms-win-core-winrt-l1-1-0.dll');

--- a/test/bstr_test.dart
+++ b/test/bstr_test.dart
@@ -12,6 +12,18 @@ void main() {
   const testRuns = 500;
 
   test('BSTR allocation', () {
+    const testString = 'This is a sample text string.';
+    final testStringPtr = testString.toNativeUtf16();
+    final bstr = SysAllocString(testStringPtr);
+
+    expect(SysStringLen(bstr), equals(testString.length));
+    expect(SysStringByteLen(bstr), equals(testString.length * 2));
+
+    SysFreeString(bstr);
+    free(testStringPtr);
+  });
+
+  test('BSTR.fromString', () {
     const testString = 'Hello world';
 
     for (var i = 0; i < testRuns; i++) {
@@ -28,6 +40,7 @@ void main() {
       final pNull =
           Pointer<WORD>.fromAddress(bstr.ptr.address + testString.length * 2);
       expect(pNull.value, isZero, reason: 'test run $i');
+
       bstr.free();
     }
   });
@@ -51,6 +64,7 @@ void main() {
       final pNull =
           Pointer<WORD>.fromAddress(bstr.ptr.address + longString.length * 2);
       expect(pNull.value, isZero);
+
       bstr.free();
     }
   });
@@ -65,7 +79,6 @@ void main() {
       expect(testString.length, equals(84));
       expect(bstr.byteLength, equals(84 * 2));
       expect(bstr.length, equals(84));
-
       expect(bstr.toString(), equals(testString));
 
       bstr.free();

--- a/test/com_network_test.dart
+++ b/test/com_network_test.dart
@@ -6,37 +6,23 @@ import 'package:ffi/ffi.dart';
 import 'package:test/test.dart';
 import 'package:win32/win32.dart';
 
-const testRuns = 5000;
+import 'helpers.dart';
 
 void main() {
-  test('Network manager', () {
-    final hr = CoInitializeEx(
-        nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-    expect(hr, equals(S_OK));
-    final nlm = NetworkListManager.createInstance();
-    expect(nlm.ptr.address, isNonZero);
-  });
-
   group('Network testing', () {
-    setUp(() {
-      final hr = CoInitializeEx(
-          nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-      if (FAILED(hr)) throw WindowsException(hr);
-    });
+    setUpAll(initializeCOM);
 
-    test('Network is connected', () {
+    test('network is connected', () {
       final nlm = NetworkListManager.createInstance();
       expect(nlm.isConnected, equals(VARIANT_TRUE));
     });
 
-    test('Network is connected to the internet', () {
-      for (var i = 0; i < testRuns; i++) {
-        final nlm = NetworkListManager.createInstance();
-        expect(nlm.isConnectedToInternet, equals(VARIANT_TRUE));
-      }
+    test('network is connected to the internet', () {
+      final nlm = NetworkListManager.createInstance();
+      expect(nlm.isConnectedToInternet, equals(VARIANT_TRUE));
     });
 
-    test('Can enumerate a network connection', () {
+    test('can enumerate a network connection', () {
       final nlm = NetworkListManager.createInstance();
       final enumPtr = calloc<COMObject>();
       final netPtr = calloc<COMObject>();
@@ -56,7 +42,7 @@ void main() {
           anyOf(equals(VARIANT_TRUE), equals(VARIANT_FALSE)));
     });
 
-    test('First network connection has a description', () {
+    test('first network connection has a description', () {
       final nlm = NetworkListManager.createInstance();
       final enumPtr = calloc<COMObject>();
       final netPtr = calloc<COMObject>();
@@ -80,5 +66,8 @@ void main() {
       SysFreeString(descPtr.value);
       free(descPtr);
     });
+
+    tearDown(forceGC);
+    tearDownAll(CoUninitialize);
   });
 }

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -1,7 +1,55 @@
+import 'dart:developer';
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
+
+/// Forces garbage collection through aggressive memory allocation.
+///
+/// This function ensures the execution of the `Finalizer`s during GC, thereby
+/// effectively averting potential "double free" or "use after free" errors.
+///
+/// Usage example:
+/// ```dart
+/// group('COM testing', () {
+///   setUpAll(initializeCOM);
+///
+///   test('dialog object exists', () {
+///     final dialog = FileOpenDialog.createInstance();
+///     expect(dialog.ptr.address, isNonZero);
+///     expect(dialog.ptr.ref.lpVtbl.address, isNonZero);
+///   });
+///
+///   test('can cast to IUnknown', () {
+///     final dialog = FileOpenDialog.createInstance();
+///     final unk = IUnknown.from(dialog);
+///     expect(unk.ptr.address, isNonZero);
+///     expect(unk.ptr.ref.lpVtbl.address, isNonZero);
+///   });
+///
+///   tearDown(forceGC);
+///   tearDownAll(CoUninitialize);
+/// });
+/// ```
+///
+/// Garbage collection is triggered by continuously allocating memory in a loop.
+/// The [fullGcCycles] parameter controls the number of cycles to perform,
+/// providing flexibility in the intensity of garbage collection.
+Future<void> forceGC({int fullGcCycles = 2}) async {
+  final barrier = reachabilityBarrier;
+
+  final storage = <List<int>>[];
+
+  void allocateMemory() {
+    storage.add(List.generate(30000, (n) => n));
+    if (storage.length > 100) storage.removeAt(0);
+  }
+
+  while (reachabilityBarrier < barrier + fullGcCycles) {
+    await Future<void>.delayed(Duration.zero);
+    allocateMemory();
+  }
+}
 
 int getWindowsBuildNumber() => int.parse(getRegistryValue(
     HKEY_LOCAL_MACHINE,
@@ -51,4 +99,10 @@ Object getRegistryValue(int key, String subKey, String valueName) {
   RegCloseKey(openKeyPtr.value);
 
   return dataValue;
+}
+
+void initializeCOM() {
+  final hr = CoInitializeEx(
+      nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+  if (FAILED(hr)) throw WindowsException(hr);
 }


### PR DESCRIPTION
- Updates the `Finalizer` callback to decrement the reference count of the object only when COM is initialized
- Resolves issues in tests that were leading to program crashes, along with various cleanup tasks
- Implements a mechanism to guarantee the execution of Finalizers after tests, thus preventing the recurrence of such crashes in the future