### PR TITLE
feat: add `SetClassLongPtr` function.

### DIFF
--- a/packages/generator/data/win32_functions.json
+++ b/packages/generator/data/win32_functions.json
@@ -4733,6 +4733,10 @@
         "prototype": "BOOL SetCaretPos(\n  int X,\n  int Y\n);",
         "comment": "Moves the caret to the specified coordinates. If the window that owns the caret was created with the CS_OWNDC class style, then the specified coordinates are subject to the mapping mode of the device context associated with that window."
     },
+    "SetClassLongPtr": {
+        "prototype": "ULONG_PTR SetClassLongPtrW(\n  HWND hWnd,\n  int  nIndex,\n  LONG_PTR dwNewLong\n);",
+        "comment": "Changes an attribute of the specified window class."
+    },
     "SetClipboardData": {
         "prototype": "HANDLE SetClipboardData(\n  UINT   uFormat,\n  HANDLE hMem\n);",
         "comment": "Places data on the clipboard in a specified clipboard format. The window must be the current clipboard owner, and the application must have called the OpenClipboard function."

--- a/packages/win32/lib/src/win32/user32.g.dart
+++ b/packages/win32/lib/src/win32/user32.g.dart
@@ -6733,6 +6733,23 @@ int SetCaretPos(int X, int Y) => _SetCaretPos(X, Y);
 final _SetCaretPos = _user32.lookupFunction<Int32 Function(Int32 X, Int32 Y),
     int Function(int X, int Y)>('SetCaretPos');
 
+/// Changes an attribute of the specified window class.
+///
+/// ```c
+/// ULONG_PTR SetClassLongPtrW(
+///   HWND hWnd,
+///   int  nIndex,
+///   LONG_PTR dwNewLong
+/// );
+/// ```
+/// {@category user32}
+int SetClassLongPtr(int hWnd, int nIndex, int dwNewLong) =>
+    _SetClassLongPtr(hWnd, nIndex, dwNewLong);
+
+final _SetClassLongPtr = _user32.lookupFunction<
+    IntPtr Function(IntPtr hWnd, Int32 nIndex, IntPtr dwNewLong),
+    int Function(int hWnd, int nIndex, int dwNewLong)>('SetClassLongPtrW');
+
 /// Places data on the clipboard in a specified clipboard format. The window
 /// must be the current clipboard owner, and the application must have
 /// called the OpenClipboard function.

--- a/packages/win32/test/api_test.dart
+++ b/packages/win32/test/api_test.dart
@@ -8218,6 +8218,14 @@ void main() {
           int Function(int X, int Y)>('SetCaretPos');
       expect(SetCaretPos, isA<Function>());
     });
+    test('Can instantiate SetClassLongPtr', () {
+      final user32 = DynamicLibrary.open('user32.dll');
+      final SetClassLongPtr = user32.lookupFunction<
+          IntPtr Function(IntPtr hWnd, Int32 nIndex, IntPtr dwNewLong),
+          int Function(
+              int hWnd, int nIndex, int dwNewLong)>('SetClassLongPtrW');
+      expect(SetClassLongPtr, isA<Function>());
+    });
     test('Can instantiate SetClipboardData', () {
       final user32 = DynamicLibrary.open('user32.dll');
       final SetClipboardData = user32.lookupFunction<


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Adds `SetClassLongPtr` to Win32. Goal is to allow the user to update the dock icon.

First contribution here, sorry if anything is incorrect - not sure protocol on version bumping and so forth.

## Related Issue

<no issue created>

<!--- Link the relevant issue here -->

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🧪 `test` -- Test
- [ ] 🗑️ `chore` -- Chore
