### PR TITLE
feat: add the `WIN32_FILE_ATTRIBUTE_DATA` struct

### DIFF
--- a/examples/fileinfo.dart
+++ b/examples/fileinfo.dart
@@ -1,0 +1,34 @@
+// File attribute information
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:win32/win32.dart';
+
+double fileTimeToSeconds(FILETIME fileTime) =>
+    ((fileTime.dwHighDateTime << 32) + fileTime.dwLowDateTime) / 10E6;
+
+void main() {
+  final filePath = Directory.current.path;
+
+  print('Information for: $filePath\n');
+
+  using((arena) {
+    final info = arena<WIN32_FILE_ATTRIBUTE_DATA>(1);
+    if (GetFileAttributesEx(
+          filePath.toNativeUtf16(),
+          GetFileExInfoStandard,
+          info,
+        ) ==
+        FALSE) {
+      print('Failed to get file information');
+    }
+    print('dwFileAttributes: ${info.ref.dwFileAttributes}');
+    print('ftCreationTime: ${fileTimeToSeconds(info.ref.ftCreationTime)}');
+    print('ftLastAccessTime: ${fileTimeToSeconds(info.ref.ftLastAccessTime)}');
+    print('ftLastWriteTime: ${fileTimeToSeconds(info.ref.ftLastWriteTime)}');
+    print('nFileSizeHigh: ${info.ref.nFileSizeHigh}');
+    print('nFileSizeLow: ${info.ref.nFileSizeLow}');
+  });
+}

