### PR TITLE
chore(release): `package:win32` v6.0.0

### DIFF
--- a/examples/explorer/lib/main.dart
+++ b/examples/explorer/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:ffi/ffi.dart';
+import 'package:ffi_leak_tracker/ffi_leak_tracker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
@@ -8,7 +9,11 @@ import 'volumepanel.dart';
 import 'windowroundingselector.dart';
 
 void main() {
+  LeakTracker.enableInDebug();
+
   runApp(const ExplorerApp());
+
+  LeakTracker.verifyNoLeaksInDebug();
 }
 
 class ExplorerApp extends StatelessWidget {

--- a/examples/explorer/pubspec.yaml
+++ b/examples/explorer/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
 
 dependencies:
   ffi: ^2.2.0
+  ffi_leak_tracker: ^0.1.0
   flutter:
     sdk: flutter
   font_awesome_flutter: ^10.12.0

--- a/examples/task_manager/lib/main.dart
+++ b/examples/task_manager/lib/main.dart
@@ -1,16 +1,15 @@
 import 'package:ffi_leak_tracker/ffi_leak_tracker.dart';
 import 'package:flutter/material.dart';
-import 'package:win32/win32.dart';
 
 import 'models.dart';
 import 'task_service.dart';
 
 void main() {
-  LeakTracker.enable();
+  LeakTracker.enableInDebug();
 
   runApp(const TaskManagerApp());
 
-  reportMemoryLeaks();
+  LeakTracker.verifyNoLeaksInDebug();
 }
 
 class TaskManagerApp extends StatelessWidget {

--- a/examples/task_manager/pubspec.yaml
+++ b/examples/task_manager/pubspec.yaml
@@ -7,8 +7,7 @@ environment:
 
 dependencies:
   ffi: ^2.2.0
-  ffi_leak_tracker:
-    path: ../../packages/ffi_leak_tracker # TODO: update to ^0.1.0 when released
+  ffi_leak_tracker: ^0.1.0
   flutter:
     sdk: flutter
   win32:

--- a/packages/win32/CHANGELOG.md
+++ b/packages/win32/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [6.0.0] - 2026-02-X
+## [6.0.0] - 2026-02-22
 
 ### 🔄 Breaking Changes
 

--- a/website/docs/advanced/leak-tracking.md
+++ b/website/docs/advanced/leak-tracking.md
@@ -2,9 +2,9 @@
 title: Leak Tracking
 ---
 
-[`package:ffi_leak_tracker`][package:ffi_leak_tracker] provides
-helps you find and diagnose native memory leaks in Dart FFI code by tracking
-allocations made through its custom allocators.
+[`package:ffi_leak_tracker`][package:ffi_leak_tracker] helps you find and
+diagnose native memory leaks in Dart FFI code by tracking allocations made
+through its custom allocators.
 
 It is designed to answer one question precisely:
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the
  title.

  Please look at the following checklist to ensure that your PR can be accepted
  quickly:
-->

## Description

This release introduces a **major redesign of the Win32 Dart API** with a strong focus on **type safety**, **deterministic resource management**, and **idiomatic Dart usage**. Most changes are mechanical but widespread.

Key breaking changes include:

- **Exception-based error handling**
  - APIs returning `HRESULT` now throw `WindowsException` on failure
  - Logical return values are returned directly instead of via out-parameters

- **New error model for APIs that call `SetLastError()`**
  - Such APIs now return `Win32Result<T>` which captures both the logical return value and the associated last-error code atomically on the native side, ensuring the **error state is preserved**

- **Strongly typed Win32 handles**
  - Opaque handles (e.g., `HKEY`, `HWND`, `HICON`) are now extension types instead of plain `int` or `Pointer` values

- **Win32 `BOOL` mapped to Dart `bool`**
  - Applies uniformly to return values, parameters, and struct fields

- **Enums are now extension types**
  - Replaces raw `int` constants with strongly typed extension types

- **Explicit COM lifetime management**
  - Automatic cleanup via `Finalizer` has been removed
  - COM objects must be released explicitly or managed with `Arena`

- **COM and `HRESULT` API simplifications**
  - `QueryInterface`-style methods now return interfaces directly
  - Manual `HRESULT` checks and pointer plumbing are eliminated

- **Major string API cleanup**
  - Renamed and simplified string conversion helpers
  - Removed `TEXT()`, `BSTR` class, and legacy helpers

- **GUID API redesign**
  - Removed `Guid` class and string-based helpers
  - `GUID` struct is now the single, explicit representation

- **`winsock2` library removed**
  - All Winsock APIs are now exported directly from `win32.dart`

- **Dispatcher API redesign**
  - Strongly typed results
  - No manual `VARIANT` or `DISPPARAMS` construction
  - Explicit ownership and cleanup

> See the [**Migration Guide**](https://win32.pub/docs/migration/5xx-to-6xx) with examples and mechanical migration steps.

### 🚀 Features

- **Scope-based lifetime management**
  - New extensions for `Arena` to manage native memory and COM lifetimes

- **Much stronger type safety across the API surface**
  - Typed handles, enums, booleans, GUIDs, and COM interfaces

- **More idiomatic Dart APIs**
  - Fewer pointers, fewer out-parameters, clearer ownership rules

- **Reliable error handling**
  - Atomic capture of `GetLastError()` values on native side, exposed via
    `Win32Result<T>`

- **Cleaner, more consistent conversion APIs**
  - Unified naming and semantics for strings, binary data, and `FILETIME` values

- **Native memory leak detection** via [package:ffi_leak_tracker]
  - Tracks allocations with call stacks and timestamps; see the [**Leak Tracking**](https://win32.pub/docs/advanced/leak-tracking) guide for details

[package:ffi_leak_tracker]: https://pub.dev/packages/ffi_leak_tracker

## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [ ] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [ ] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [ ] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [ ] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [ ] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
