### PR TITLE
perf(winmd): optimize reader

### DIFF
--- a/packages/winmd/lib/src/reader/blob.dart
+++ b/packages/winmd/lib/src/reader/blob.dart
@@ -24,7 +24,10 @@ import 'metadata_index.dart';
 final class Blob {
   /// Constructs a [Blob] with the specified [metadataIndex], [readerIndex],
   /// and byte [slice].
-  Blob(this.metadataIndex, this.readerIndex, this.slice);
+  Blob(this.metadataIndex, this.readerIndex, Uint8List slice)
+    : _slice = slice,
+      _byteData = slice.buffer.asByteData(),
+      _baseOffset = slice.offsetInBytes;
 
   /// The metadata index that provides contextual information for interpreting
   /// the blob.
@@ -33,22 +36,27 @@ final class Blob {
   /// The index of the reader in the [metadataIndex].
   final int readerIndex;
 
+  final Uint8List _slice;
+  final ByteData _byteData;
+  final int _baseOffset;
+  var _pos = 0;
+
   /// The slice of raw byte data that represents the contents of the blob.
-  Uint8List slice;
+  Uint8List get slice => .sublistView(_slice, _pos);
 
   /// Whether the blob is fully read (i.e., the [slice] is empty).
   @pragma('vm:prefer-inline')
-  bool get isEmpty => slice.isEmpty;
+  bool get isEmpty => _pos >= _slice.length;
 
   /// The current length of the [slice], i.e., the number of remaining bytes to
   /// read.
   @pragma('vm:prefer-inline')
-  int get length => slice.length;
+  int get length => _slice.length - _pos;
 
   /// Allows direct access to the elements in the [slice] by index, similar to
   /// a list.
   @pragma('vm:prefer-inline')
-  int operator [](int index) => slice[index];
+  int operator [](int index) => _slice[_pos + index];
 
   /// Decodes a value of type [T] using the provided decoder function.
   T decode<T extends CodedIndex>() {
@@ -63,9 +71,18 @@ final class Blob {
   /// `true`.
   /// Otherwise, it returns `false` and leaves the [slice] unchanged.
   bool tryRead(int expected) {
-    final CompressedInteger(:value, :bytesRead) = .decode(slice);
+    if (expected < 0x80) {
+      // Fast path: all common element-type tokens (BYREF, VOID, SZARRAY, PTR,
+      // CMOD_OPT, CMOD_REQD, ...) are < 0x80 and encode as a single byte.
+      if (_slice[_pos] == expected) {
+        _pos++;
+        return true;
+      }
+      return false;
+    }
+    final CompressedInteger(:value, :bytesRead) = .decode(_slice, _pos);
     if (value == expected) {
-      _offset(bytesRead);
+      _pos += bytesRead;
       return true;
     }
     return false;
@@ -127,7 +144,9 @@ final class Blob {
 
   /// Reads either a `FieldSig` or a `MethodRefSig` from the blob.
   MemberRefSignature readMemberRefSignature() {
-    if (slice[0] == CallingConvention.FIELD) return FieldSig(readFieldSig());
+    if (_slice[_pos] == CallingConvention.FIELD) {
+      return FieldSig(readFieldSig());
+    }
     return readMethodRefSig();
   }
 
@@ -187,16 +206,18 @@ final class Blob {
 
   /// Reads modifier tokens and decodes them into a list of [TypeDefOrRef].
   List<TypeDefOrRef> readModifiers() {
-    final mods = <TypeDefOrRef>[];
-    while (true) {
-      final CompressedInteger(:value, :bytesRead) = .decode(slice);
-      if (value != ELEMENT_TYPE_CMOD_OPT && value != ELEMENT_TYPE_CMOD_REQD) {
-        break;
-      } else {
-        _offset(bytesRead);
-        mods.add(.decode(metadataIndex, readerIndex, readCompressed()));
-      }
+    // Fast path: the vast majority of signatures have no modifiers.
+    // CMOD_REQD (31) and CMOD_OPT (32) are both < 0x80 → encoded as 1 byte.
+    final byte = _slice[_pos];
+    if (byte != ELEMENT_TYPE_CMOD_OPT && byte != ELEMENT_TYPE_CMOD_REQD) {
+      return const [];
     }
+    final mods = <TypeDefOrRef>[];
+    do {
+      _pos++; // consume the 1-byte CMOD tag
+      mods.add(.decode(metadataIndex, readerIndex, readCompressed()));
+    } while (_slice[_pos] == ELEMENT_TYPE_CMOD_OPT ||
+        _slice[_pos] == ELEMENT_TYPE_CMOD_REQD);
     return UnmodifiableListView(mods);
   }
 
@@ -223,7 +244,7 @@ final class Blob {
 
   /// Reads either a `LocalVarSig` or a `StandAloneMethodSig` from the blob.
   StandAloneSignature readStandAloneSignature() {
-    if (slice[0] == CallingConvention.LOCAL_SIG) {
+    if (_slice[_pos] == CallingConvention.LOCAL_SIG) {
       final prolog = readUint8();
       assert(
         prolog == CallingConvention.LOCAL_SIG,
@@ -380,8 +401,8 @@ final class Blob {
 
   /// Reads a compressed integer from the blob.
   int readCompressed() {
-    final CompressedInteger(:value, :bytesRead) = .decode(slice);
-    _offset(bytesRead);
+    final CompressedInteger(:value, :bytesRead) = .decode(_slice, _pos);
+    _pos += bytesRead;
     return value;
   }
 
@@ -394,133 +415,104 @@ final class Blob {
 
   /// Reads a signed 8-bit integer.
   int readInt8() {
-    final value = slice.buffer.asByteData().getInt8(slice.offsetInBytes);
-    _offset(1);
+    final value = _byteData.getInt8(_baseOffset + _pos);
+    _pos++;
     return value;
   }
 
   /// Reads an unsigned 8-bit integer.
   int readUint8() {
-    final value = slice[0];
-    _offset(1);
+    final value = _slice[_pos];
+    _pos++;
     return value;
   }
 
   /// Reads a signed 16-bit integer.
   int readInt16() {
-    final value = slice.buffer.asByteData().getInt16(
-      slice.offsetInBytes,
-      .little,
-    );
-    _offset(2);
+    final value = _byteData.getInt16(_baseOffset + _pos, .little);
+    _pos += 2;
     return value;
   }
 
   /// Reads an unsigned 16-bit integer.
   int readUint16() {
-    final value = slice.buffer.asByteData().getUint16(
-      slice.offsetInBytes,
-      .little,
-    );
-    _offset(2);
+    final value = _byteData.getUint16(_baseOffset + _pos, .little);
+    _pos += 2;
     return value;
   }
 
   /// Reads a signed 32-bit integer.
   int readInt32() {
-    final value = slice.buffer.asByteData().getInt32(
-      slice.offsetInBytes,
-      .little,
-    );
-    _offset(4);
+    final value = _byteData.getInt32(_baseOffset + _pos, .little);
+    _pos += 4;
     return value;
   }
 
   /// Reads an unsigned 32-bit integer.
   int readUint32() {
-    final value = slice.buffer.asByteData().getUint32(
-      slice.offsetInBytes,
-      .little,
-    );
-    _offset(4);
+    final value = _byteData.getUint32(_baseOffset + _pos, .little);
+    _pos += 4;
     return value;
   }
 
   /// Reads a signed 64-bit integer.
   int readInt64() {
-    final value = slice.buffer.asByteData().getInt64(
-      slice.offsetInBytes,
-      .little,
-    );
-    _offset(8);
+    final value = _byteData.getInt64(_baseOffset + _pos, .little);
+    _pos += 8;
     return value;
   }
 
   /// Reads an unsigned 64-bit integer.
   int readUint64() {
-    final value = slice.buffer.asByteData().getUint64(
-      slice.offsetInBytes,
-      .little,
-    );
-    _offset(8);
+    final value = _byteData.getUint64(_baseOffset + _pos, .little);
+    _pos += 8;
     return value;
   }
 
   /// Reads a 32-bit floating point number.
   double readFloat32() {
-    final value = slice.buffer.asByteData().getFloat32(
-      slice.offsetInBytes,
-      .little,
-    );
-    _offset(4);
+    final value = _byteData.getFloat32(_baseOffset + _pos, .little);
+    _pos += 4;
     return value;
   }
 
   /// Reads a 64-bit floating point number.
   double readFloat64() {
-    final value = slice.buffer.asByteData().getFloat64(
-      slice.offsetInBytes,
-      .little,
-    );
-    _offset(8);
+    final value = _byteData.getFloat64(_baseOffset + _pos, .little);
+    _pos += 8;
     return value;
   }
 
   /// Reads a UTF-8 encoded string.
   String readUtf8() {
     final length = readCompressed();
-    final stringBytes = Uint8List.sublistView(slice, 0, length);
+    final stringBytes = Uint8List.sublistView(_slice, _pos, _pos + length);
     final value = utf8.decode(stringBytes);
-    _offset(length);
+    _pos += length;
     return value;
   }
 
   /// Reads a UTF-16 encoded string.
   String readUtf16() {
-    final stringLength = length ~/ 2;
+    final totalBytes = _slice.length - _pos;
+    final stringLength = totalBytes ~/ 2;
     final Uint16List stringBytes;
-    if (slice.offsetInBytes.isEven) {
+    if ((_baseOffset + _pos).isEven) {
       // If aligned, directly use asUint16List for efficiency.
-      stringBytes = slice.buffer.asUint16List(
-        slice.offsetInBytes,
+      stringBytes = _slice.buffer.asUint16List(
+        _baseOffset + _pos,
         stringLength,
       );
     } else {
       // If unaligned, manually decode UTF-16.
       stringBytes = .new(stringLength);
       for (var i = 0; i < stringLength; i++) {
-        final low = slice[i * 2];
-        final high = slice[i * 2 + 1];
-        stringBytes[i] = low | (high << 8);
+        stringBytes[i] = _slice[_pos + i * 2] | (_slice[_pos + i * 2 + 1] << 8);
       }
     }
-    _offset(length);
+    _pos += totalBytes;
     return .fromCharCodes(stringBytes);
   }
-
-  /// Updates the slice to a view that skips the first [offset] bytes.
-  @pragma('vm:prefer-inline')
-  void _offset(int offset) => slice = .sublistView(slice, offset);
 
   @override
   String toString() => slice.toString();

--- a/packages/winmd/lib/src/reader/extensions.dart
+++ b/packages/winmd/lib/src/reader/extensions.dart
@@ -9,16 +9,11 @@ extension Uint8ListExtension on Uint8List {
   ///
   /// The resulting string is returned.
   String readString(int offset) {
-    final buffer = StringBuffer();
-    var i = 0;
-
-    // Read the array until the null terminator is encountered.
-    while (true) {
-      final char = this[offset + i];
-      if (char == 0) return buffer.toString();
-      buffer.writeCharCode(char);
-      i++;
+    var end = offset;
+    while (this[end] != 0) {
+      end++;
     }
+    return .fromCharCodes(this, offset, end);
   }
 
   /// Reads an unsigned 8-bit integer at the given [offset].

--- a/packages/winmd/lib/src/reader/has_custom_attributes.dart
+++ b/packages/winmd/lib/src/reader/has_custom_attributes.dart
@@ -13,6 +13,10 @@ base mixin HasCustomAttributes on Row {
     HasCustomAttribute(this).encode(),
   ).toList(growable: false);
 
+  late final Map<String, CustomAttribute> _attributeMap = {
+    for (final attribute in attributes) attribute.name: attribute,
+  };
+
   /// Retrieves the first argument of the custom attribute with the given
   /// [attributeName], if it is a string.
   ///
@@ -29,20 +33,19 @@ base mixin HasCustomAttributes on Row {
     return null;
   }
 
-  /// Finds the first [CustomAttribute] with the specified [name].
+  /// Finds a custom attribute with the specified [name].
   ///
   /// Throws a [WinmdException] if no matching attribute is found.
   CustomAttribute findAttribute(String name) =>
-      attributes.where((attr) => attr.name == name).firstOrNull ??
+      _attributeMap[name] ??
       (throw WinmdException('Attribute not found: $name'));
 
-  /// Attempts to find the first [CustomAttribute] with the specified [name].
+  /// Attempts to find a custom attribute with the specified [name].
   ///
   /// Returns `null` if no matching attribute is found.
-  CustomAttribute? tryFindAttribute(String name) =>
-      attributes.where((attr) => attr.name == name).firstOrNull;
+  CustomAttribute? tryFindAttribute(String name) => _attributeMap[name];
 
-  /// Determines whether an attribute with the specified [name] is attached to
-  /// this row.
-  bool hasAttribute(String name) => tryFindAttribute(name) != null;
+  /// Determines whether a custom attribute with the specified [name] is
+  /// attached to this row.
+  bool hasAttribute(String name) => _attributeMap.containsKey(name);
 }

--- a/packages/winmd/lib/src/reader/heap/blob.dart
+++ b/packages/winmd/lib/src/reader/heap/blob.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:typed_data';
 
 import '../../compressed_integer.dart';
@@ -6,23 +7,22 @@ import 'metadata_heap.dart';
 /// Provides indexed access to the `#Blob` heap in a metadata file.
 final class BlobHeap extends MetadataHeap {
   /// Creates a [BlobHeap] from the provided binary [data].
-  const BlobHeap(super.data);
+  BlobHeap(super.data);
+
+  final _cache = HashMap<int, Uint8List>();
 
   /// The number of blobs in the heap.
-  int get count {
-    var count = 0;
+  late final int count = () {
+    var n = 0;
     var offset = 0;
-
     while (offset < data.length) {
       try {
         final CompressedInteger(:value, :bytesRead) = .decode(data, offset);
         final totalSize = bytesRead + value;
         final nextOffset = offset + totalSize;
         if (totalSize == 0 || nextOffset > data.length) break;
-        count++;
+        n++;
         offset = nextOffset;
-
-        // Skip padded zeroes.
         while (offset < data.length && data[offset] == 0) {
           offset++;
         }
@@ -30,9 +30,8 @@ final class BlobHeap extends MetadataHeap {
         break;
       }
     }
-
-    return count;
-  }
+    return n;
+  }();
 
   /// Enumerates all blobs in the heap.
   Iterable<Uint8List> get blobs sync* {
@@ -64,7 +63,14 @@ final class BlobHeap extends MetadataHeap {
       offset >= 0 && offset < data.length,
       'Offset $offset out of bounds.',
     );
+    if (_cache[offset] case final cached?) return cached;
     final CompressedInteger(:value, :bytesRead) = .decode(data, offset);
-    return .sublistView(data, offset + bytesRead, offset + value + bytesRead);
+    final blob = Uint8List.sublistView(
+      data,
+      offset + bytesRead,
+      offset + value + bytesRead,
+    );
+    _cache[offset] = blob;
+    return blob;
   }
 }

--- a/packages/winmd/lib/src/reader/heap/guid.dart
+++ b/packages/winmd/lib/src/reader/heap/guid.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:typed_data';
 
 import '../../guid.dart';
@@ -6,7 +7,9 @@ import 'metadata_heap.dart';
 /// Provides indexed access to the `#GUID` heap in a metadata file.
 final class GuidHeap extends MetadataHeap {
   /// Creates a [GuidHeap] from the provided binary [data].
-  const GuidHeap(super.data);
+  GuidHeap(super.data);
+
+  final _cache = HashMap<int, Guid>();
 
   /// The number of GUIDs stored in this heap.
   int get count => data.length ~/ 16;
@@ -26,11 +29,14 @@ final class GuidHeap extends MetadataHeap {
       offset >= 0 && offset < data.length,
       'Offset $offset out of bounds.',
     );
+    if (_cache[offset] case final cached?) return cached;
     final byteData = ByteData.sublistView(data, offset, offset + 8);
-    final data1 = byteData.getUint32(0, Endian.little);
-    final data2 = byteData.getUint16(4, Endian.little);
-    final data3 = byteData.getUint16(6, Endian.little);
+    final data1 = byteData.getUint32(0, .little);
+    final data2 = byteData.getUint16(4, .little);
+    final data3 = byteData.getUint16(6, .little);
     final data4 = Uint8List.sublistView(data, offset + 8, offset + 16);
-    return .new(data1, data2, data3, data4.asUnmodifiableView());
+    final guid = Guid(data1, data2, data3, data4.asUnmodifiableView());
+    _cache[offset] = guid;
+    return guid;
   }
 }

--- a/packages/winmd/lib/src/reader/heap/string.dart
+++ b/packages/winmd/lib/src/reader/heap/string.dart
@@ -1,37 +1,34 @@
+import 'dart:collection';
+
 import 'metadata_heap.dart';
 
 /// Provides indexed access to the `#Strings` heap in a metadata file.
 final class StringHeap extends MetadataHeap {
   /// Creates a [StringHeap] from the provided binary [data].
-  const StringHeap(super.data);
+  StringHeap(super.data);
+
+  final _cache = HashMap<int, String>();
 
   /// The number of strings in the heap.
-  int get count {
-    var count = 0;
+  late final int count = () {
+    var n = 0;
     var offset = 0;
-
     while (offset < data.length) {
       while (offset < data.length && data[offset] != 0) {
         offset++;
       }
-
-      // Found a null terminator → valid string
       if (offset < data.length) {
-        count++;
-        offset++; // Skip null terminator
+        n++;
+        offset++;
       } else {
-        // If no null terminator, likely corrupted or incomplete
         break;
       }
-
-      // Skip padded zeroes
       while (offset < data.length && data[offset] == 0) {
         offset++;
       }
     }
-
-    return count;
-  }
+    return n;
+  }();
 
   /// Enumerates all strings in the heap.
   Iterable<String> get strings sync* {
@@ -47,8 +44,8 @@ final class StringHeap extends MetadataHeap {
 
       if (offset >= data.length) break;
 
-      // Extract the string from the start to the null terminator.
-      yield this[start];
+      // Decode inline (avoids a second null-terminator scan via operator[]).
+      yield .fromCharCodes(data, start, offset);
 
       offset++; // Skip null terminator.
 
@@ -65,15 +62,16 @@ final class StringHeap extends MetadataHeap {
       offset >= 0 && offset < data.length,
       'Offset $offset out of bounds.',
     );
-    final buffer = StringBuffer();
-    var i = 0;
+    if (_cache[offset] case final cached?) return cached;
 
-    // Read the array until the null terminator is encountered.
-    while (true) {
-      final char = data[offset + i];
-      if (char == 0) return buffer.toString();
-      buffer.writeCharCode(char);
-      i++;
+    // Find the null terminator.
+    var end = offset;
+    while (data[end] != 0) {
+      end++;
     }
+
+    final string = String.fromCharCodes(data, offset, end);
+    _cache[offset] = string;
+    return string;
   }
 }

--- a/packages/winmd/lib/src/reader/heap/user_string.dart
+++ b/packages/winmd/lib/src/reader/heap/user_string.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:typed_data';
 
 import '../../compressed_integer.dart';
@@ -6,21 +7,21 @@ import 'metadata_heap.dart';
 /// Provides indexed access to the `#US` heap in a metadata file.
 final class UserStringHeap extends MetadataHeap {
   /// Creates a [UserStringHeap] from the provided binary [data].
-  const UserStringHeap(super.data);
+  UserStringHeap(super.data);
+
+  final _cache = HashMap<int, String>();
 
   /// The number of user-defined strings in the heap.
-  int get count {
-    var count = 0;
+  late final int count = () {
+    var n = 0;
     var offset = 0;
     while (offset < data.length) {
       try {
         final CompressedInteger(:value, :bytesRead) = .decode(data, offset);
         final totalBytes = value + bytesRead;
-        if (totalBytes == 0) break; // Prevent infinite loop on malformed input.
-        count++;
+        if (totalBytes == 0) break;
+        n++;
         offset += totalBytes;
-
-        // Skip padded zeroes
         while (offset < data.length && data[offset] == 0) {
           offset++;
         }
@@ -28,8 +29,8 @@ final class UserStringHeap extends MetadataHeap {
         break;
       }
     }
-    return count;
-  }
+    return n;
+  }();
 
   /// Enumerates all user-defined strings in the heap.
   Iterable<String> get userStrings sync* {
@@ -39,10 +40,8 @@ final class UserStringHeap extends MetadataHeap {
         yield this[offset];
         final CompressedInteger(:value, :bytesRead) = .decode(data, offset);
         final totalBytes = value + bytesRead;
-        if (totalBytes == 0) break; // Prevent infinite loop on malformed input.
+        if (totalBytes == 0) break;
         offset += totalBytes;
-
-        // Skip padded zeroes
         while (offset < data.length && data[offset] == 0) {
           offset++;
         }
@@ -58,12 +57,13 @@ final class UserStringHeap extends MetadataHeap {
       offset >= 0 && offset < data.length,
       'Offset $offset out of bounds.',
     );
+    if (_cache[offset] case final cached?) return cached;
     final CompressedInteger(:value, :bytesRead) = .decode(data, offset);
     assert(
       value.isOdd || value == 0,
       'Expected payload size to be an odd number or zero, but got: $value',
     );
-    if (value == 0) return '';
+    if (value == 0) return _cache[offset] = '';
     final stringBytes = ByteData.sublistView(
       data,
       offset + bytesRead,
@@ -71,8 +71,8 @@ final class UserStringHeap extends MetadataHeap {
     );
     final charCodes = List.generate(
       stringBytes.lengthInBytes ~/ 2,
-      (i) => stringBytes.getUint16(i * 2, Endian.little),
+      (i) => stringBytes.getUint16(i * 2, .little),
     );
-    return .fromCharCodes(charCodes);
+    return _cache[offset] = .fromCharCodes(charCodes);
   }
 }

--- a/packages/winmd/lib/src/reader/metadata_index.dart
+++ b/packages/winmd/lib/src/reader/metadata_index.dart
@@ -50,7 +50,7 @@ import 'table/type_spec.dart';
 final class MetadataIndex {
   /// Creates a [MetadataIndex] from a single [MetadataReader].
   factory MetadataIndex.fromReader(MetadataReader reader) =>
-      MetadataIndex.fromReaders([reader]);
+      .fromReaders([reader]);
 
   /// Creates a [MetadataIndex] from a list of [MetadataReader]s.
   ///
@@ -58,15 +58,16 @@ final class MetadataIndex {
   /// for type definitions and nested types. If multiple readers are provided,
   /// they are indexed by order of appearance.
   factory MetadataIndex.fromReaders(List<MetadataReader> readers) {
-    final namespaceToTypeMap =
-        HashMap<String, HashMap<String, List<_ReaderAndTypeDefIndex>>>();
-    final nestedTypeMap = HashMap<_ReaderAndTypeDefIndex, List<int>>();
+    final namespaceToTypeMap = HashMap<String, HashMap<String, List<int>>>();
+    final nestedTypeMap = HashMap<int, List<int>>();
     const nestedClassTable = MetadataTable.nestedClass;
     const typeDefTable = MetadataTable.typeDef;
 
     for (var readerIndex = 0; readerIndex < readers.length; readerIndex++) {
       final reader = readers[readerIndex];
       final tableStream = reader.tableStream;
+      // Pre-compute the reader base so we avoid a shift per entry.
+      final packedReaderBase = readerIndex << 32;
 
       for (final typeDefIndex in tableStream.typeDef) {
         final namespace = reader.readString(typeDefIndex, typeDefTable, 2);
@@ -78,14 +79,14 @@ final class MetadataIndex {
         namespaceToTypeMap
             .putIfAbsent(namespace, HashMap.new)
             .putIfAbsent(name, () => [])
-            .add(.new(readerIndex, typeDefIndex));
+            .add(packedReaderBase | typeDefIndex);
       }
 
       for (final nestedClass in tableStream.nestedClass) {
         final inner = reader.readUint(nestedClass, nestedClassTable, 0) - 1;
         final outer = reader.readUint(nestedClass, nestedClassTable, 1) - 1;
         nestedTypeMap
-            .putIfAbsent(.new(readerIndex, outer), () => [])
+            .putIfAbsent(packedReaderBase | outer, () => [])
             .add(inner);
       }
     }
@@ -106,14 +107,13 @@ final class MetadataIndex {
   /// The list of metadata readers contributing to this index.
   final List<MetadataReader> readers;
 
-  final HashMap<String, HashMap<String, List<_ReaderAndTypeDefIndex>>>
-  _namespaceToTypeMap;
-  final HashMap<_ReaderAndTypeDefIndex, List<int>> _nestedTypeMap;
+  final HashMap<String, HashMap<String, List<int>>> _namespaceToTypeMap;
+  final HashMap<int, List<int>> _nestedTypeMap;
 
   /// Enumerates all [TypeDef]s available in this index.
   Iterable<TypeDef> get allTypes => _namespaceToTypeMap.values.expand(
     (namespace) => namespace.values.expand(
-      (types) => types.map((e) => .new(this, e.readerIndex, e.typeDefIndex)),
+      (types) => types.map((e) => .new(this, e >> 32, e & 0xFFFFFFFF)),
     ),
   );
 
@@ -127,22 +127,25 @@ final class MetadataIndex {
     return e.value.entries.expand((e) {
       final name = e.key;
       return e.value.map(
-        (e) => (namespace, name, .new(this, e.readerIndex, e.typeDefIndex)),
+        (e) => (namespace, name, .new(this, e >> 32, e & 0xFFFFFFFF)),
       );
     });
   });
 
   /// Enumerates the nested types defined under the given [parent] type.
-  Iterable<TypeDef> nestedTypes(TypeDef parent) =>
-      _nestedTypeMap[_ReaderAndTypeDefIndex(parent.readerIndex, parent.index)]
-          ?.map((index) => .new(this, parent.readerIndex, index)) ??
-      const Iterable.empty();
+  Iterable<TypeDef> nestedTypes(TypeDef parent) {
+    final key = (parent.readerIndex << 32) | parent.index;
+    return _nestedTypeMap[key]?.map(
+          (index) => .new(this, parent.readerIndex, index),
+        ) ??
+        const .empty();
+  }
 
   /// Enumerates all [TypeDef] instances matching the given [namespace] and
   /// [name].
   Iterable<TypeDef> findTypes(String namespace, String name) =>
       _namespaceToTypeMap[namespace]?[name]?.map(
-        (e) => .new(this, e.readerIndex, e.typeDefIndex),
+        (e) => .new(this, e >> 32, e & 0xFFFFFFFF),
       ) ??
       const .empty();
 
@@ -152,13 +155,14 @@ final class MetadataIndex {
   /// - No types are found for the specified namespace and name.
   /// - More than one type is found, indicating ambiguity.
   TypeDef findSingleType(String namespace, String name) {
-    final types = findTypes(namespace, name).toList(growable: false);
-    if (types.isEmpty) {
+    final list = _namespaceToTypeMap[namespace]?[name];
+    if (list == null || list.isEmpty) {
       throw WinmdException('Type not found: $namespace.$name');
-    } else if (types.length > 1) {
+    } else if (list.length > 1) {
       throw WinmdException('More than one type found: $namespace.$name');
     }
-    return types[0];
+    final e = list[0];
+    return .new(this, e >> 32, e & 0xFFFFFFFF);
   }
 
   /// Attempts to find a single [TypeDef] matching the given [namespace] and
@@ -166,9 +170,10 @@ final class MetadataIndex {
   ///
   /// Returns `null` if no types are found, or more than one type is found.
   TypeDef? tryFindSingleType(String namespace, String name) {
-    final types = findTypes(namespace, name).toList(growable: false);
-    if (types.isEmpty || types.length > 1) return null;
-    return types[0];
+    final list = _namespaceToTypeMap[namespace]?[name];
+    if (list == null || list.isEmpty || list.length > 1) return null;
+    final e = list[0];
+    return .new(this, e >> 32, e & 0xFFFFFFFF);
   }
 
   /// Enumerates all [Assembly] entries across all readers.
@@ -386,21 +391,4 @@ final class MetadataIndex {
   String toString() =>
       'MetadataIndex(readers: ${readers.length}, '
       'namespaces: ${_namespaceToTypeMap.length})';
-}
-
-final class _ReaderAndTypeDefIndex {
-  const _ReaderAndTypeDefIndex(this.readerIndex, this.typeDefIndex);
-
-  final int readerIndex;
-  final int typeDefIndex;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is _ReaderAndTypeDefIndex &&
-          readerIndex == other.readerIndex &&
-          typeDefIndex == other.typeDefIndex;
-
-  @override
-  int get hashCode => Object.hash(readerIndex, typeDefIndex);
 }

--- a/packages/winmd/lib/src/reader/metadata_lookup.dart
+++ b/packages/winmd/lib/src/reader/metadata_lookup.dart
@@ -16,12 +16,16 @@ final class MetadataLookup {
     final constants = HashMap<String, HashMap<String, Field>>();
     final functions = HashMap<String, HashMap<String, MethodDef>>();
     final types = HashMap<String, HashMap<String, List<TypeDef>>>();
+    final constantsByName = HashMap<String, Field>();
+    final functionsByName = HashMap<String, MethodDef>();
+    final typesByName = HashMap<String, List<TypeDef>>();
 
     for (final (namespace, name, type) in index.namespaceTypeEntries) {
       types
           .putIfAbsent(namespace, HashMap.new)
           .putIfAbsent(name, () => [])
           .add(type);
+      typesByName.putIfAbsent(name, () => []).add(type);
 
       if (!type.flags.has(TypeAttributes.windowsRuntime)) {
         switch (type.category) {
@@ -30,11 +34,13 @@ final class MetadataLookup {
               functions
                   .putIfAbsent(namespace, HashMap.new)
                   .putIfAbsent(method.name, () => method);
+              functionsByName.putIfAbsent(method.name, () => method);
             }
             for (final field in type.fields) {
               constants
                   .putIfAbsent(namespace, HashMap.new)
                   .putIfAbsent(field.name, () => field);
+              constantsByName.putIfAbsent(field.name, () => field);
             }
 
           case .enum$ when !type.hasAttribute('ScopedEnumAttribute'):
@@ -43,6 +49,7 @@ final class MetadataLookup {
                 constants
                     .putIfAbsent(namespace, HashMap.new)
                     .putIfAbsent(field.name, () => field);
+                constantsByName.putIfAbsent(field.name, () => field);
               }
             }
 
@@ -51,7 +58,15 @@ final class MetadataLookup {
       }
     }
 
-    return MetadataLookup._(index, constants, functions, types);
+    return MetadataLookup._(
+      index,
+      constants,
+      functions,
+      types,
+      constantsByName,
+      functionsByName,
+      typesByName,
+    );
   }
 
   MetadataLookup._(
@@ -59,9 +74,10 @@ final class MetadataLookup {
     this.constantIndex,
     this.functionIndex,
     this.typeIndex,
-  ) : _cachedConstantsByName = .new(),
-      _cachedFunctionsByName = .new(),
-      _cachedTypesByName = .new();
+    this._constantsByName,
+    this._functionsByName,
+    this._typesByName,
+  );
 
   /// The underlying [MetadataIndex] from which this lookup was created.
   final MetadataIndex index;
@@ -75,9 +91,9 @@ final class MetadataLookup {
   /// A map of [TypeDef]s indexed by their namespace and name.
   final HashMap<String, HashMap<String, List<TypeDef>>> typeIndex;
 
-  final HashMap<String, Field> _cachedConstantsByName;
-  final HashMap<String, MethodDef> _cachedFunctionsByName;
-  final HashMap<String, List<TypeDef>> _cachedTypesByName;
+  final HashMap<String, Field> _constantsByName;
+  final HashMap<String, MethodDef> _functionsByName;
+  final HashMap<String, List<TypeDef>> _typesByName;
 
   /// Finds a constant by its [namespace] and [name].
   ///
@@ -89,15 +105,9 @@ final class MetadataLookup {
   /// Finds a constant by its [name] across all namespaces.
   ///
   /// Throws a [WinmdException] if the constant is not found.
-  Field findConstantByName(String name) => _cachedConstantsByName.putIfAbsent(
-    name,
-    () => constantIndex.values
-        .expand((namespace) => namespace.values)
-        .firstWhere(
-          (field) => field.name == name,
-          orElse: () => throw WinmdException('Constant not found: $name'),
-        ),
-  );
+  Field findConstantByName(String name) =>
+      _constantsByName[name] ??
+      (throw WinmdException('Constant not found: $name'));
 
   /// Attempts to find a constant by its [namespace] and [name].
   ///
@@ -106,19 +116,7 @@ final class MetadataLookup {
       constantIndex[namespace]?[name];
 
   /// Attempts to find a constant by its [name] across all namespaces.
-  Field? tryFindConstantByName(String name) {
-    if (_cachedConstantsByName[name] case final constant?) return constant;
-
-    final constant = constantIndex.values
-        .expand((namespace) => namespace.values)
-        .where((field) => field.name == name)
-        .firstOrNull;
-    if (constant != null) {
-      _cachedConstantsByName[name] = constant;
-    }
-
-    return constant;
-  }
+  Field? tryFindConstantByName(String name) => _constantsByName[name];
 
   /// Finds a function by its [namespace] and [name].
   ///
@@ -129,15 +127,8 @@ final class MetadataLookup {
 
   /// Finds a function by its [name] across all namespaces.
   MethodDef findFunctionByName(String name) =>
-      _cachedFunctionsByName.putIfAbsent(
-        name,
-        () => functionIndex.values
-            .expand((namespace) => namespace.values)
-            .firstWhere(
-              (method) => method.name == name,
-              orElse: () => throw WinmdException('Function not found: $name'),
-            ),
-      );
+      _functionsByName[name] ??
+      (throw WinmdException('Function not found: $name'));
 
   /// Attempts to find a function by its [namespace] and [name].
   ///
@@ -146,19 +137,7 @@ final class MetadataLookup {
       functionIndex[namespace]?[name];
 
   /// Attempts to find a function by its [name] across all namespaces.
-  MethodDef? tryFindFunctionByName(String name) {
-    if (_cachedFunctionsByName[name] case final function?) return function;
-
-    final function = functionIndex.values
-        .expand((namespace) => namespace.values)
-        .where((method) => method.name == name)
-        .firstOrNull;
-    if (function != null) {
-      _cachedFunctionsByName[name] = function;
-    }
-
-    return function;
-  }
+  MethodDef? tryFindFunctionByName(String name) => _functionsByName[name];
 
   /// Enumerates all [TypeDef] instances matching the given [namespace] and
   /// [name].
@@ -167,14 +146,7 @@ final class MetadataLookup {
 
   /// Finds all [TypeDef] instances matching the [name] across all namespaces.
   Iterable<TypeDef> findTypesByName(String name) =>
-      _cachedTypesByName.putIfAbsent(
-        name,
-        () => typeIndex.values
-            .expand((namespace) => namespace.values)
-            .expand((typeList) => typeList)
-            .where((type) => type.name == name)
-            .toList(growable: false),
-      );
+      _typesByName[name] ?? const .empty();
 
   /// Finds a single [TypeDef] matching the given [namespace] and [name].
   ///
@@ -182,13 +154,13 @@ final class MetadataLookup {
   /// - No types are found for the specified namespace and name.
   /// - More than one type is found, indicating ambiguity.
   TypeDef findSingleType(String namespace, String name) {
-    final types = findTypes(namespace, name).toList();
-    if (types.isEmpty) {
+    final list = typeIndex[namespace]?[name];
+    if (list == null || list.isEmpty) {
       throw WinmdException('Type not found: $namespace.$name');
-    } else if (types.length > 1) {
+    } else if (list.length > 1) {
       throw WinmdException('More than one type found: $namespace.$name');
     }
-    return types[0];
+    return list[0];
   }
 
   /// Finds a single [TypeDef] matching the given [name] across all namespaces.
@@ -197,13 +169,13 @@ final class MetadataLookup {
   /// - No types are found for the specified name.
   /// - More than one type is found, indicating ambiguity.
   TypeDef findSingleTypeByName(String name) {
-    final types = findTypesByName(name).toList(growable: false);
-    if (types.isEmpty) {
+    final list = _typesByName[name];
+    if (list == null || list.isEmpty) {
       throw WinmdException('Type not found: $name');
-    } else if (types.length > 1) {
+    } else if (list.length > 1) {
       throw WinmdException('More than one type found: $name');
     }
-    return types[0];
+    return list[0];
   }
 
   /// Attempts to find a single [TypeDef] matching the given [namespace] and
@@ -211,9 +183,9 @@ final class MetadataLookup {
   ///
   /// Returns `null` if no types are found, or more than one type is found.
   TypeDef? tryFindSingleType(String namespace, String name) {
-    final types = findTypes(namespace, name).toList(growable: false);
-    if (types.isEmpty || types.length > 1) return null;
-    return types[0];
+    final list = typeIndex[namespace]?[name];
+    if (list == null || list.isEmpty || list.length > 1) return null;
+    return list[0];
   }
 
   /// Attempts to find a single [TypeDef] matching the given [name] across all
@@ -221,9 +193,9 @@ final class MetadataLookup {
   ///
   /// Returns `null` if no types are found, or more than one type is found.
   TypeDef? tryFindSingleTypeByName(String name) {
-    final types = findTypesByName(name).toList(growable: false);
-    if (types.isEmpty || types.length > 1) return null;
-    return types[0];
+    final list = _typesByName[name];
+    if (list == null || list.isEmpty || list.length > 1) return null;
+    return list[0];
   }
 
   @override

--- a/packages/winmd/lib/src/reader/metadata_reader.dart
+++ b/packages/winmd/lib/src/reader/metadata_reader.dart
@@ -587,17 +587,20 @@ final class MetadataReader {
     );
   }
 
-  const MetadataReader._(
+  MetadataReader._(
     this.data,
     this.blobHeap,
     this.guidHeap,
     this.stringHeap,
     this.tableStream,
     this.userStringHeap,
-  );
+  ) : _byteData = .sublistView(data);
 
   /// The raw metadata binary data.
   final Uint8List data;
+
+  /// A [ByteData] view on a range of elements of [data].
+  final ByteData _byteData;
 
   /// The heap containing blobs.
   final BlobHeap blobHeap;
@@ -636,16 +639,18 @@ final class MetadataReader {
   String readString(int row, MetadataTable table, int column) =>
       stringHeap[readUint(row, table, column)];
 
-  /// Reads an unsigned integer from the specified [row] and [column] of [table].
+  /// Reads an unsigned integer from the specified [row] and [column] of
+  /// [table].
+  @pragma('vm:prefer-inline')
   int readUint(int row, MetadataTable table, int column) {
     final table$ = tableStream[table];
     final column$ = table$.columns[column];
     final offset = table$.offset + row * table$.width + column$.offset;
     return switch (column$.width) {
-      1 => data.readUint8(offset),
-      2 => data.readUint16(offset),
-      4 => data.readUint32(offset),
-      8 => data.readUint64(offset),
+      1 => _byteData.getUint8(offset),
+      2 => _byteData.getUint16(offset, .little),
+      4 => _byteData.getUint32(offset, .little),
+      8 => _byteData.getUint64(offset, .little),
       _ => throw WinmdException('Invalid column width: ${column$.width}'),
     };
   }
@@ -654,25 +659,34 @@ final class MetadataReader {
   /// [table], with an optional [offset].
   @pragma('vm:prefer-inline')
   int readUint8(int row, MetadataTable table, int column, [int offset = 0]) =>
-      data.readUint8(_calculateOffset(row, table, column) + offset);
+      _byteData.getUint8(_calculateOffset(row, table, column) + offset);
 
   /// Reads an unsigned 16-bit integer from the specified [row] and [column] of
   /// [table], with an optional [offset].
   @pragma('vm:prefer-inline')
   int readUint16(int row, MetadataTable table, int column, [int offset = 0]) =>
-      data.readUint16(_calculateOffset(row, table, column) + offset);
+      _byteData.getUint16(
+        _calculateOffset(row, table, column) + offset,
+        .little,
+      );
 
   /// Reads an unsigned 32-bit integer from the specified [row] and [column] of
   /// [table], with an optional [offset].
   @pragma('vm:prefer-inline')
   int readUint32(int row, MetadataTable table, int column, [int offset = 0]) =>
-      data.readUint32(_calculateOffset(row, table, column) + offset);
+      _byteData.getUint32(
+        _calculateOffset(row, table, column) + offset,
+        .little,
+      );
 
   /// Reads an unsigned 64-bit integer from the specified [row] and [column] of
   /// [table], with an optional [offset].
   @pragma('vm:prefer-inline')
   int readUint64(int row, MetadataTable table, int column, [int offset = 0]) =>
-      data.readUint64(_calculateOffset(row, table, column) + offset);
+      _byteData.getUint64(
+        _calculateOffset(row, table, column) + offset,
+        .little,
+      );
 
   /// Calculates the byte offset for the specified [row], [table], and [column].
   @pragma('vm:prefer-inline')
@@ -684,12 +698,29 @@ final class MetadataReader {
 
   /// Returns an iterable of rows where the specified [column] matches [value].
   Iterable<int> getEqualRange(MetadataTable table, int column, int value) {
+    final table$ = tableStream[table];
+    final column$ = table$.columns[column];
+    final tableOffset = table$.offset;
+    final rowWidth = table$.width;
+    final colOffset = column$.offset;
+    final colWidth = column$.width;
+
+    int readAt(int row) {
+      final byteOffset = tableOffset + row * rowWidth + colOffset;
+      return switch (colWidth) {
+        1 => _byteData.getUint8(byteOffset),
+        2 => _byteData.getUint16(byteOffset, .little),
+        4 => _byteData.getUint32(byteOffset, .little),
+        _ => _byteData.getUint64(byteOffset, .little),
+      };
+    }
+
     var first = 0;
-    var last = tableStream[table].rows;
+    var last = table$.rows;
 
     while (first < last) {
       final middle = first + (last - first) ~/ 2;
-      final middleValue = readUint(middle, table, column);
+      final middleValue = readAt(middle);
 
       if (middleValue < value) {
         first = middle + 1;
@@ -734,11 +765,24 @@ final class MetadataReader {
     int column,
     int value,
   ) {
+    final table$ = tableStream[table];
+    final column$ = table$.columns[column];
+    final tableOffset = table$.offset;
+    final rowWidth = table$.width;
+    final colOffset = column$.offset;
+    final colWidth = column$.width;
     var low = first;
     var high = last;
     while (low < high) {
       final middle = low + (high - low) ~/ 2;
-      if (readUint(middle, table, column) < value) {
+      final byteOffset = tableOffset + middle * rowWidth + colOffset;
+      final midVal = switch (colWidth) {
+        1 => _byteData.getUint8(byteOffset),
+        2 => _byteData.getUint16(byteOffset, .little),
+        4 => _byteData.getUint32(byteOffset, .little),
+        _ => _byteData.getUint64(byteOffset, .little),
+      };
+      if (midVal < value) {
         low = middle + 1;
       } else {
         high = middle;
@@ -755,11 +799,24 @@ final class MetadataReader {
     int column,
     int value,
   ) {
+    final table$ = tableStream[table];
+    final column$ = table$.columns[column];
+    final tableOffset = table$.offset;
+    final rowWidth = table$.width;
+    final colOffset = column$.offset;
+    final colWidth = column$.width;
     var low = first;
     var high = last;
     while (low < high) {
       final middle = low + (high - low) ~/ 2;
-      if (value < readUint(middle, table, column)) {
+      final byteOffset = tableOffset + middle * rowWidth + colOffset;
+      final midVal = switch (colWidth) {
+        1 => _byteData.getUint8(byteOffset),
+        2 => _byteData.getUint16(byteOffset, .little),
+        4 => _byteData.getUint32(byteOffset, .little),
+        _ => _byteData.getUint64(byteOffset, .little),
+      };
+      if (value < midVal) {
         high = middle;
       } else {
         low = middle + 1;

--- a/packages/winmd/lib/src/reader/row.dart
+++ b/packages/winmd/lib/src/reader/row.dart
@@ -53,7 +53,8 @@ import 'table/type_spec.dart';
 abstract base class Row {
   /// Creates a new instance of [Row] with the provided metadata index, reader
   /// index, and index.
-  const Row(this.metadataIndex, this.readerIndex, this.index);
+  Row(this.metadataIndex, this.readerIndex, this.index)
+    : reader = metadataIndex.readers[readerIndex];
 
   /// The metadata index for the current row.
   final MetadataIndex metadataIndex;
@@ -64,6 +65,9 @@ abstract base class Row {
   /// The index of the row within the metadata table, starting from zero.
   final int index;
 
+  /// The metadata reader for this row.
+  final MetadataReader reader;
+
   /// The metadata table associated with this row.
   MetadataTable get table;
 
@@ -73,16 +77,12 @@ abstract base class Row {
 
   /// Retrieves the [RowCompanion] associated with the specified [T].
   @internal
+  @pragma('vm:prefer-inline')
   static RowCompanion<T> companion<T extends Row>() {
     final companion = _companions[T];
     if (companion == null) throw StateError('No companion found for $T.');
     return companion as RowCompanion<T>;
   }
-
-  /// Retrieves the [MetadataReader] for the current row based on the
-  /// [readerIndex].
-  @pragma('vm:prefer-inline')
-  MetadataReader get reader => metadataIndex.readers[readerIndex];
 
   /// Reads a [Blob] from the specified [column].
   ///


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the
  title.

  Please look at the following checklist to ensure that your PR can be accepted
  quickly:
-->

## Description

This PR focuses on speeding up WinMD metadata reading by reducing repeated lookups/scans and by using more efficient data representations for table/heap access.

**Changes:**
- Cache per-row **MetadataReader** in **Row** instances and streamline reader access paths.
- Optimize primitive reads by introducing a **ByteData** view and reducing repeated offset/width computations in search helpers.
- Add caching/precomputation in heaps and lookup/index structures (heap item caches, packed `(readerIndex, typeDefIndex)` keys, and by-name indices).


## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [ ] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [ ] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [x] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [ ] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [ ] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
