### PR TITLE
Deprecate WinRT helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.3.0-wip
 
-- Migrate away from `.elementAt` (#825)
+- Migrate away from `.elementAt` in favor of `operator +` (#825)
 - Bump minimum required Dart version to `3.3.0` (#825)
 - Deprecate `CallWndProc` typedef in favor of `HOOKPROC` (#826)
 - Deprecate `CCHookProc` typedef in favor of `LPCCHOOKPROC` (#826)
@@ -56,6 +56,12 @@
   `WLAN_NOTIFICATION_CALLBACK` (#826)
 - **Note**: You can automatically migrate your code to use the new typedefs by
   running `dart fix --apply` in your terminal.
+- Deprecate `convertFromHString` function (#829)
+- Deprecate `convertToHString` function (#829)
+- Deprecate `getClassName` function (#829)
+- Deprecate `getInterfaces` function (#829)
+- Deprecate `getTrustLevel` function (#829)
+- Deprecate `Pointer<HSTRING>.toDartString` extension method (#829)
 
 ## 5.2.0
 

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2024, Dart | Windows. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/// Represents the trust level of an activatable class.
+///
+/// {@category enum}
+enum TrustLevel {
+  /// The component has access to resources that are not protected.
+  baseTrust(0),
+
+  /// The component has access to resources requested in the app manifest and
+  /// approved by the user.
+  partialTrust(1),
+
+  /// The component requires the full privileges of the user.
+  fullTrust(2);
+
+  final int value;
+
+  const TrustLevel(this.value);
+
+  factory TrustLevel.from(int value) =>
+      TrustLevel.values.firstWhere((e) => e.value == value,
+          orElse: () => throw ArgumentError.value(
+              value, 'value', 'No enum value with that value'));
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -128,6 +128,7 @@ LPWSTR TEXT(String string) => string.toNativeUtf16();
 /// `String`.
 ///
 /// {@category winrt}
+@Deprecated('No replacement')
 String convertFromHString(int hstring) =>
     WindowsGetStringRawBuffer(hstring, nullptr).toDartString();
 
@@ -140,6 +141,7 @@ String convertFromHString(int hstring) =>
 /// reaches 0, the Windows Runtime deallocates the buffer.
 ///
 /// {@category winrt}
+@Deprecated('No replacement')
 int convertToHString(String string) {
   final hString = calloc<HSTRING>();
   final stringPtr = string.toNativeUtf16();

--- a/lib/src/winrt_helpers.dart
+++ b/lib/src/winrt_helpers.dart
@@ -10,6 +10,7 @@ import 'package:ffi/ffi.dart';
 
 import 'com/iinspectable.dart';
 import 'combase.dart';
+import 'enums.dart';
 import 'exceptions.dart';
 import 'guid.dart';
 import 'macros.dart';
@@ -17,39 +18,18 @@ import 'types.dart';
 import 'utils.dart';
 import 'win32/api_ms_win_core_winrt_string_l1_1_0.g.dart';
 
+@Deprecated('No replacement')
 extension WinRTStringConversion on Pointer<HSTRING> {
   /// Gets the Dart string at the handle pointed to by this object.
+  @Deprecated('No replacement')
   String toDartString() => convertFromHString(value);
-}
-
-/// Represents the trust level of an activatable class.
-///
-/// {@category enum}
-enum TrustLevel {
-  /// The component has access to resources that are not protected.
-  baseTrust(0),
-
-  /// The component has access to resources requested in the app manifest and
-  /// approved by the user.
-  partialTrust(1),
-
-  /// The component requires the full privileges of the user.
-  fullTrust(2);
-
-  final int value;
-
-  const TrustLevel(this.value);
-
-  factory TrustLevel.from(int value) =>
-      TrustLevel.values.firstWhere((e) => e.value == value,
-          orElse: () => throw ArgumentError.value(
-              value, 'value', 'No enum value with that value'));
 }
 
 /// Returns the interface IDs that are implemented by the Windows Runtime
 /// [object].
 ///
 /// The `IUnknown` and `IInspectable` interfaces are excluded.
+@Deprecated('No replacement')
 List<String> getInterfaces(IInspectable object) {
   final pIIDCount = calloc<Uint32>();
   final pIIDs = calloc<Pointer<GUID>>();
@@ -81,6 +61,7 @@ List<String> getInterfaces(IInspectable object) {
 }
 
 /// Gets the fully qualified name of the Windows Runtime [object].
+@Deprecated('No replacement')
 String getClassName(IInspectable object) {
   final hClassName = calloc<HSTRING>();
 
@@ -107,6 +88,7 @@ String getClassName(IInspectable object) {
 }
 
 /// Gets the trust level of the Windows Runtime [object].
+@Deprecated('No replacement')
 TrustLevel getTrustLevel(IInspectable object) {
   final pTrustLevel = calloc<Int32>();
 

--- a/lib/win32.dart
+++ b/lib/win32.dart
@@ -31,6 +31,7 @@ export 'src/callbacks.dart';
 export 'src/constants.dart';
 export 'src/constants_metadata.dart';
 export 'src/constants_nodoc.dart';
+export 'src/enums.dart';
 export 'src/exceptions.dart';
 export 'src/guid.dart';
 export 'src/inline.dart';

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 @TestOn('windows')
 
 import 'package:ffi/ffi.dart';

--- a/test/winrt_helpers_test.dart
+++ b/test/winrt_helpers_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 @TestOn('windows')
 
 import 'dart:ffi';


### PR DESCRIPTION
These helpers date back to the period when the WinRT projection was integrated into the win32 package (pre-`v5`). They should've been removed in `v5`, along with the WinRT projection bits.

Given their specific use cases, it's doubtful they see much, if any, active use. Nevertheless, any remaining users can simply copy these functions into their codebase. It seems logical to remove them from this package, as they no longer serve a significant purpose.