--- a/examples/fileinfo.dart
+++ b/examples/fileinfo.dart
@@ -6,8 +6,28 @@ import 'dart:io';
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
-double fileTimeToSeconds(FILETIME fileTime) =>
-    ((fileTime.dwHighDateTime << 32) + fileTime.dwLowDateTime) / 10E6;
+extension on FILETIME {
+  DateTime toDateTime() {
+    final microseconds = combineHighLow(dwHighDateTime, dwLowDateTime) ~/ 10;
+    return DateTime.utc(1601, 1, 1).add(Duration(microseconds: microseconds));
+  }
+}
+
+int combineHighLow(int high, int low) => (high << 32) | low;
+
+/// Converts file attributes to a human-readable string.
+String getAttributesString(int attributes) {
+  final result = <String>[];
+  if ((attributes & FILE_ATTRIBUTE_READONLY) != 0) result.add('Read-only');
+  if ((attributes & FILE_ATTRIBUTE_HIDDEN) != 0) result.add('Hidden');
+  if ((attributes & FILE_ATTRIBUTE_SYSTEM) != 0) result.add('System');
+  if ((attributes & FILE_ATTRIBUTE_DIRECTORY) != 0) result.add('Directory');
+  if ((attributes & FILE_ATTRIBUTE_ARCHIVE) != 0) result.add('Archive');
+  if ((attributes & FILE_ATTRIBUTE_NORMAL) != 0) result.add('Normal');
+  // There are many more attributes that could be added here, this is just an
+  // example.
+  return result.isEmpty ? 'None' : result.join(', ');
+}
 
 void main() {
   final filePath = Directory.current.path;
@@ -15,21 +35,26 @@ void main() {
   print('Information for: $filePath\n');
 
   using((arena) {
-    final info = arena<WIN32_FILE_ATTRIBUTE_DATA>(1);
+    final lpFileInfo = arena<WIN32_FILE_ATTRIBUTE_DATA>();
     if (GetFileAttributesEx(
           filePath.toNativeUtf16(),
           GetFileExInfoStandard,
-          info,
+          lpFileInfo,
         ) ==
         FALSE) {
       print('Failed to get file information');
       return;
     }
-    print('dwFileAttributes: ${info.ref.dwFileAttributes}');
-    print('ftCreationTime: ${fileTimeToSeconds(info.ref.ftCreationTime)}');
-    print('ftLastAccessTime: ${fileTimeToSeconds(info.ref.ftLastAccessTime)}');
-    print('ftLastWriteTime: ${fileTimeToSeconds(info.ref.ftLastWriteTime)}');
-    print('nFileSizeHigh: ${info.ref.nFileSizeHigh}');
-    print('nFileSizeLow: ${info.ref.nFileSizeLow}');
+    final info = lpFileInfo.ref;
+    final attributes = info.dwFileAttributes;
+    final isDirectory = (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+    print('Attributes: ${getAttributesString(attributes)}');
+    print('Creation Time: ${info.ftCreationTime.toDateTime()}');
+    print('Last Access Time: ${info.ftLastAccessTime.toDateTime()}');
+    print('Last Write Time: ${info.ftLastWriteTime.toDateTime()}');
+    if (!isDirectory) {
+      final sizeInBytes = combineHighLow(info.nFileSizeHigh, info.nFileSizeLow);
+      print('Size: $sizeInBytes bytes');
+    }
   });
 }

--- a/examples/fileinfo.dart
+++ b/examples/fileinfo.dart
@@ -23,6 +23,7 @@ void main() {
         ) ==
         FALSE) {
       print('Failed to get file information');
+      return;
     }
     print('dwFileAttributes: ${info.ref.dwFileAttributes}');
     print('ftCreationTime: ${fileTimeToSeconds(info.ref.ftCreationTime)}');

--- a/packages/generator/data/win32_structs.json
+++ b/packages/generator/data/win32_structs.json
@@ -229,6 +229,7 @@
     "Windows.Win32.Storage.FileSystem.CREATEFILE2_EXTENDED_PARAMETERS": "Contains optional extended parameters for CreateFile2.",
     "Windows.Win32.Storage.FileSystem.FILE_SEGMENT_ELEMENT": "Union that contains a 64-bit value that points to a page of data.",
     "Windows.Win32.Storage.FileSystem.VS_FIXEDFILEINFO": "Contains version information for a file. This information is language and code page independent.",
+    "Windows.Win32.Storage.FileSystem.WIN32_FILE_ATTRIBUTE_DATA": "Contains attribute information for a file or directory. The GetFileAttributesEx function uses this structure.",
     "Windows.Win32.Storage.FileSystem.WIN32_FIND_DATAW": "Contains information about the file that is found by the FindFirstFile, FindFirstFileEx, or FindNextFile function.",
     "Windows.Win32.Storage.Packaging.Appx.APPX_PACKAGE_SETTINGS": "Represents package settings used to create a package.",
     "Windows.Win32.System.ApplicationInstallationAndServicing.ACTCTXW": "The ACTCTX structure is used by the CreateActCtx function to create the activation context.",

--- a/packages/win32/example/README.md
+++ b/packages/win32/example/README.md
@@ -19,25 +19,27 @@ visit [pub.dev] to explore packages that depend on it.
 
 ## Windows system APIs (kernel32)
 
-| Example               | Description                                             |
-| --------------------- | ------------------------------------------------------- |
-| [manifest]            | Demonstrates the use of app manifests for compiled apps |
-| [service_manager_cli] | Demonstrates managing Windows services                  |
-| [credentials.dart]    | Adds a credential to the store and retrieves it         |
-| [dump.dart]           | Use debugger libraries to print DLL exported functions  |
-| [dynamic_load.dart]   | Demonstrate loading a DLL and calling it at runtime     |
-| [filever.dart]        | Getting file version information from the file resource |
-| [modules.dart]        | Enumerates all loaded modules on the current system     |
-| [pipe.dart]           | Shows use of named pipes for interprocess communication |
-| [registry.dart]       | Demonstrates querying the registry for values           |
-| [vt.dart]             | Shows virtual terminal sequences                        |
-| [wsl.dart]            | Retrieve information from a WSL instance through APIs   |
+| Example               | Description                                                   |
+| --------------------- | ------------------------------------------------------------- |
+| [manifest]            | Demonstrates the use of app manifests for compiled apps       |
+| [service_manager_cli] | Demonstrates managing Windows services                        |
+| [credentials.dart]    | Adds a credential to the store and retrieves it               |
+| [dump.dart]           | Use debugger libraries to print DLL exported functions        |
+| [dynamic_load.dart]   | Demonstrate loading a DLL and calling it at runtime           |
+| [fileinfo.dart]       | Shows how to get file information using `GetFileAttributesEx` |
+| [filever.dart]        | Getting file version information from the file resource       |
+| [modules.dart]        | Enumerates all loaded modules on the current system           |
+| [pipe.dart]           | Shows use of named pipes for interprocess communication       |
+| [registry.dart]       | Demonstrates querying the registry for values                 |
+| [vt.dart]             | Shows virtual terminal sequences                              |
+| [wsl.dart]            | Retrieve information from a WSL instance through APIs         |
 
 [manifest]: https://github.com/halildurmus/win32/blob/main/examples/manifest
 [service_manager_cli]: https://github.com/halildurmus/win32/blob/main/examples/service_manager_cli
 [credentials.dart]: https://github.com/halildurmus/win32/blob/main/examples/credentials.dart
 [dump.dart]: https://github.com/halildurmus/win32/blob/main/examples/dump.dart
 [dynamic_load.dart]: https://github.com/halildurmus/win32/blob/main/examples/dynamic_load.dart
+[fileinfo.dart]: https://github.com/halildurmus/win32/blob/main/examples/fileinfo.dart
 [filever.dart]: https://github.com/halildurmus/win32/blob/main/examples/filever.dart
 [modules.dart]: https://github.com/halildurmus/win32/blob/main/examples/modules.dart
 [pipe.dart]: https://github.com/halildurmus/win32/blob/main/examples/pipe.dart

--- a/packages/win32/lib/src/structs.g.dart
+++ b/packages/win32/lib/src/structs.g.dart
@@ -10287,6 +10287,27 @@ base class WAVEOUTCAPS extends Struct {
   external int dwSupport;
 }
 
+/// Contains attribute information for a file or directory. The
+/// GetFileAttributesEx function uses this structure.
+///
+/// {@category struct}
+base class WIN32_FILE_ATTRIBUTE_DATA extends Struct {
+  @Uint32()
+  external int dwFileAttributes;
+
+  external FILETIME ftCreationTime;
+
+  external FILETIME ftLastAccessTime;
+
+  external FILETIME ftLastWriteTime;
+
+  @Uint32()
+  external int nFileSizeHigh;
+
+  @Uint32()
+  external int nFileSizeLow;
+}
+
 /// Contains information about the file that is found by the FindFirstFile,
 /// FindFirstFileEx, or FindNextFile function.
 ///


### PR DESCRIPTION
## Description

Add the `WIN32_FILE_ATTRIBUTE_DATA` struct

## Related Issue

<!--- Put an `x` in all the boxes that apply: -->

- [X] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [ ] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [ ] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [ ] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [ ] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [ ] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
