### PR TITLE
fix: `nodoc` deprecation fix

### DIFF
--- a/packages/win32/dartdoc_options.yaml
+++ b/packages/win32/dartdoc_options.yaml
@@ -107,7 +107,6 @@ dartdoc:
       'examples',
     ]
   showUndocumentedCategories: true
-  nodoc: ['lib/src/constants_nodoc.dart']
   ignore:
     - broken-link
     - missing-from-search-index

--- a/packages/win32/lib/src/constants_nodoc.dart
+++ b/packages/win32/lib/src/constants_nodoc.dart
@@ -3,10 +3,6 @@
 // *** NOTE: This file contains constants that we have chosen not to document,
 // mostly because their function is obvious, or because they are documented in
 // the public Microsoft Windows documentation online.
-//
-// This file (only) is excluded from dartdoc in `dartdoc_options.yaml`. By
-// keeping non-documented constants in a separate file, we save ourselves the
-// need to add the /// @nodoc modifier to every single constant in this file.
 
 // Contributors are invited and encouraged to submit comments for these
 // constants from the open source Microsoft documentation, such as
@@ -15,6 +11,10 @@
 
 // ignore_for_file: camel_case_types, constant_identifier_names
 // ignore_for_file: non_constant_identifier_names
+
+// Do not document this whole library.
+/// @nodoc
+library;
 
 import 'dart:ffi';
 

--- a/packages/win32/lib/src/constants_nodoc.dart
+++ b/packages/win32/lib/src/constants_nodoc.dart
@@ -12,7 +12,7 @@
 // ignore_for_file: camel_case_types, constant_identifier_names
 // ignore_for_file: non_constant_identifier_names
 
-// Do not document this whole library.
+// Do not document anything in this library.
 /// @nodoc
 library;
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the
  title.

  Please look at the following checklist to ensure that your PR can be accepted
  quickly:
-->

## Description

Running `dart doc .` in `packages/win32` previously generated a warning that:

```
plaintext
warning: deprecated dartdoc usage: The '--nodoc' option is deprecated, and will soon be removed.
    from package-win32: file:///C:/Users/[username]/Downloads/forks/win32/packages/win32
```

This is fixed by this PR, which replaces the deprecated `nodoc` option in `dartdoc_options.yaml` with a `@nodoc` annotation in `constants_nodoc.dart`. As described in #948 , I've achieved this without needing a `@nodoc` on every constant in `constants_nodoc.dart`.

## Related Issue

Fixes #948 .

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [x] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [ ] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [ ] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [x] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [ ] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
