### PR TITLE
feat: Add MOVEFILE constants

### DIFF
--- a/packages/win32/lib/src/constants.dart
+++ b/packages/win32/lib/src/constants.dart
@@ -13360,7 +13360,7 @@ const SVSFUnusedFlags = -512;
 const MOVEFILE_COPY_ALLOWED = 2;
 
 /// Reserved for future use.
-const MOVEFILE_CREATE_HARDLINK = 16
+const MOVEFILE_CREATE_HARDLINK = 16;
 
 /// The system does not move the file until the operating system is restarted.
 const MOVEFILE_DELAY_UNTIL_REBOOT = 4;

--- a/packages/win32/lib/src/constants.dart
+++ b/packages/win32/lib/src/constants.dart
@@ -13350,3 +13350,27 @@ const SVSFVoiceMask = 511;
 
 /// This mask has every unused bit set.
 const SVSFUnusedFlags = -512;
+
+// -----------------------------------------------------------------------------
+// MOVEFILE constants
+// -----------------------------------------------------------------------------
+
+/// If the file is to be moved to a different volume, the function simulates
+/// the move by using the CopyFile and DeleteFile functions.
+const MOVEFILE_COPY_ALLOWED = 2;
+
+/// Reserved for future use.
+const MOVEFILE_CREATE_HARDLINK = 16
+
+/// The system does not move the file until the operating system is restarted.
+const MOVEFILE_DELAY_UNTIL_REBOOT = 4;
+
+/// The function fails if the source file is a link source, but the file cannot
+/// be tracked after the move.
+const MOVEFILE_FAIL_IF_NOT_TRACKABLE = 32;
+
+/// Replace the destination file if it already exists.
+const MOVEFILE_REPLACE_EXISTING = 1;
+
+/// The function does not return until the file is actually moved on the disk.
+const MOVEFILE_WRITE_THROUGH = 8;


### PR DESCRIPTION
## Description

Add `MOVEFILE_` constants used by `MoveFileEx`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [ ] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [ ] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [ ] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [ ] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [ ] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
