### PR TITLE
Add Service Manager CLI example

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,10 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  exclude: ['example/explorer/**', 'test_fixes/**']
+  exclude:
+    - example/explorer/**
+    - example/service_manager_cli/**
+    - test_fixes/**
   errors:
     todo: ignore
 

--- a/example/README.md
+++ b/example/README.md
@@ -7,24 +7,25 @@ demonstrate various aspects of invoking Windows APIs, including:
 - Invoking COM classes (both `IUnknown` and `IDispatch` interface types)
 - Integrating Windows code with Flutter
 
-Other examples of packages that use Win32 can be found on pub.dev, at the
-following location:
+Other examples of packages that use `package:win32` can be found on pub.dev, at
+the following location:
 [https://pub.dev/packages?q=dependency%3Awin32](https://pub.dev/packages?q=dependency%3Awin32).
 
 ## Windows system APIs (kernel32)
 
-| Example             | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| `credentials.dart`  | Adds a credential to the store and retrieves it         |
-| `dump.dart`         | Use debugger libraries to print DLL exported functions  |
-| `dynamic_load.dart` | Demonstrate loading a DLL and calling it at runtime     |
-| `filever.dart`      | Getting file version information from the file resource |
-| `manifest\`         | Demonstrates the use of app manifests for compiled apps |
-| `modules.dart`      | Enumerates all loaded modules on the current system     |
-| `pipe.dart`         | Shows use of named pipes for interprocess communication |
-| `registry.dart`     | Demonstrates querying the registry for values           |
-| `vt.dart`           | Shows virtual terminal sequences                        |
-| `wsl.dart`          | Retrieve information from a WSL instance through APIs   |
+| Example                | Description                                             |
+| ---------------------- | ------------------------------------------------------- |
+| `manifest\`            | Demonstrates the use of app manifests for compiled apps |
+| `service_manager_cli\` | Demonstrates managing Windows services                  |
+| `credentials.dart`     | Adds a credential to the store and retrieves it         |
+| `dump.dart`            | Use debugger libraries to print DLL exported functions  |
+| `dynamic_load.dart`    | Demonstrate loading a DLL and calling it at runtime     |
+| `filever.dart`         | Getting file version information from the file resource |
+| `modules.dart`         | Enumerates all loaded modules on the current system     |
+| `pipe.dart`            | Shows use of named pipes for interprocess communication |
+| `registry.dart`        | Demonstrates querying the registry for values           |
+| `vt.dart`              | Shows virtual terminal sequences                        |
+| `wsl.dart`             | Retrieve information from a WSL instance through APIs   |
 
 ## Accessing local hardware and devices
 
@@ -63,6 +64,8 @@ following location:
 
 | Example               | Description                                               |
 | --------------------- | --------------------------------------------------------- |
+| `notepad\`            | Lightweight replica of the Windows notepad applet         |
+| `tetris\`             | Port of an open-source Tetris game to Dart                |
 | `hello.dart`          | Basic Petzoldian "hello world" Win32 app                  |
 | `msgbox.dart`         | Demonstrates a MessageBox from the console                |
 | `commdlg.dart`        | Demonstrates using the color chooser common dialog box    |
@@ -70,13 +73,11 @@ following location:
 | `dialog.dart`         | Create a custom dialog box in code                        |
 | `customtitlebar.dart` | Demonstrates creation of owner-draw title bar region      |
 | `dialogshow.dart`     | Creates a common item dialog (file picker) using COM      |
-| `notepad\`            | Lightweight replica of the Windows notepad applet         |
 | `paint.dart`          | Demonstrates simple GDI drawing and min/max window sizing |
 | `scroll.dart`         | Example of horizontal and vertical scrolling text window  |
 | `sendinput.dart`      | Sends keyboard and mouse input to another window          |
 | `snake.dart`          | Snake game using various GDI features                     |
 | `taskdialog.dart`     | Demonstrates using modern task dialog boxes               |
-| `tetris\main.dart`    | Port of an open-source Tetris game to Dart                |
 | `window.dart`         | Enumerates open windows and basic window manipulation     |
 
 ## COM APIs

--- a/example/service_manager_cli/.gitignore
+++ b/example/service_manager_cli/.gitignore
@@ -1,0 +1,3 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/

--- a/example/service_manager_cli/README.md
+++ b/example/service_manager_cli/README.md
@@ -1,0 +1,45 @@
+# Service Manager CLI
+
+A command-line interface for managing Windows services.
+
+## Feature Overview
+
+- **Enumerating services:** View a set of all available services on the system.
+- **Starting and stopping a service:** Start or stop a service by its name.
+- **Querying service status:** Retrieve the current operational status of a
+  service by its name.
+
+## Installation
+
+Activate the CLI tool globally by running the following command:
+
+```sh
+cd example
+dart pub global activate service_manager_cli -s path
+```
+
+## Usage
+
+Run the CLI tool to see the usage information:
+
+```sh
+service_manager_cli
+```
+
+The following output will be displayed:
+
+```text
+A command-line interface for managing Windows services.
+
+Usage: service_manager_cli <command> [arguments]
+
+Global options:
+  -v, --verbose         Show additional command output.
+  -h, --help            Print this usage information.
+
+Available commands:
+  list                  List all services.
+  start <service_name>  Start a service.
+  status <service_name> Get the status of a service.
+  stop <service_name>   Stop a service.
+```

--- a/example/service_manager_cli/analysis_options.yaml
+++ b/example/service_manager_cli/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/example/service_manager_cli/bin/service_manager_cli.dart
+++ b/example/service_manager_cli/bin/service_manager_cli.dart
@@ -1,0 +1,126 @@
+import 'dart:io';
+
+import 'package:service_manager_cli/service_manager_cli.dart';
+
+void main(List<String> arguments) {
+  if (arguments.isEmpty ||
+      arguments.contains('-h') ||
+      arguments.contains('--help')) {
+    printUsage();
+    return;
+  }
+
+  bool verbose = false;
+  if (arguments.contains('-v') || arguments.contains('--verbose')) {
+    verbose = true;
+    arguments = arguments.where((arg) => arg != '-v').toList();
+  }
+
+  ServiceManager.log = verbose;
+
+  final command = arguments[0];
+  final serviceName = arguments.length > 1 ? arguments[1] : null;
+
+  switch (command) {
+    case 'list':
+      listServices();
+      break;
+
+    case 'start':
+      if (serviceName == null) {
+        print('Please provide the service name to start.');
+        exit(1);
+      }
+      startService(serviceName);
+      break;
+
+    case 'status':
+      if (serviceName == null) {
+        print('Please provide a service name to get status.');
+        exit(1);
+      }
+      status(serviceName);
+      break;
+
+    case 'stop':
+      if (serviceName == null) {
+        print('Please provide the service name to stop.');
+        exit(1);
+      }
+      stopService(serviceName);
+      break;
+
+    default:
+      print('Unknown command: $command');
+      print('');
+      printUsage();
+      exit(1);
+  }
+}
+
+void printUsage() {
+  print('A command-line interface for managing Windows services.');
+  print('');
+  print('Usage: service_manager_cli <command> [arguments]');
+  print('');
+  print('Global options:');
+  print('  -v, --verbose         Show additional command output.');
+  print('  -h, --help            Print this usage information.');
+  print('');
+  print('Available commands:');
+  print('  list                  List all services.');
+  print('  start <service_name>  Start a service.');
+  print('  status <service_name> Get the status of a service.');
+  print('  stop <service_name>   Stop a service.');
+}
+
+void listServices() {
+  final services = ServiceManager.services;
+  if (services.isEmpty) {
+    print('Failed to get services.');
+    return;
+  }
+
+  print('Found ${services.length} services:');
+  for (final service in services) {
+    print(' $service');
+  }
+}
+
+void startService(String serviceName) {
+  print(switch (ServiceManager.start(serviceName)) {
+    ServiceStartResult.success =>
+      'Service "$serviceName" started successfully.',
+    ServiceStartResult.accessDenied =>
+      'The attempt to start the service "$serviceName" was denied due to '
+          'insufficient permissions.',
+    ServiceStartResult.alreadyRunning =>
+      'Service "$serviceName" is already running.',
+    ServiceStartResult.failed => 'Failed to start service "$serviceName".',
+    ServiceStartResult.timedOut =>
+      'The attempt to start service "$serviceName" timed out.'
+  });
+}
+
+void status(String serviceName) {
+  final status = ServiceManager.status(serviceName);
+  if (status == null) {
+    print('Failed to get status of service "$serviceName".');
+  } else {
+    print('Status of service "$serviceName": ${status.name}');
+  }
+}
+
+void stopService(String serviceName) {
+  print(switch (ServiceManager.stop(serviceName)) {
+    ServiceStopResult.success => 'Service "$serviceName" stopped successfully.',
+    ServiceStopResult.accessDenied =>
+      'The attempt to stop the service "$serviceName" was denied due to '
+          'insufficient permissions.',
+    ServiceStopResult.alreadyStopped =>
+      'Service "$serviceName" is already stopped.',
+    ServiceStopResult.failed => 'Failed to stop service "$serviceName".',
+    ServiceStopResult.timedOut =>
+      'The attempt to stop service "$serviceName" timed out.'
+  });
+}

--- a/example/service_manager_cli/lib/service_manager_cli.dart
+++ b/example/service_manager_cli/lib/service_manager_cli.dart
@@ -1,0 +1,4 @@
+library;
+
+export 'src/models.dart';
+export 'src/service_manager.dart';

--- a/example/service_manager_cli/lib/src/models.dart
+++ b/example/service_manager_cli/lib/src/models.dart
@@ -1,0 +1,105 @@
+import 'package:win32/win32.dart';
+
+/// The result of an attempt to start a service.
+enum ServiceStartResult {
+  /// The attempt to start the service was denied due to insufficient
+  /// permissions.
+  accessDenied,
+
+  /// The service is already running.
+  alreadyRunning,
+
+  /// The attempt to start the service failed for an unspecified reason.
+  failed,
+
+  /// The service was started successfully.
+  success,
+
+  /// The attempt to start the service timed out.
+  timedOut,
+}
+
+/// The various states a service can be in.
+enum ServiceStatus {
+  /// The service is not running.
+  stopped,
+
+  /// The service is in the process of starting.
+  startPending,
+
+  /// The service is in the process of stopping.
+  stopPending,
+
+  /// The service is running.
+  running,
+
+  /// The service is in the process of resuming from a paused state.
+  continuePending,
+
+  /// The service is in the process of being paused.
+  pausePending,
+
+  /// The service is paused.
+  paused;
+
+  /// Converts an integer value to a corresponding [ServiceStatus] enum.
+  ///
+  /// Throws an [ArgumentError] if the value does not correspond to a valid
+  /// value.
+  static ServiceStatus fromValue(int value) => switch (value) {
+        SERVICE_STATUS_CURRENT_STATE.SERVICE_STOPPED => ServiceStatus.stopped,
+        SERVICE_STATUS_CURRENT_STATE.SERVICE_START_PENDING =>
+          ServiceStatus.startPending,
+        SERVICE_STATUS_CURRENT_STATE.SERVICE_STOP_PENDING =>
+          ServiceStatus.stopPending,
+        SERVICE_STATUS_CURRENT_STATE.SERVICE_RUNNING => ServiceStatus.running,
+        SERVICE_STATUS_CURRENT_STATE.SERVICE_CONTINUE_PENDING =>
+          ServiceStatus.continuePending,
+        SERVICE_STATUS_CURRENT_STATE.SERVICE_PAUSE_PENDING =>
+          ServiceStatus.pausePending,
+        SERVICE_STATUS_CURRENT_STATE.SERVICE_PAUSED => ServiceStatus.paused,
+        _ => throw ArgumentError('Invalid value: $value')
+      };
+}
+
+/// The result of an attempt to stop a service.
+enum ServiceStopResult {
+  /// The attempt to stop the service was denied due to insufficient
+  /// permissions.
+  accessDenied,
+
+  /// The service is already stopped.
+  alreadyStopped,
+
+  /// The attempt to stop the service failed for an unspecified reason.
+  failed,
+
+  /// The service was stopped successfully.
+  success,
+
+  /// The attempt to stop the service timed out.
+  timedOut,
+}
+
+/// Represents a Windows service with its name, display name, and current
+/// status.
+class Service {
+  const Service({
+    required this.displayName,
+    required this.name,
+    required this.status,
+  });
+
+  /// The display name of the service.
+  final String displayName;
+
+  /// The name of the service.
+  final String name;
+
+  /// The current status of the service.
+  final ServiceStatus status;
+
+  @override
+  String toString() =>
+      'Service(displayName: $displayName, name: $name, status: $status)';
+}

--- a/example/service_manager_cli/lib/src/service_manager.dart
+++ b/example/service_manager_cli/lib/src/service_manager.dart
@@ -1,0 +1,559 @@
+import 'dart:collection';
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:win32/win32.dart';
+
+import 'models.dart';
+
+/// Provides functionality for managing Windows services, including:
+/// - Enumerating available services
+/// - Starting and stopping services
+/// - Retrieving the current status of services
+abstract class ServiceManager {
+  /// Whether to log informative messages to the console.
+  static bool log = false;
+
+  /// Retrieves a set of all services (sorted by display name).
+  static Set<Service> get services {
+    final services =
+        SplayTreeSet<Service>((a, b) => a.displayName.compareTo(b.displayName));
+
+    // Get a handle to the SCM database.
+    final scmHandle =
+        OpenSCManager(nullptr, nullptr, SC_MANAGER_ENUMERATE_SERVICE);
+    if (scmHandle == NULL) return services;
+
+    return using((arena) {
+      try {
+        final bytesNeeded = arena<DWORD>();
+        final servicesReturned = arena<DWORD>();
+        final resumeHandle = arena<DWORD>();
+
+        _log('Getting service list...');
+
+        // First call to EnumServicesStatusEx to get the required buffer size.
+        EnumServicesStatusEx(
+          scmHandle,
+          SC_ENUM_TYPE.SC_ENUM_PROCESS_INFO,
+          ENUM_SERVICE_TYPE.SERVICE_WIN32,
+          ENUM_SERVICE_STATE.SERVICE_STATE_ALL,
+          nullptr,
+          0,
+          bytesNeeded,
+          servicesReturned,
+          resumeHandle,
+          nullptr,
+        );
+
+        final buffer = arena<BYTE>(bytesNeeded.value);
+
+        // Second call to EnumServicesStatusEx to get the actual data.
+        if (EnumServicesStatusEx(
+              scmHandle,
+              SC_ENUM_TYPE.SC_ENUM_PROCESS_INFO,
+              ENUM_SERVICE_TYPE.SERVICE_WIN32,
+              ENUM_SERVICE_STATE.SERVICE_STATE_ALL,
+              buffer,
+              bytesNeeded.value,
+              bytesNeeded,
+              servicesReturned,
+              resumeHandle,
+              nullptr,
+            ) !=
+            FALSE) {
+          final enumBuffer = buffer.cast<ENUM_SERVICE_STATUS_PROCESS>();
+          for (var i = 0; i < servicesReturned.value; i++) {
+            final serviceStatus = (enumBuffer + i).ref;
+            final ENUM_SERVICE_STATUS_PROCESS(:lpServiceName, :lpDisplayName) =
+                serviceStatus;
+            final serviceName = lpServiceName.toDartString();
+            final displayName = lpDisplayName.toDartString();
+            final status = ServiceStatus.fromValue(
+              serviceStatus.ServiceStatusProcess.dwCurrentState,
+            );
+            final service = Service(
+              displayName: displayName,
+              name: serviceName,
+              status: status,
+            );
+            services.add(service);
+          }
+        }
+      } finally {
+        CloseServiceHandle(scmHandle);
+      }
+
+      return services;
+    });
+  }
+
+  /// Starts a service defined by [serviceName].
+  static ServiceStartResult start(String serviceName) {
+    // Get a handle to the SCM database.
+    final scmHandle = OpenSCManager(
+      nullptr, // local computer
+      nullptr, // ServicesActive database
+      SC_MANAGER_ALL_ACCESS, // full access rights
+    );
+    if (scmHandle == NULL) return ServiceStartResult.accessDenied;
+
+    return using((arena) {
+      // Get a handle to the service.
+      final hService = OpenService(
+        scmHandle,
+        serviceName.toNativeUtf16(allocator: arena),
+        SERVICE_ALL_ACCESS,
+      );
+      if (hService == NULL) {
+        CloseServiceHandle(scmHandle);
+        return ServiceStartResult.failed;
+      }
+
+      final lpBuffer = arena<SERVICE_STATUS_PROCESS>();
+      final bytesNeeded = arena<DWORD>();
+
+      // Check the status in case the service is not stopped.
+      if (QueryServiceStatusEx(
+            hService,
+            SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+            lpBuffer.cast(),
+            sizeOf<SERVICE_STATUS_PROCESS>(),
+            bytesNeeded,
+          ) ==
+          FALSE) {
+        CloseServiceHandle(hService);
+        CloseServiceHandle(scmHandle);
+        return ServiceStartResult.failed;
+      }
+
+      final ssp = lpBuffer.ref;
+
+      // Check if the service is already running. It would be possible to stop
+      // the service here, but for simplicity this example just returns.
+      if (ssp.dwCurrentState != SERVICE_STATUS_CURRENT_STATE.SERVICE_STOPPED &&
+          ssp.dwCurrentState !=
+              SERVICE_STATUS_CURRENT_STATE.SERVICE_STOP_PENDING) {
+        CloseServiceHandle(hService);
+        CloseServiceHandle(scmHandle);
+        return ServiceStartResult.alreadyRunning;
+      }
+
+      // Save the tick count and initial checkpoint.
+      var startTickCount = GetTickCount();
+      var oldCheckPoint = ssp.dwCheckPoint;
+
+      // If a stop is pending, wait for it.
+      while (ssp.dwCurrentState ==
+          SERVICE_STATUS_CURRENT_STATE.SERVICE_STOP_PENDING) {
+        _log('Service stop pending...');
+
+        // Do not wait longer than the wait hint. A good interval is one-tenth
+        // of the wait hint but not less than 1 second and not more than 10
+        // seconds.
+
+        var waitTime = ssp.dwWaitHint ~/ 10;
+        waitTime = waitTime < 1000
+            ? 1000
+            : waitTime > 10000
+                ? 10000
+                : waitTime;
+        _log('Sleeping for ${ssp.dwWaitHint} ms...');
+        Sleep(waitTime);
+
+        // Check the status until the service is no longer stop pending.
+        if (QueryServiceStatusEx(
+              hService,
+              SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+              lpBuffer.cast(),
+              sizeOf<SERVICE_STATUS_PROCESS>(),
+              bytesNeeded,
+            ) ==
+            FALSE) {
+          CloseServiceHandle(hService);
+          CloseServiceHandle(scmHandle);
+          return ServiceStartResult.failed;
+        }
+
+        if (ssp.dwCheckPoint > oldCheckPoint) {
+          // Continue to wait and check.
+          startTickCount = GetTickCount();
+          oldCheckPoint = ssp.dwCheckPoint;
+        } else if (GetTickCount() - startTickCount > ssp.dwWaitHint) {
+          CloseServiceHandle(hService);
+          CloseServiceHandle(scmHandle);
+          return ServiceStartResult.timedOut;
+        }
+      }
+
+      // Attempt to start the service.
+      if (StartService(hService, 0, nullptr) == FALSE) {
+        CloseServiceHandle(hService);
+        CloseServiceHandle(scmHandle);
+        return ServiceStartResult.failed;
+      } else {
+        _log('Service start pending...');
+      }
+
+      // Check the status until the service is no longer start pending.
+      if (QueryServiceStatusEx(
+            hService,
+            SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+            lpBuffer.cast(),
+            sizeOf<SERVICE_STATUS_PROCESS>(),
+            bytesNeeded,
+          ) ==
+          FALSE) {
+        CloseServiceHandle(hService);
+        CloseServiceHandle(scmHandle);
+        return ServiceStartResult.failed;
+      }
+
+      // Save the tick count and initial checkpoint.
+      startTickCount = GetTickCount();
+      oldCheckPoint = ssp.dwCheckPoint;
+
+      while (ssp.dwCurrentState ==
+          SERVICE_STATUS_CURRENT_STATE.SERVICE_START_PENDING) {
+        // Do not wait longer than the wait hint. A good interval is one-tenth
+        // of the wait hint but not less than 1 second and not more than 10
+        // seconds.
+
+        var waitTime = ssp.dwWaitHint ~/ 10;
+        waitTime = waitTime < 1000
+            ? 1000
+            : waitTime > 10000
+                ? 10000
+                : waitTime;
+        _log('Sleeping for ${ssp.dwWaitHint} ms...');
+        Sleep(waitTime);
+
+        // Check the status again.
+        if (QueryServiceStatusEx(
+              hService,
+              SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+              lpBuffer.cast(),
+              sizeOf<SERVICE_STATUS_PROCESS>(),
+              bytesNeeded,
+            ) ==
+            FALSE) {
+          break;
+        }
+
+        if (ssp.dwCheckPoint > oldCheckPoint) {
+          // Continue to wait and check.
+          startTickCount = GetTickCount();
+          oldCheckPoint = ssp.dwCheckPoint;
+        } else if (GetTickCount() - startTickCount > ssp.dwWaitHint) {
+          // No progress made within the wait hint.
+          break;
+        }
+      }
+
+      // Determine whether the service is running.
+      final serviceRunning =
+          ssp.dwCurrentState == SERVICE_STATUS_CURRENT_STATE.SERVICE_RUNNING;
+      CloseServiceHandle(hService);
+      CloseServiceHandle(scmHandle);
+
+      return serviceRunning
+          ? ServiceStartResult.success
+          : ServiceStartResult.failed;
+    });
+  }
+
+  /// Retrieves the status of a service defined by [serviceName].
+  static ServiceStatus? status(String serviceName) {
+    // Get a handle to the SCM database.
+    final scmHandle = OpenSCManager(nullptr, nullptr, SC_MANAGER_CONNECT);
+    if (scmHandle == NULL) return null;
+
+    return using((arena) {
+      // Get a handle to the service.
+      final hService = OpenService(
+        scmHandle,
+        serviceName.toNativeUtf16(allocator: arena),
+        SERVICE_QUERY_STATUS,
+      );
+      if (hService == NULL) {
+        CloseServiceHandle(scmHandle);
+        return null;
+      }
+
+      try {
+        final lpBuffer = arena<SERVICE_STATUS_PROCESS>();
+        final bytesNeeded = arena<DWORD>();
+
+        // Query the service status.
+        if (QueryServiceStatusEx(
+              hService,
+              SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+              lpBuffer.cast(),
+              sizeOf<SERVICE_STATUS_PROCESS>(),
+              bytesNeeded,
+            ) ==
+            FALSE) {
+          return null;
+        }
+
+        return ServiceStatus.fromValue(lpBuffer.ref.dwCurrentState);
+      } finally {
+        CloseServiceHandle(hService);
+        CloseServiceHandle(scmHandle);
+      }
+    });
+  }
+
+  /// Stops a service defined by [serviceName].
+  static ServiceStopResult stop(String serviceName) {
+    // Get a handle to the SCM database.
+    final scmHandle = OpenSCManager(
+      nullptr, // local computer
+      nullptr, // ServicesActive database
+      SC_MANAGER_ALL_ACCESS, // full access rights
+    );
+    if (scmHandle == NULL) return ServiceStopResult.accessDenied;
+
+    return using((arena) {
+      // Get a handle to the service.
+      final hService = OpenService(
+        scmHandle,
+        serviceName.toNativeUtf16(allocator: arena),
+        SERVICE_STOP | SERVICE_QUERY_STATUS | SERVICE_ENUMERATE_DEPENDENTS,
+      );
+      if (hService == NULL) {
+        CloseServiceHandle(scmHandle);
+        return ServiceStopResult.failed;
+      }
+
+      try {
+        final lpBuffer = arena<SERVICE_STATUS_PROCESS>();
+        final bytesNeeded = arena<DWORD>();
+
+        // Make sure the service is not already stopped.
+        if (QueryServiceStatusEx(
+              hService,
+              SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+              lpBuffer.cast(),
+              sizeOf<SERVICE_STATUS_PROCESS>(),
+              bytesNeeded,
+            ) ==
+            FALSE) {
+          return ServiceStopResult.failed;
+        }
+
+        final ssp = lpBuffer.ref;
+        if (ssp.dwCurrentState ==
+            SERVICE_STATUS_CURRENT_STATE.SERVICE_STOPPED) {
+          return ServiceStopResult.alreadyStopped;
+        }
+
+        final startTime = GetTickCount();
+        const timeout = 30000; // 30-second timeout
+
+        // If a stop is pending, wait for it.
+        while (ssp.dwCurrentState ==
+            SERVICE_STATUS_CURRENT_STATE.SERVICE_STOP_PENDING) {
+          _log('Service stop pending...');
+
+          // Do not wait longer than the wait hint. A good interval is one-tenth
+          // of the wait hint but not less than 1 second and not more than 10
+          // seconds.
+
+          var waitTime = ssp.dwWaitHint ~/ 10;
+          waitTime = waitTime < 1000
+              ? 1000
+              : waitTime > 10000
+                  ? 10000
+                  : waitTime;
+          _log('Sleeping for ${ssp.dwWaitHint} ms...');
+          Sleep(waitTime);
+
+          if (QueryServiceStatusEx(
+                hService,
+                SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+                lpBuffer.cast(),
+                sizeOf<SERVICE_STATUS_PROCESS>(),
+                bytesNeeded,
+              ) ==
+              FALSE) {
+            return ServiceStopResult.failed;
+          }
+
+          if (ssp.dwCurrentState ==
+              SERVICE_STATUS_CURRENT_STATE.SERVICE_STOPPED) {
+            return ServiceStopResult.success;
+          }
+
+          if (GetTickCount() - startTime > timeout) {
+            return ServiceStopResult.timedOut;
+          }
+        }
+
+        // If the service is running, dependencies must be stopped first.
+        final result = _stopDependentServices(hService, scmHandle);
+        if (result
+            case ServiceStopResult.accessDenied ||
+                ServiceStopResult.failed ||
+                ServiceStopResult.timedOut) {
+          return result;
+        }
+
+        // Send a stop code to the service.
+        if (ControlService(
+              hService,
+              SERVICE_CONTROL_STOP,
+              lpBuffer.cast<SERVICE_STATUS>(),
+            ) ==
+            FALSE) {
+          return ServiceStopResult.failed;
+        }
+
+        // Wait for the service to stop.
+
+        _log('Service stop pending...');
+
+        while (ssp.dwCurrentState !=
+            SERVICE_STATUS_CURRENT_STATE.SERVICE_STOPPED) {
+          _log('Sleeping for ${ssp.dwWaitHint} ms...');
+          Sleep(ssp.dwWaitHint);
+
+          if (QueryServiceStatusEx(
+                hService,
+                SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+                lpBuffer.cast(),
+                sizeOf<SERVICE_STATUS_PROCESS>(),
+                bytesNeeded,
+              ) ==
+              FALSE) {
+            return ServiceStopResult.failed;
+          }
+
+          if (ssp.dwCurrentState ==
+              SERVICE_STATUS_CURRENT_STATE.SERVICE_STOPPED) break;
+
+          if (GetTickCount() - startTime > timeout) {
+            return ServiceStopResult.timedOut;
+          }
+        }
+
+        return ServiceStopResult.success;
+      } finally {
+        CloseServiceHandle(hService);
+        CloseServiceHandle(scmHandle);
+      }
+    });
+  }
+
+  /// Stops dependent services of a service defined by [hService].
+  static ServiceStopResult _stopDependentServices(
+    int hService,
+    int scmHandle,
+  ) {
+    return using((arena) {
+      final bytesNeeded = arena<DWORD>();
+      final servicesReturned = arena<DWORD>();
+
+      _log('Checking for dependent services...');
+
+      // Pass a zero-length buffer to get the required buffer size.
+      if (EnumDependentServices(
+            hService,
+            ENUM_SERVICE_STATE.SERVICE_ACTIVE,
+            nullptr,
+            0,
+            bytesNeeded,
+            servicesReturned,
+          ) ==
+          TRUE) {
+        _log('No dependent services found.');
+      } else {
+        // Allocate a buffer for the dependencies.
+        final lpServices =
+            arena<BYTE>(bytesNeeded.value).cast<ENUM_SERVICE_STATUS>();
+
+        // Enumerate the dependencies.
+        if (EnumDependentServices(
+              hService,
+              ENUM_SERVICE_STATE.SERVICE_ACTIVE,
+              lpServices,
+              bytesNeeded.value,
+              bytesNeeded,
+              servicesReturned,
+            ) ==
+            FALSE) {
+          return ServiceStopResult.failed;
+        }
+
+        _log('Found ${servicesReturned.value} dependent services:');
+        for (var i = 0; i < servicesReturned.value; i++) {
+          final ess = lpServices[i];
+          _log(' (${i + 1}/${servicesReturned.value}) Stopping '
+              '${ess.lpServiceName.toDartString()}...');
+
+          // Open the service.
+          final hDepService = OpenService(
+            scmHandle,
+            ess.lpServiceName,
+            SERVICE_STOP | SERVICE_QUERY_STATUS,
+          );
+          if (hDepService == NULL) return ServiceStopResult.failed;
+
+          try {
+            final lpServiceStatus = arena<SERVICE_STATUS_PROCESS>();
+
+            // Send a stop code.
+            if (ControlService(
+                  hDepService,
+                  SERVICE_CONTROL_STOP,
+                  lpServiceStatus.cast<SERVICE_STATUS>(),
+                ) ==
+                FALSE) {
+              return ServiceStopResult.failed;
+            }
+
+            final startTime = GetTickCount();
+            const timeout = 30000; // 30-second timeout
+            final ssp = lpServiceStatus.ref;
+
+            // Wait for the service to stop.
+            while (ssp.dwCurrentState !=
+                SERVICE_STATUS_CURRENT_STATE.SERVICE_STOPPED) {
+              _log('Sleeping for ${ssp.dwWaitHint} ms...');
+              Sleep(ssp.dwWaitHint);
+
+              if (QueryServiceStatusEx(
+                    hDepService,
+                    SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+                    lpServiceStatus.cast(),
+                    sizeOf<SERVICE_STATUS_PROCESS>(),
+                    bytesNeeded,
+                  ) ==
+                  FALSE) {
+                return ServiceStopResult.failed;
+              }
+
+              if (ssp.dwCurrentState ==
+                  SERVICE_STATUS_CURRENT_STATE.SERVICE_STOPPED) break;
+
+              if (GetTickCount() - startTime > timeout) {
+                return ServiceStopResult.timedOut;
+              }
+            }
+          } finally {
+            // Always release the service handle.
+            CloseServiceHandle(hDepService);
+          }
+        }
+      }
+
+      _log('Dependent services stopped.');
+      return ServiceStopResult.success;
+    });
+  }
+
+  /// Logs a message to the console if [log] is `true`.
+  static void _log(String message) {
+    if (log) print(message);
+  }
+}

--- a/example/service_manager_cli/pubspec.yaml
+++ b/example/service_manager_cli/pubspec.yaml
@@ -1,0 +1,17 @@
+name: service_manager_cli
+description: Service Manager CLI
+publish_to: none
+
+environment:
+  sdk: ^3.4.0
+
+dependencies:
+  ffi: ^2.1.2
+  win32:
+    path: ../../
+
+dev_dependencies:
+  lints: ^4.0.0
+
+executables:
+  service_manager_cli:


### PR DESCRIPTION
```text
A command-line interface for managing Windows services.

Usage: service_manager_cli <command> [arguments]

Global options:
  -v, --verbose         Show additional command output.
  -h, --help            Print this usage information.

Available commands:
  list                  List all services.
  start <service_name>  Start a service.
  status <service_name> Get the status of a service.
  stop <service_name>   Stop a service.
```